### PR TITLE
Bump to typedoc ^0.28.2, Bump to typescript ~5.2.2

### DIFF
--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -12,7 +12,7 @@
         "@nevware21/coverage-tools": "^0.1.3",
         "@nevware21/publish-npm": "^0.1.3",
         "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.8 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.2 < 2.x",
         "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.0.1",
@@ -42,8 +42,9 @@
         "rollup-plugin-minify-es": "^1.1.1",
         "ts-mocha": "^10.0.0",
         "tslib": "^2.3.0",
-        "typedoc": "^0.26.2",
-        "typescript": "^4.9.5",
+        "typedoc": "^0.28.2",
+        "typedoc-github-theme": "^0.3.0",
+        "typescript": "~5.2.2",
         "uglify-js": "^3.15.5"
       }
     },
@@ -325,6 +326,18 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.2.3.tgz",
+      "integrity": "sha512-yemSYr0Oiqk5NAQRfbD5DKUTlThiZw1MxTMx/YpQTg6m4QRJDtV2JTYSuNevgx1ayy/O7x+uwDjh3IgECGFY/Q==",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.2.2",
+        "@shikijs/langs": "^3.2.2",
+        "@shikijs/themes": "^3.2.2",
+        "@shikijs/types": "^3.2.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -473,9 +486,9 @@
       }
     },
     "node_modules/@microsoft/api-extractor": {
-      "version": "7.52.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.52.2.tgz",
-      "integrity": "sha512-RX37V5uhBBPUvrrcmIxuQ8TPsohvr6zxo7SsLPOzBYcH9nbjbvtdXrts4cxHCXGOin9JR5ar37qfxtCOuEBTHA==",
+      "version": "7.52.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.52.5.tgz",
+      "integrity": "sha512-6WWgjjg6FkoDWpF/O3sjB05OkszpI5wtKJqd8fUIR/JJUv8IqNCGr1lJUZJnc1HegcT9gAvyf98KfH0wFncU0w==",
       "dependencies": {
         "@microsoft/api-extractor-model": "7.30.5",
         "@microsoft/tsdoc": "~0.15.1",
@@ -483,7 +496,7 @@
         "@rushstack/node-core-library": "5.13.0",
         "@rushstack/rig-package": "0.5.3",
         "@rushstack/terminal": "0.15.2",
-        "@rushstack/ts-command-line": "4.23.7",
+        "@rushstack/ts-command-line": "5.0.0",
         "lodash": "~4.17.15",
         "minimatch": "~3.0.3",
         "resolve": "~1.22.1",
@@ -570,9 +583,9 @@
       }
     },
     "node_modules/@nevware21/ts-utils": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.11.8.tgz",
-      "integrity": "sha512-62Y1mHgSu99IK4BRKC3sxdj/uIBHy6SDof3WUd29jom2HQy8sGCUdbYtFwMOkbUS6rahkL11Eg/ImtwsQsCnyw=="
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.12.2.tgz",
+      "integrity": "sha512-wEJpAgVC9kac6mh2Oa2QIEoBy3ZgCJyl8qp8rfyT56xzRCNppYQ5nEGb58JLJA5s69U6TgkA9uq5QbQ/htmR/w=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -617,9 +630,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.8.0.tgz",
-      "integrity": "sha512-yTwt2KWRmCQAfhvbCRjebaSX8pV1//I0Y3g+A7f/eS7gf0l4eRJoUCvcYdVtboeU4CTOZQuqYbZNS8aBYb8ROQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.0.tgz",
+      "integrity": "sha512-HdHF4rny4JCvIcm7V1dpvpctIGqM3/Me255CB44vW7hDG1zYMmcBMjpNqZEDxdCfXGLkx5kP0+Jz5DUS+ukqtA==",
       "dependencies": {
         "debug": "^4.4.0",
         "extract-zip": "^2.0.1",
@@ -831,28 +844,16 @@
         }
       }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.5.tgz",
-      "integrity": "sha512-Dq1bqBdLaZ1Gb/l2e5/+o3B18+8TI9ANlA1SkejZqDgdU/jK/ThYaMPMJpVMMXy2uRHvGKbkz9vheVGdq3cJfA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
     "node_modules/@rush-temp/tripwire": {
       "version": "0.0.0",
       "resolved": "file:projects/tripwire.tgz",
-      "integrity": "sha512-2B4t8tG1GSbUffvr6fpLk/Q2FcAqOLVgJK3BrF6BG/lHFPfmsb9/5/98hVy4xOHJoF/g9Gd60KX5AwOlHo998Q==",
+      "integrity": "sha512-pUZbW1oVNvQAnHnpg2H4jKZPBeuB2TYhUZrUv2bQ6lFuOnFICP5pQy5rXftQelo+f3ZXvcZr+50oczxslLTRrQ==",
       "dependencies": {
         "@microsoft/api-extractor": "^7.34.4",
         "@nevware21/coverage-tools": "^0.1.3",
         "@nevware21/publish-npm": "^0.1.3",
         "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.8 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.2 < 2.x",
         "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.0.1",
@@ -880,20 +881,21 @@
         "rollup-plugin-minify-es": "^1.1.1",
         "ts-mocha": "^10.0.0",
         "tslib": "^2.3.0",
-        "typedoc": "^0.26.2",
-        "typescript": "^4.9.5",
+        "typedoc": "^0.28.2",
+        "typedoc-github-theme": "^0.3.0",
+        "typescript": "~5.2.2",
         "uglify-js": "^3.15.5"
       }
     },
     "node_modules/@rush-temp/tripwire-chai": {
       "version": "0.0.0",
       "resolved": "file:projects/tripwire-chai.tgz",
-      "integrity": "sha512-gzWr8GgDZgBeFpRd/w2M6l8bbpQdc2baEoG0YvUlHTNOR7HoUEtnPnVFSrKnIoZ8pO4zmaqxFWjAR+dM4iF/EQ==",
+      "integrity": "sha512-/k61ORhm8WEXryI7Ryc7G7BWPnX9qJAInJw0esYt9o2TnCK7DVAHcJ17lYE+ynv62WDMXHpf4KzQFZvs0hmeyw==",
       "dependencies": {
         "@microsoft/api-extractor": "^7.34.4",
         "@nevware21/coverage-tools": "^0.1.3",
         "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.8 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.2 < 2.x",
         "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.0.1",
@@ -920,8 +922,9 @@
         "rollup-plugin-istanbul": "^4.0.0",
         "rollup-plugin-minify-es": "^1.1.1",
         "ts-mocha": "^10.0.0",
-        "typedoc": "^0.26.2",
-        "typescript": "^4.9.5",
+        "typedoc": "^0.28.2",
+        "typedoc-github-theme": "^0.3.0",
+        "typescript": "~5.2.2",
         "uglify-js": "^3.15.5"
       }
     },
@@ -990,9 +993,9 @@
       }
     },
     "node_modules/@rushstack/ts-command-line": {
-      "version": "4.23.7",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.23.7.tgz",
-      "integrity": "sha512-Gr9cB7DGe6uz5vq2wdr89WbVDKz0UeuFEn5H2CfWDe7JvjFFaiV15gi6mqDBTbHhHCWS7w8mF1h3BnIfUndqdA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.0.0.tgz",
+      "integrity": "sha512-SW6nqZVxH26Rxz25+lJQRlnXI/YCrNH7NfDEWPPm9i0rwkSE6Rgtmzw96cuZgQjacOh0sw77d6V4SvgarAfr8g==",
       "dependencies": {
         "@rushstack/terminal": "0.15.2",
         "@types/argparse": "1.0.38",
@@ -1000,60 +1003,37 @@
         "string-argv": "~0.3.1"
       }
     },
-    "node_modules/@shikijs/core": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.29.2.tgz",
-      "integrity": "sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==",
-      "dependencies": {
-        "@shikijs/engine-javascript": "1.29.2",
-        "@shikijs/engine-oniguruma": "1.29.2",
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1",
-        "@types/hast": "^3.0.4",
-        "hast-util-to-html": "^9.0.4"
-      }
-    },
-    "node_modules/@shikijs/engine-javascript": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.29.2.tgz",
-      "integrity": "sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==",
-      "dependencies": {
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1",
-        "oniguruma-to-es": "^2.2.0"
-      }
-    },
     "node_modules/@shikijs/engine-oniguruma": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.2.tgz",
-      "integrity": "sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.2.2.tgz",
+      "integrity": "sha512-vyXRnWVCSvokwbaUD/8uPn6Gqsf5Hv7XwcW4AgiU4Z2qwy19sdr6VGzMdheKKN58tJOOe5MIKiNb901bgcUXYQ==",
       "dependencies": {
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1"
+        "@shikijs/types": "3.2.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "node_modules/@shikijs/langs": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-1.29.2.tgz",
-      "integrity": "sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.2.2.tgz",
+      "integrity": "sha512-NY0Urg2dV9ETt3JIOWoMPuoDNwte3geLZ4M1nrPHbkDS8dWMpKcEwlqiEIGqtwZNmt5gKyWpR26ln2Bg2ecPgw==",
       "dependencies": {
-        "@shikijs/types": "1.29.2"
+        "@shikijs/types": "3.2.2"
       }
     },
     "node_modules/@shikijs/themes": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-1.29.2.tgz",
-      "integrity": "sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.2.2.tgz",
+      "integrity": "sha512-Zuq4lgAxVKkb0FFdhHSdDkALuRpsj1so1JdihjKNQfgM78EHxV2JhO10qPsMrm01FkE3mDRTdF68wfmsqjt6HA==",
       "dependencies": {
-        "@shikijs/types": "1.29.2"
+        "@shikijs/types": "3.2.2"
       }
     },
     "node_modules/@shikijs/types": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.2.tgz",
-      "integrity": "sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.2.2.tgz",
+      "integrity": "sha512-a5TiHk7EH5Lso8sHcLHbVNNhWKP0Wi3yVnXnu73g86n3WoDgEra7n3KszyeCGuyoagspQ2fzvy4cpSc8pKhb0A==",
       "dependencies": {
-        "@shikijs/vscode-textmate": "^10.0.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       }
     },
@@ -1112,25 +1092,17 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "optional": true
     },
-    "node_modules/@types/mdast": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
-      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-      "dependencies": {
-        "@types/unist": "*"
-      }
-    },
     "node_modules/@types/mocha": {
       "version": "10.0.10",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
       "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q=="
     },
     "node_modules/@types/node": {
-      "version": "22.13.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.15.tgz",
-      "integrity": "sha512-imAbQEEbVni6i6h6Bd5xkCRwLqFc8hihCsi2GbtDoAtUcAFQ6Zs4pFXTZUUbroTkXdImczWM9AI8eZUuybXE3w==",
+      "version": "22.14.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
+      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
       "dependencies": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -1151,11 +1123,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@ungap/structured-clone": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -1417,9 +1384,9 @@
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.0.2.tgz",
-      "integrity": "sha512-S5mmkMesiduMqnz51Bfh0Et9EX0aTCJxhsI4bvzFFLs8Z1AV8RDHadfY5CyLwdoLHgXbNBEN1gQcbEtGwuvixw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.2.tgz",
+      "integrity": "sha512-8wSeOia5B7LwD4+h465y73KOdj5QHsbbuoUfPBi+pXgFJIPuG7SsiOdJuijWMyfid49eD+WivpfY7KT8gbAzBA==",
       "optional": true,
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -1826,9 +1793,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001707",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
-      "integrity": "sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==",
+      "version": "1.0.30001715",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001715.tgz",
+      "integrity": "sha512-7ptkFGMm2OAOgvZpwgA4yjQ5SQbrNVGdRjzH0pBdy1Fasvcr+KAeECmbCAECzTuDuoX0FCY8KzUxjf9+9kfZEw==",
       "funding": [
         {
           "type": "opencollective",
@@ -1843,15 +1810,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
-    },
-    "node_modules/ccount": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
-      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1879,24 +1837,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/character-entities-html4": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
-      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/character-entities-legacy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
-      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -1921,9 +1861,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-2.1.2.tgz",
-      "integrity": "sha512-vtRWBK2uImo5/W2oG6/cDkkHSm+2t6VHgnj+Rcwhb0pP74OoUb4GipyRX/T/y39gYQPhioP0DPShn+A7P6CHNw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-3.0.0.tgz",
+      "integrity": "sha512-ZOGRDAhBMX1uxL2Cm2TDuhImbrsEz5A/tTcVU6RpXEWaTNUNwsHW6njUXizh51Ir6iqHbKAfhA2XK33uBcLo5A==",
       "dependencies": {
         "mitt": "^3.0.1",
         "zod": "^3.24.1"
@@ -2027,15 +1967,6 @@
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/comma-separated-tokens": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
-      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/commander": {
@@ -2425,14 +2356,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/des.js": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
@@ -2459,22 +2382,10 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/devlop": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
-      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-      "dependencies": {
-        "dequal": "^2.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1413902",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1413902.tgz",
-      "integrity": "sha512-yRtvFD8Oyk7C9Os3GmnFZLu53yAfsnyw1s+mLmHHUK0GQEc9zthHWvS1r67Zqzm5t7v56PILHIVZ7kmFMaL2yQ=="
+      "version": "0.0.1425554",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1425554.tgz",
+      "integrity": "sha512-uRfxR6Nlzdzt0ihVIkV+sLztKgs7rgquY/Mhcv1YNCWDh5IZgl5mnn2aeEnW5stYTE0wwiF4RYVz8eMEpV1SEw=="
     },
     "node_modules/di": {
       "version": "0.0.1",
@@ -2562,9 +2473,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.129",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.129.tgz",
-      "integrity": "sha512-JlXUemX4s0+9f8mLqib/bHH8gOHf5elKS6KeWG3sk3xozb/JTq/RLXIv8OKUWiK4Ah00Wm88EFj5PYkFr4RUPA=="
+      "version": "1.5.140",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.140.tgz",
+      "integrity": "sha512-o82Rj+ONp4Ip7Cl1r7lrqx/pXhbp/lh9DpKcMNscFJdh8ebyRofnc7Sh01B4jx403RI0oqTBvlZ7OBIZLMr2+Q=="
     },
     "node_modules/elliptic": {
       "version": "6.6.1",
@@ -2589,11 +2500,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "node_modules/emoji-regex-xs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
-      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg=="
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -3157,19 +3063,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -3661,40 +3554,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hast-util-to-html": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
-      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "ccount": "^2.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "html-void-elements": "^3.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "stringify-entities": "^4.0.0",
-        "zwitch": "^2.0.4"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/hast-util-whitespace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
-      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
-      "dependencies": {
-        "@types/hast": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -3737,15 +3596,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
-    },
-    "node_modules/html-void-elements": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
-      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -5140,26 +4990,6 @@
         "safe-buffer": "^5.1.2"
       }
     },
-    "node_modules/mdast-util-to-hast": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
-      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
-      "dependencies": {
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "@ungap/structured-clone": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "trim-lines": "^3.0.0",
-        "unist-util-position": "^5.0.0",
-        "unist-util-visit": "^5.0.0",
-        "vfile": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
     "node_modules/mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
@@ -5180,90 +5010,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/micromark-util-character": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
-      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-encode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
-      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ]
-    },
-    "node_modules/micromark-util-sanitize-uri": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
-      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-symbol": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
-      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ]
-    },
-    "node_modules/micromark-util-types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
-      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ]
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -5790,16 +5536,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/oniguruma-to-es": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.3.0.tgz",
-      "integrity": "sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==",
-      "dependencies": {
-        "emoji-regex-xs": "^1.0.0",
-        "regex": "^5.1.1",
-        "regex-recursion": "^5.1.1"
-      }
-    },
     "node_modules/os-browserify": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
@@ -6175,15 +5911,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/property-information": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.0.0.tgz",
-      "integrity": "sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/proxy-agent": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
@@ -6277,16 +6004,16 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "24.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.4.0.tgz",
-      "integrity": "sha512-E4JhJzjS8AAI+6N/b+Utwarhz6zWl3+MR725fal+s3UlOlX2eWdsvYYU+Q5bXMjs9eZEGkNQroLkn7j11s2k1Q==",
+      "version": "24.6.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.6.1.tgz",
+      "integrity": "sha512-/4ocGfu8LNvDbWUqJZV2VmwEWpbOdJa69y2Jivd213tV0ekAtUh/bgT1hhW63SDN/CtrEucOPwoomZ+9M+eBEg==",
       "hasInstallScript": true,
       "dependencies": {
-        "@puppeteer/browsers": "2.8.0",
-        "chromium-bidi": "2.1.2",
+        "@puppeteer/browsers": "2.10.0",
+        "chromium-bidi": "3.0.0",
         "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1413902",
-        "puppeteer-core": "24.4.0",
+        "devtools-protocol": "0.0.1425554",
+        "puppeteer-core": "24.6.1",
         "typed-query-selector": "^2.12.0"
       },
       "bin": {
@@ -6297,14 +6024,14 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.4.0.tgz",
-      "integrity": "sha512-eFw66gCnWo0X8Hyf9KxxJtms7a61NJVMiSaWfItsFPzFBsjsWdmcNlBdsA1WVwln6neoHhsG+uTVesKmTREn/g==",
+      "version": "24.6.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.6.1.tgz",
+      "integrity": "sha512-sMCxsY+OPWO2fecBrhIeCeJbWWXJ6UaN997sTid6whY0YT9XM0RnxEwLeUibluIS5/fRmuxe1efjb5RMBsky7g==",
       "dependencies": {
-        "@puppeteer/browsers": "2.8.0",
-        "chromium-bidi": "2.1.2",
+        "@puppeteer/browsers": "2.10.0",
+        "chromium-bidi": "3.0.0",
         "debug": "^4.4.0",
-        "devtools-protocol": "0.0.1413902",
+        "devtools-protocol": "0.0.1425554",
         "typed-query-selector": "^2.12.0",
         "ws": "^8.18.1"
       },
@@ -6491,28 +6218,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/regex": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/regex/-/regex-5.1.1.tgz",
-      "integrity": "sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==",
-      "dependencies": {
-        "regex-utilities": "^2.3.0"
-      }
-    },
-    "node_modules/regex-recursion": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-5.1.1.tgz",
-      "integrity": "sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==",
-      "dependencies": {
-        "regex": "^5.1.1",
-        "regex-utilities": "^2.3.0"
-      }
-    },
-    "node_modules/regex-utilities": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
-      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -6869,21 +6574,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/shiki": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.29.2.tgz",
-      "integrity": "sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==",
-      "dependencies": {
-        "@shikijs/core": "1.29.2",
-        "@shikijs/engine-javascript": "1.29.2",
-        "@shikijs/engine-oniguruma": "1.29.2",
-        "@shikijs/langs": "1.29.2",
-        "@shikijs/themes": "1.29.2",
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1",
-        "@types/hast": "^3.0.4"
-      }
-    },
     "node_modules/shortid": {
       "version": "2.2.17",
       "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.17.tgz",
@@ -7191,15 +6881,6 @@
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "deprecated": "Please use @jridgewell/sourcemap-codec instead"
     },
-    "node_modules/space-separated-tokens": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
-      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -7384,19 +7065,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/stringify-entities": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
-      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
-      "dependencies": {
-        "character-entities-html4": "^2.0.0",
-        "character-entities-legacy": "^3.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/strip-ansi": {
@@ -7628,15 +7296,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
-    "node_modules/trim-lines": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
-      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/ts-mocha": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-10.1.0.tgz",
@@ -7749,24 +7408,36 @@
       "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg=="
     },
     "node_modules/typedoc": {
-      "version": "0.26.11",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.26.11.tgz",
-      "integrity": "sha512-sFEgRRtrcDl2FxVP58Ze++ZK2UQAEvtvvH8rRlig1Ja3o7dDaMHmaBfvJmdGnNEFaLTpQsN8dpvZaTqJSu/Ugw==",
+      "version": "0.28.3",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.3.tgz",
+      "integrity": "sha512-5svOCTfXvVSh6zbZKSQluZhR8yN2tKpTeHZxlmWpE6N5vc3R8k/jhg9nnD6n5tN9/ObuQTojkONrOxFdUFUG9w==",
       "dependencies": {
+        "@gerrit0/mini-shiki": "^3.2.2",
         "lunr": "^2.3.9",
         "markdown-it": "^14.1.0",
         "minimatch": "^9.0.5",
-        "shiki": "^1.16.2",
-        "yaml": "^2.5.1"
+        "yaml": "^2.7.1"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 18",
+        "pnpm": ">= 10"
       },
       "peerDependencies": {
-        "typescript": "4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x"
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x"
+      }
+    },
+    "node_modules/typedoc-github-theme": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/typedoc-github-theme/-/typedoc-github-theme-0.3.0.tgz",
+      "integrity": "sha512-7HzKJt8ZZSTNYczK8BcZZbpr7GsyTZgsoLFKtO4NYxXOb7mSr92yTj7hl16ind0WsOzxPo2DZGjkUH2VoPrdxg==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "typedoc": "~0.28.0"
       }
     },
     "node_modules/typedoc/node_modules/brace-expansion": {
@@ -7792,15 +7463,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/ua-parser-js": {
@@ -7886,72 +7557,9 @@
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "node_modules/undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
-    },
-    "node_modules/unist-util-is": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
-      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-position": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
-      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-stringify-position": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
-      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-      "dependencies": {
-        "@types/unist": "^3.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
-      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/unist-util-visit-parents": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
-      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -8089,32 +7697,6 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/vfile": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
-      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "vfile-message": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/vfile-message": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
-      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
-      "dependencies": {
-        "@types/unist": "^3.0.0",
-        "unist-util-stringify-position": "^4.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vm-browserify": {
@@ -8361,20 +7943,11 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
+      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zwitch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
-      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     }
   },
@@ -8580,6 +8153,18 @@
       "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
       "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
     },
+    "@gerrit0/mini-shiki": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.2.3.tgz",
+      "integrity": "sha512-yemSYr0Oiqk5NAQRfbD5DKUTlThiZw1MxTMx/YpQTg6m4QRJDtV2JTYSuNevgx1ayy/O7x+uwDjh3IgECGFY/Q==",
+      "requires": {
+        "@shikijs/engine-oniguruma": "^3.2.2",
+        "@shikijs/langs": "^3.2.2",
+        "@shikijs/themes": "^3.2.2",
+        "@shikijs/types": "^3.2.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
     "@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -8685,9 +8270,9 @@
       }
     },
     "@microsoft/api-extractor": {
-      "version": "7.52.2",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.52.2.tgz",
-      "integrity": "sha512-RX37V5uhBBPUvrrcmIxuQ8TPsohvr6zxo7SsLPOzBYcH9nbjbvtdXrts4cxHCXGOin9JR5ar37qfxtCOuEBTHA==",
+      "version": "7.52.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.52.5.tgz",
+      "integrity": "sha512-6WWgjjg6FkoDWpF/O3sjB05OkszpI5wtKJqd8fUIR/JJUv8IqNCGr1lJUZJnc1HegcT9gAvyf98KfH0wFncU0w==",
       "requires": {
         "@microsoft/api-extractor-model": "7.30.5",
         "@microsoft/tsdoc": "~0.15.1",
@@ -8695,7 +8280,7 @@
         "@rushstack/node-core-library": "5.13.0",
         "@rushstack/rig-package": "0.5.3",
         "@rushstack/terminal": "0.15.2",
-        "@rushstack/ts-command-line": "4.23.7",
+        "@rushstack/ts-command-line": "5.0.0",
         "lodash": "~4.17.15",
         "minimatch": "~3.0.3",
         "resolve": "~1.22.1",
@@ -8762,9 +8347,9 @@
       }
     },
     "@nevware21/ts-utils": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.11.8.tgz",
-      "integrity": "sha512-62Y1mHgSu99IK4BRKC3sxdj/uIBHy6SDof3WUd29jom2HQy8sGCUdbYtFwMOkbUS6rahkL11Eg/ImtwsQsCnyw=="
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.12.2.tgz",
+      "integrity": "sha512-wEJpAgVC9kac6mh2Oa2QIEoBy3ZgCJyl8qp8rfyT56xzRCNppYQ5nEGb58JLJA5s69U6TgkA9uq5QbQ/htmR/w=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -8797,9 +8382,9 @@
       "peer": true
     },
     "@puppeteer/browsers": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.8.0.tgz",
-      "integrity": "sha512-yTwt2KWRmCQAfhvbCRjebaSX8pV1//I0Y3g+A7f/eS7gf0l4eRJoUCvcYdVtboeU4CTOZQuqYbZNS8aBYb8ROQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.0.tgz",
+      "integrity": "sha512-HdHF4rny4JCvIcm7V1dpvpctIGqM3/Me255CB44vW7hDG1zYMmcBMjpNqZEDxdCfXGLkx5kP0+Jz5DUS+ukqtA==",
       "requires": {
         "debug": "^4.4.0",
         "extract-zip": "^2.0.1",
@@ -8916,21 +8501,15 @@
         "picomatch": "^4.0.2"
       }
     },
-    "@rollup/rollup-linux-x64-gnu": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.5.tgz",
-      "integrity": "sha512-Dq1bqBdLaZ1Gb/l2e5/+o3B18+8TI9ANlA1SkejZqDgdU/jK/ThYaMPMJpVMMXy2uRHvGKbkz9vheVGdq3cJfA==",
-      "optional": true
-    },
     "@rush-temp/tripwire": {
       "version": "file:projects\\tripwire.tgz",
-      "integrity": "sha512-2B4t8tG1GSbUffvr6fpLk/Q2FcAqOLVgJK3BrF6BG/lHFPfmsb9/5/98hVy4xOHJoF/g9Gd60KX5AwOlHo998Q==",
+      "integrity": "sha512-pUZbW1oVNvQAnHnpg2H4jKZPBeuB2TYhUZrUv2bQ6lFuOnFICP5pQy5rXftQelo+f3ZXvcZr+50oczxslLTRrQ==",
       "requires": {
         "@microsoft/api-extractor": "^7.34.4",
         "@nevware21/coverage-tools": "^0.1.3",
         "@nevware21/publish-npm": "^0.1.3",
         "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.8 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.2 < 2.x",
         "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.0.1",
@@ -8958,19 +8537,20 @@
         "rollup-plugin-minify-es": "^1.1.1",
         "ts-mocha": "^10.0.0",
         "tslib": "^2.3.0",
-        "typedoc": "^0.26.2",
-        "typescript": "^4.9.5",
+        "typedoc": "^0.28.2",
+        "typedoc-github-theme": "^0.3.0",
+        "typescript": "~5.2.2",
         "uglify-js": "^3.15.5"
       }
     },
     "@rush-temp/tripwire-chai": {
       "version": "file:projects\\tripwire-chai.tgz",
-      "integrity": "sha512-gzWr8GgDZgBeFpRd/w2M6l8bbpQdc2baEoG0YvUlHTNOR7HoUEtnPnVFSrKnIoZ8pO4zmaqxFWjAR+dM4iF/EQ==",
+      "integrity": "sha512-/k61ORhm8WEXryI7Ryc7G7BWPnX9qJAInJw0esYt9o2TnCK7DVAHcJ17lYE+ynv62WDMXHpf4KzQFZvs0hmeyw==",
       "requires": {
         "@microsoft/api-extractor": "^7.34.4",
         "@nevware21/coverage-tools": "^0.1.3",
         "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.8 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.2 < 2.x",
         "@rollup/plugin-commonjs": "^25.0.0",
         "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.0.1",
@@ -8997,8 +8577,9 @@
         "rollup-plugin-istanbul": "^4.0.0",
         "rollup-plugin-minify-es": "^1.1.1",
         "ts-mocha": "^10.0.0",
-        "typedoc": "^0.26.2",
-        "typescript": "^4.9.5",
+        "typedoc": "^0.28.2",
+        "typedoc-github-theme": "^0.3.0",
+        "typescript": "~5.2.2",
         "uglify-js": "^3.15.5"
       }
     },
@@ -9049,9 +8630,9 @@
       }
     },
     "@rushstack/ts-command-line": {
-      "version": "4.23.7",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.23.7.tgz",
-      "integrity": "sha512-Gr9cB7DGe6uz5vq2wdr89WbVDKz0UeuFEn5H2CfWDe7JvjFFaiV15gi6mqDBTbHhHCWS7w8mF1h3BnIfUndqdA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-5.0.0.tgz",
+      "integrity": "sha512-SW6nqZVxH26Rxz25+lJQRlnXI/YCrNH7NfDEWPPm9i0rwkSE6Rgtmzw96cuZgQjacOh0sw77d6V4SvgarAfr8g==",
       "requires": {
         "@rushstack/terminal": "0.15.2",
         "@types/argparse": "1.0.38",
@@ -9059,60 +8640,37 @@
         "string-argv": "~0.3.1"
       }
     },
-    "@shikijs/core": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-1.29.2.tgz",
-      "integrity": "sha512-vju0lY9r27jJfOY4Z7+Rt/nIOjzJpZ3y+nYpqtUZInVoXQ/TJZcfGnNOGnKjFdVZb8qexiCuSlZRKcGfhhTTZQ==",
-      "requires": {
-        "@shikijs/engine-javascript": "1.29.2",
-        "@shikijs/engine-oniguruma": "1.29.2",
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1",
-        "@types/hast": "^3.0.4",
-        "hast-util-to-html": "^9.0.4"
-      }
-    },
-    "@shikijs/engine-javascript": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-1.29.2.tgz",
-      "integrity": "sha512-iNEZv4IrLYPv64Q6k7EPpOCE/nuvGiKl7zxdq0WFuRPF5PAE9PRo2JGq/d8crLusM59BRemJ4eOqrFrC4wiQ+A==",
-      "requires": {
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1",
-        "oniguruma-to-es": "^2.2.0"
-      }
-    },
     "@shikijs/engine-oniguruma": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.29.2.tgz",
-      "integrity": "sha512-7iiOx3SG8+g1MnlzZVDYiaeHe7Ez2Kf2HrJzdmGwkRisT7r4rak0e655AcM/tF9JG/kg5fMNYlLLKglbN7gBqA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.2.2.tgz",
+      "integrity": "sha512-vyXRnWVCSvokwbaUD/8uPn6Gqsf5Hv7XwcW4AgiU4Z2qwy19sdr6VGzMdheKKN58tJOOe5MIKiNb901bgcUXYQ==",
       "requires": {
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1"
+        "@shikijs/types": "3.2.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
       }
     },
     "@shikijs/langs": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-1.29.2.tgz",
-      "integrity": "sha512-FIBA7N3LZ+223U7cJDUYd5shmciFQlYkFXlkKVaHsCPgfVLiO+e12FmQE6Tf9vuyEsFe3dIl8qGWKXgEHL9wmQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.2.2.tgz",
+      "integrity": "sha512-NY0Urg2dV9ETt3JIOWoMPuoDNwte3geLZ4M1nrPHbkDS8dWMpKcEwlqiEIGqtwZNmt5gKyWpR26ln2Bg2ecPgw==",
       "requires": {
-        "@shikijs/types": "1.29.2"
+        "@shikijs/types": "3.2.2"
       }
     },
     "@shikijs/themes": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-1.29.2.tgz",
-      "integrity": "sha512-i9TNZlsq4uoyqSbluIcZkmPL9Bfi3djVxRnofUHwvx/h6SRW3cwgBC5SML7vsDcWyukY0eCzVN980rqP6qNl9g==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.2.2.tgz",
+      "integrity": "sha512-Zuq4lgAxVKkb0FFdhHSdDkALuRpsj1so1JdihjKNQfgM78EHxV2JhO10qPsMrm01FkE3mDRTdF68wfmsqjt6HA==",
       "requires": {
-        "@shikijs/types": "1.29.2"
+        "@shikijs/types": "3.2.2"
       }
     },
     "@shikijs/types": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.29.2.tgz",
-      "integrity": "sha512-VJjK0eIijTZf0QSTODEXCqinjBn0joAHQ+aPSBzrv4O2d/QSbsMw+ZeSRx03kV34Hy7NzUvV/7NqfYGRLrASmw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.2.2.tgz",
+      "integrity": "sha512-a5TiHk7EH5Lso8sHcLHbVNNhWKP0Wi3yVnXnu73g86n3WoDgEra7n3KszyeCGuyoagspQ2fzvy4cpSc8pKhb0A==",
       "requires": {
-        "@shikijs/vscode-textmate": "^10.0.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       }
     },
@@ -9168,25 +8726,17 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "optional": true
     },
-    "@types/mdast": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
-      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-      "requires": {
-        "@types/unist": "*"
-      }
-    },
     "@types/mocha": {
       "version": "10.0.10",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.10.tgz",
       "integrity": "sha512-xPyYSz1cMPnJQhl0CLMH68j3gprKZaTjG3s5Vi+fDgx+uhG9NOXwbVt52eFS8ECyXhyKcjDLCBEqBExKuiZb7Q=="
     },
     "@types/node": {
-      "version": "22.13.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.15.tgz",
-      "integrity": "sha512-imAbQEEbVni6i6h6Bd5xkCRwLqFc8hihCsi2GbtDoAtUcAFQ6Zs4pFXTZUUbroTkXdImczWM9AI8eZUuybXE3w==",
+      "version": "22.14.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
+      "integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
       "requires": {
-        "undici-types": "~6.20.0"
+        "undici-types": "~6.21.0"
       }
     },
     "@types/resolve": {
@@ -9207,11 +8757,6 @@
       "requires": {
         "@types/node": "*"
       }
-    },
-    "@ungap/structured-clone": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -9400,9 +8945,9 @@
       "optional": true
     },
     "bare-fs": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.0.2.tgz",
-      "integrity": "sha512-S5mmkMesiduMqnz51Bfh0Et9EX0aTCJxhsI4bvzFFLs8Z1AV8RDHadfY5CyLwdoLHgXbNBEN1gQcbEtGwuvixw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.2.tgz",
+      "integrity": "sha512-8wSeOia5B7LwD4+h465y73KOdj5QHsbbuoUfPBi+pXgFJIPuG7SsiOdJuijWMyfid49eD+WivpfY7KT8gbAzBA==",
       "optional": true,
       "requires": {
         "bare-events": "^2.5.4",
@@ -9679,14 +9224,9 @@
       "peer": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001707",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
-      "integrity": "sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw=="
-    },
-    "ccount": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
-      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="
+      "version": "1.0.30001715",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001715.tgz",
+      "integrity": "sha512-7ptkFGMm2OAOgvZpwgA4yjQ5SQbrNVGdRjzH0pBdy1Fasvcr+KAeECmbCAECzTuDuoX0FCY8KzUxjf9+9kfZEw=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -9707,16 +9247,6 @@
         }
       }
     },
-    "character-entities-html4": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
-      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="
-    },
-    "character-entities-legacy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
-      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="
-    },
     "chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -9733,9 +9263,9 @@
       }
     },
     "chromium-bidi": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-2.1.2.tgz",
-      "integrity": "sha512-vtRWBK2uImo5/W2oG6/cDkkHSm+2t6VHgnj+Rcwhb0pP74OoUb4GipyRX/T/y39gYQPhioP0DPShn+A7P6CHNw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-3.0.0.tgz",
+      "integrity": "sha512-ZOGRDAhBMX1uxL2Cm2TDuhImbrsEz5A/tTcVU6RpXEWaTNUNwsHW6njUXizh51Ir6iqHbKAfhA2XK33uBcLo5A==",
       "requires": {
         "mitt": "^3.0.1",
         "zod": "^3.24.1"
@@ -9817,11 +9347,6 @@
           "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
         }
       }
-    },
-    "comma-separated-tokens": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
-      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="
     },
     "commander": {
       "version": "2.13.0",
@@ -10116,11 +9641,6 @@
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
       "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
     },
-    "dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="
-    },
     "des.js": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.1.0.tgz",
@@ -10140,18 +9660,10 @@
       "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
       "integrity": "sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q=="
     },
-    "devlop": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
-      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-      "requires": {
-        "dequal": "^2.0.0"
-      }
-    },
     "devtools-protocol": {
-      "version": "0.0.1413902",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1413902.tgz",
-      "integrity": "sha512-yRtvFD8Oyk7C9Os3GmnFZLu53yAfsnyw1s+mLmHHUK0GQEc9zthHWvS1r67Zqzm5t7v56PILHIVZ7kmFMaL2yQ=="
+      "version": "0.0.1425554",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1425554.tgz",
+      "integrity": "sha512-uRfxR6Nlzdzt0ihVIkV+sLztKgs7rgquY/Mhcv1YNCWDh5IZgl5mnn2aeEnW5stYTE0wwiF4RYVz8eMEpV1SEw=="
     },
     "di": {
       "version": "0.0.1",
@@ -10226,9 +9738,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "electron-to-chromium": {
-      "version": "1.5.129",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.129.tgz",
-      "integrity": "sha512-JlXUemX4s0+9f8mLqib/bHH8gOHf5elKS6KeWG3sk3xozb/JTq/RLXIv8OKUWiK4Ah00Wm88EFj5PYkFr4RUPA=="
+      "version": "1.5.140",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.140.tgz",
+      "integrity": "sha512-o82Rj+ONp4Ip7Cl1r7lrqx/pXhbp/lh9DpKcMNscFJdh8ebyRofnc7Sh01B4jx403RI0oqTBvlZ7OBIZLMr2+Q=="
     },
     "elliptic": {
       "version": "6.6.1",
@@ -10255,11 +9767,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "emoji-regex-xs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
-      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg=="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -10656,12 +10163,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
-    "fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "optional": true
-    },
     "function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -11017,32 +10518,6 @@
         "function-bind": "^1.1.2"
       }
     },
-    "hast-util-to-html": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
-      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
-      "requires": {
-        "@types/hast": "^3.0.0",
-        "@types/unist": "^3.0.0",
-        "ccount": "^2.0.0",
-        "comma-separated-tokens": "^2.0.0",
-        "hast-util-whitespace": "^3.0.0",
-        "html-void-elements": "^3.0.0",
-        "mdast-util-to-hast": "^13.0.0",
-        "property-information": "^7.0.0",
-        "space-separated-tokens": "^2.0.0",
-        "stringify-entities": "^4.0.0",
-        "zwitch": "^2.0.4"
-      }
-    },
-    "hast-util-whitespace": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
-      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
-      "requires": {
-        "@types/hast": "^3.0.0"
-      }
-    },
     "he": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
@@ -11076,11 +10551,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="
-    },
-    "html-void-elements": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
-      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="
     },
     "http-errors": {
       "version": "2.0.0",
@@ -12141,22 +11611,6 @@
         "safe-buffer": "^5.1.2"
       }
     },
-    "mdast-util-to-hast": {
-      "version": "13.2.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.0.tgz",
-      "integrity": "sha512-QGYKEuUsYT9ykKBCMOEDLsU5JRObWQusAolFMeko/tYPufNkRffBAQjIE+99jbA87xv6FgmjLtwjh9wBWajwAA==",
-      "requires": {
-        "@types/hast": "^3.0.0",
-        "@types/mdast": "^4.0.0",
-        "@ungap/structured-clone": "^1.0.0",
-        "devlop": "^1.0.0",
-        "micromark-util-sanitize-uri": "^2.0.0",
-        "trim-lines": "^3.0.0",
-        "unist-util-position": "^5.0.0",
-        "unist-util-visit": "^5.0.0",
-        "vfile": "^6.0.0"
-      }
-    },
     "mdurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
@@ -12171,40 +11625,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
-    },
-    "micromark-util-character": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
-      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
-      "requires": {
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
-    },
-    "micromark-util-encode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
-      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="
-    },
-    "micromark-util-sanitize-uri": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
-      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
-      "requires": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-encode": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "micromark-util-symbol": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
-      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="
-    },
-    "micromark-util-types": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
-      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="
     },
     "micromatch": {
       "version": "4.0.8",
@@ -12589,16 +12009,6 @@
         "wrappy": "1"
       }
     },
-    "oniguruma-to-es": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-2.3.0.tgz",
-      "integrity": "sha512-bwALDxriqfKGfUufKGGepCzu9x7nJQuoRoAFp4AnwehhC2crqrDIAP/uN2qdlsAvSMpeRC3+Yzhqc7hLmle5+g==",
-      "requires": {
-        "emoji-regex-xs": "^1.0.0",
-        "regex": "^5.1.1",
-        "regex-recursion": "^5.1.1"
-      }
-    },
     "os-browserify": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
@@ -12871,11 +12281,6 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
-    "property-information": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.0.0.tgz",
-      "integrity": "sha512-7D/qOz/+Y4X/rzSB6jKxKUsQnphO046ei8qxG59mtM3RG3DHgTK81HrxrmoDVINJb8NKT5ZsRbwHvQ6B68Iyhg=="
-    },
     "proxy-agent": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
@@ -12956,27 +12361,27 @@
       "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="
     },
     "puppeteer": {
-      "version": "24.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.4.0.tgz",
-      "integrity": "sha512-E4JhJzjS8AAI+6N/b+Utwarhz6zWl3+MR725fal+s3UlOlX2eWdsvYYU+Q5bXMjs9eZEGkNQroLkn7j11s2k1Q==",
+      "version": "24.6.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.6.1.tgz",
+      "integrity": "sha512-/4ocGfu8LNvDbWUqJZV2VmwEWpbOdJa69y2Jivd213tV0ekAtUh/bgT1hhW63SDN/CtrEucOPwoomZ+9M+eBEg==",
       "requires": {
-        "@puppeteer/browsers": "2.8.0",
-        "chromium-bidi": "2.1.2",
+        "@puppeteer/browsers": "2.10.0",
+        "chromium-bidi": "3.0.0",
         "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1413902",
-        "puppeteer-core": "24.4.0",
+        "devtools-protocol": "0.0.1425554",
+        "puppeteer-core": "24.6.1",
         "typed-query-selector": "^2.12.0"
       }
     },
     "puppeteer-core": {
-      "version": "24.4.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.4.0.tgz",
-      "integrity": "sha512-eFw66gCnWo0X8Hyf9KxxJtms7a61NJVMiSaWfItsFPzFBsjsWdmcNlBdsA1WVwln6neoHhsG+uTVesKmTREn/g==",
+      "version": "24.6.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.6.1.tgz",
+      "integrity": "sha512-sMCxsY+OPWO2fecBrhIeCeJbWWXJ6UaN997sTid6whY0YT9XM0RnxEwLeUibluIS5/fRmuxe1efjb5RMBsky7g==",
       "requires": {
-        "@puppeteer/browsers": "2.8.0",
-        "chromium-bidi": "2.1.2",
+        "@puppeteer/browsers": "2.10.0",
+        "chromium-bidi": "3.0.0",
         "debug": "^4.4.0",
-        "devtools-protocol": "0.0.1413902",
+        "devtools-protocol": "0.0.1425554",
         "typed-query-selector": "^2.12.0",
         "ws": "^8.18.1"
       },
@@ -13113,28 +12518,6 @@
       "requires": {
         "resolve": "^1.9.0"
       }
-    },
-    "regex": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/regex/-/regex-5.1.1.tgz",
-      "integrity": "sha512-dN5I359AVGPnwzJm2jN1k0W9LPZ+ePvoOeVMMfqIMFz53sSwXkxaJoxr50ptnsC771lK95BnTrVSZxq0b9yCGw==",
-      "requires": {
-        "regex-utilities": "^2.3.0"
-      }
-    },
-    "regex-recursion": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-5.1.1.tgz",
-      "integrity": "sha512-ae7SBCbzVNrIjgSbh7wMznPcQel1DNlDtzensnFxpiNpXt1U2ju/bHugH422r+4LAVS1FpW1YCwilmnNsjum9w==",
-      "requires": {
-        "regex": "^5.1.1",
-        "regex-utilities": "^2.3.0"
-      }
-    },
-    "regex-utilities": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
-      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="
     },
     "require-directory": {
       "version": "2.1.1",
@@ -13379,21 +12762,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
-    "shiki": {
-      "version": "1.29.2",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-1.29.2.tgz",
-      "integrity": "sha512-njXuliz/cP+67jU2hukkxCNuH1yUi4QfdZZY+sMr5PPrIyXSu5iTb/qYC4BiWWB0vZ+7TbdvYUCeL23zpwCfbg==",
-      "requires": {
-        "@shikijs/core": "1.29.2",
-        "@shikijs/engine-javascript": "1.29.2",
-        "@shikijs/engine-oniguruma": "1.29.2",
-        "@shikijs/langs": "1.29.2",
-        "@shikijs/themes": "1.29.2",
-        "@shikijs/types": "1.29.2",
-        "@shikijs/vscode-textmate": "^10.0.1",
-        "@types/hast": "^3.0.4"
-      }
-    },
     "shortid": {
       "version": "2.2.17",
       "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.17.tgz",
@@ -13603,11 +12971,6 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
-    "space-separated-tokens": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
-      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -13760,15 +13123,6 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
-      }
-    },
-    "stringify-entities": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
-      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
-      "requires": {
-        "character-entities-html4": "^2.0.0",
-        "character-entities-legacy": "^3.0.0"
       }
     },
     "strip-ansi": {
@@ -13940,11 +13294,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
-    "trim-lines": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
-      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="
-    },
     "ts-mocha": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/ts-mocha/-/ts-mocha-10.1.0.tgz",
@@ -14032,15 +13381,15 @@
       "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg=="
     },
     "typedoc": {
-      "version": "0.26.11",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.26.11.tgz",
-      "integrity": "sha512-sFEgRRtrcDl2FxVP58Ze++ZK2UQAEvtvvH8rRlig1Ja3o7dDaMHmaBfvJmdGnNEFaLTpQsN8dpvZaTqJSu/Ugw==",
+      "version": "0.28.3",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.3.tgz",
+      "integrity": "sha512-5svOCTfXvVSh6zbZKSQluZhR8yN2tKpTeHZxlmWpE6N5vc3R8k/jhg9nnD6n5tN9/ObuQTojkONrOxFdUFUG9w==",
       "requires": {
+        "@gerrit0/mini-shiki": "^3.2.2",
         "lunr": "^2.3.9",
         "markdown-it": "^14.1.0",
         "minimatch": "^9.0.5",
-        "shiki": "^1.16.2",
-        "yaml": "^2.5.1"
+        "yaml": "^2.7.1"
       },
       "dependencies": {
         "brace-expansion": {
@@ -14061,10 +13410,16 @@
         }
       }
     },
+    "typedoc-github-theme": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/typedoc-github-theme/-/typedoc-github-theme-0.3.0.tgz",
+      "integrity": "sha512-7HzKJt8ZZSTNYczK8BcZZbpr7GsyTZgsoLFKtO4NYxXOb7mSr92yTj7hl16ind0WsOzxPo2DZGjkUH2VoPrdxg==",
+      "requires": {}
+    },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
     },
     "ua-parser-js": {
       "version": "0.7.40",
@@ -14112,52 +13467,9 @@
       }
     },
     "undici-types": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg=="
-    },
-    "unist-util-is": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.0.tgz",
-      "integrity": "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==",
-      "requires": {
-        "@types/unist": "^3.0.0"
-      }
-    },
-    "unist-util-position": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
-      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
-      "requires": {
-        "@types/unist": "^3.0.0"
-      }
-    },
-    "unist-util-stringify-position": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
-      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-      "requires": {
-        "@types/unist": "^3.0.0"
-      }
-    },
-    "unist-util-visit": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.0.0.tgz",
-      "integrity": "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg==",
-      "requires": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0",
-        "unist-util-visit-parents": "^6.0.0"
-      }
-    },
-    "unist-util-visit-parents": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
-      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
-      "requires": {
-        "@types/unist": "^3.0.0",
-        "unist-util-is": "^6.0.0"
-      }
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
     },
     "universalify": {
       "version": "2.0.1",
@@ -14251,24 +13563,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
-    },
-    "vfile": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
-      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
-      "requires": {
-        "@types/unist": "^3.0.0",
-        "vfile-message": "^4.0.0"
-      }
-    },
-    "vfile-message": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.2.tgz",
-      "integrity": "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==",
-      "requires": {
-        "@types/unist": "^3.0.0",
-        "unist-util-stringify-position": "^4.0.0"
-      }
     },
     "vm-browserify": {
       "version": "1.1.2",
@@ -14441,14 +13735,9 @@
       "peer": true
     },
     "zod": {
-      "version": "3.24.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
-      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="
-    },
-    "zwitch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
-      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
+      "version": "3.24.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
+      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg=="
     }
   }
 }

--- a/core/package.json
+++ b/core/package.json
@@ -58,7 +58,7 @@
         "node": ">= 0.8.0"
     },
     "dependencies": {
-        "@nevware21/ts-utils": ">= 0.11.8 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.2 < 2.x",
         "@nevware21/ts-async": ">= 0.5.2 < 2.x",
         "tslib": "^2.3.0"
     },
@@ -91,8 +91,9 @@
         "rollup-plugin-istanbul": "^4.0.0",
         "rollup-plugin-cleanup": "^3.2.1",
         "ts-mocha": "^10.0.0",
-        "typedoc": "^0.26.2",
-        "typescript": "^4.9.5",
+        "typedoc": "^0.28.2",
+        "typedoc-github-theme": "^0.3.0",
+        "typescript": "~5.2.2",
         "uglify-js": "^3.15.5",
         "copyfiles": "^2.4.1"
     }

--- a/core/src/assert/funcs/equal.ts
+++ b/core/src/assert/funcs/equal.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  */
 
-import { arrForEach, arrMap, asString, isDate, isFunction, isObject, isPlainObject, isPrimitive, iterForOf, objToString, strLower } from "@nevware21/ts-utils";
+import { arrForEach, arrMap, asString, isDate, isFunction, isObject, isPlainObject, isPrimitive, iterForOf, objGetOwnPropertyDescriptor, objGetOwnPropertySymbols, objIs, objToString, strLower } from "@nevware21/ts-utils";
 import { MsgSource } from "../interface/types";
 import { IAssertScope } from "../interface/IAssertScope";
 import { _formatValue } from "../internal/_formatValue";
@@ -142,7 +142,7 @@ function _strictEquals<T>(value: T, expected: T): boolean {
         return value === 0 || 1 === 1;
     }
 
-    if (Object.is && Object.is(value, expected)) {
+    if (objIs(value, expected)) {
         return true;
     }
 
@@ -363,8 +363,8 @@ function _getObjKeys(value: any): Array<string | number | symbol> {
         keys.push(key);
     }
 
-    arrForEach(Object.getOwnPropertySymbols(value), (sym) => {
-        if (Object.getOwnPropertyDescriptor(value, sym).enumerable) {
+    arrForEach(objGetOwnPropertySymbols(value), (sym) => {
+        if (objGetOwnPropertyDescriptor(value, sym).enumerable) {
             keys.push(sym);
         }
     });

--- a/core/src/assert/funcs/isExtensible.ts
+++ b/core/src/assert/funcs/isExtensible.ts
@@ -8,16 +8,15 @@
 
 import { MsgSource } from "../interface/types";
 import { IAssertScope } from "../interface/IAssertScope";
+import { objIsExtensible } from "@nevware21/ts-utils";
 
 export function isExtensibleFunc<R>(this: IAssertScope, evalMsg?: MsgSource): R {
     let scope = this;
     let context = scope.context;
     let value = context.value;
 
-    let isExtensible = Object.isExtensible;
-
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/isExtensible
-    context.eval(value === Object(value) && isExtensible && isExtensible(value), evalMsg || "expected {value} to be extensible");
+    context.eval(value === Object(value) && objIsExtensible(value), evalMsg || "expected {value} to be extensible");
 
     return scope.that;
 }

--- a/core/src/assert/funcs/isFrozen.ts
+++ b/core/src/assert/funcs/isFrozen.ts
@@ -6,13 +6,14 @@
  * Licensed under the MIT license.
  */
 
+import { objIsFrozen } from "@nevware21/ts-utils";
 import { IAssertScope } from "../interface/IAssertScope";
 import { MsgSource } from "../interface/types";
 
 export function isFrozenFunc<R>(this: IAssertScope, evalMsg?: MsgSource): R{
     let scope = this;
     let context = scope.context;
-    context.eval(Object.isFrozen(context.value), evalMsg || "expected {value} to be frozen");
+    context.eval(objIsFrozen(context.value), evalMsg || "expected {value} to be frozen");
 
     return scope.that;
 }

--- a/core/src/assert/funcs/isSealed.ts
+++ b/core/src/assert/funcs/isSealed.ts
@@ -8,11 +8,12 @@
 
 import { MsgSource } from "../interface/types";
 import { IAssertScope } from "../interface/IAssertScope";
+import { objIsSealed } from "@nevware21/ts-utils";
 
 export function isSealedFunc<R>(this: IAssertScope, evalMsg?: MsgSource): R {
     let scope = this;
     let context = scope.context;
-    context.eval(Object.isSealed(context.value), evalMsg || "expected {value} to be sealed");
+    context.eval(objIsSealed(context.value), evalMsg || "expected {value} to be sealed");
 
     return scope.that;
 }

--- a/core/src/assert/funcs/keysFunc.ts
+++ b/core/src/assert/funcs/keysFunc.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  */
 
-import { arrForEach, arrSlice, asString, isArray, isObject, isStrictNullOrUndefined, isString, objKeys } from "@nevware21/ts-utils";
+import { arrForEach, arrSlice, asString, isArray, isObject, isStrictNullOrUndefined, isString, objGetOwnPropertyDescriptor, objGetOwnPropertySymbols, objKeys } from "@nevware21/ts-utils";
 import { IAssertScope } from "../interface/IAssertScope";
 import { KeysFn } from "../interface/funcs/KeysFn";
 import { EMPTY_STRING } from "../internal/const";
@@ -16,14 +16,12 @@ function _objKeys(value: any): any[] {
     if (value) {
         keys = objKeys(value);
 
-        if (Object.getOwnPropertySymbols) {
-            let symbols = Object.getOwnPropertySymbols(value);
-            arrForEach(symbols, (symbol) => {
-                if (Object.getOwnPropertyDescriptor(value, symbol).enumerable) {
-                    keys.push(symbol);
-                }
-            });
-        }
+        let symbols = objGetOwnPropertySymbols(value);
+        arrForEach(symbols, (symbol) => {
+            if (objGetOwnPropertyDescriptor(value, symbol).enumerable) {
+                keys.push(symbol);
+            }
+        });
     }
 
     return keys;

--- a/core/src/assert/internal/_formatValue.ts
+++ b/core/src/assert/internal/_formatValue.ts
@@ -8,7 +8,7 @@
 
 import {
     arrForEach, arrIndexOf, asString, dumpObj, isArray, isError, isFunction, isPlainObject, isPrimitive,
-    isRegExp, isStrictNullOrUndefined, isString, isSymbol, objForEachKey, objGetPrototypeOf
+    isRegExp, isStrictNullOrUndefined, isString, isSymbol, objForEachKey, objGetOwnPropertySymbols, objGetPrototypeOf
 } from "@nevware21/ts-utils";
 import { EMPTY_STRING } from "./const";
 
@@ -24,18 +24,12 @@ function _getObjKeys<T>(target: T): (keyof T)[] {
             }
         });
 
-        try {
-            if (Object.getOwnPropertySymbols) {
-                let symbols = Object.getOwnPropertySymbols(currentObj);
-                arrForEach(symbols, (symbol) => {
-                    if (arrIndexOf(keys, symbol) === -1) {
-                        keys.push(symbol);
-                    }
-                });
+        let symbols = objGetOwnPropertySymbols(currentObj);
+        arrForEach(symbols, (symbol) => {
+            if (arrIndexOf(keys, symbol) === -1) {
+                keys.push(symbol);
             }
-        } catch (e) {
-            // ignore
-        }
+        });
         
         let newObj = objGetPrototypeOf(currentObj);
         if (newObj === currentObj) {

--- a/core/src/assert/ops/includeOp.ts
+++ b/core/src/assert/ops/includeOp.ts
@@ -14,6 +14,33 @@ import { IIncludeOp } from "../interface/ops/IIncludeOp";
 import { IAssertScope } from "../interface/IAssertScope";
 
 /**
+ * Helper function to check if an array contains a deep equal item
+ * @param haystack - The array to search in
+ * @param needle - The item to search for
+ * @returns True if the item is found, false otherwise
+ */
+function _deepIncludesArray(haystack: any[], needle: any[]): boolean {
+    for (let i = 0; i < haystack.length; i++) {
+        const item = haystack[i];
+        if (item.length === needle.length) {
+            let allEqual = true;
+            for (let j = 0; j < item.length; j++) {
+                if (item[j] !== needle[j]) {
+                    allEqual = false;
+                    break;
+                }
+            }
+
+            if (allEqual) {
+                return true;
+            }
+        }
+    }
+    
+    return false;
+}
+
+/**
  * Creates the include assertion operation using the given scope.
  * This includes the primary include function and any additional properties
  * as identified by the {@link IncludeOpProps} interface.
@@ -72,7 +99,7 @@ export function deepIncludeOp<R>(scope: IAssertScope): IIncludeOp<R> {
         if (isString(context.value)) {
             context.eval(value.indexOf(match) > -1, evalMsg || "expected {value} to include {match}");
         } else if (isArray(context.value)) {
-            context.eval(arrIndexOf(value, match) > -1, evalMsg || "expected {value} to include {match}");
+            context.eval(_deepIncludesArray(value, match), evalMsg || "expected {value} to include {match}");
         } else if (value && isFunction(value.has)) {
             // Looks like a set or map
             context.eval(value.has(match), evalMsg || "expected {value} to include {match}");

--- a/core/test/tsconfig.browser.karma.json
+++ b/core/test/tsconfig.browser.karma.json
@@ -10,7 +10,6 @@
         "importHelpers": false,
         "noEmitHelpers": false,
         "alwaysStrict": true,
-        "suppressImplicitAnyIndexErrors": true,
         "allowSyntheticDefaultImports": true,
         "removeComments": true,
         "esModuleInterop": true

--- a/core/test/tsconfig.test.json
+++ b/core/test/tsconfig.test.json
@@ -10,7 +10,6 @@
         "importHelpers": false,
         "noEmitHelpers": false,
         "alwaysStrict": true,
-        "suppressImplicitAnyIndexErrors": true,
         "allowSyntheticDefaultImports": true,
         "removeComments": true,
         "esModuleInterop": true

--- a/core/test/tsconfig.worker.karma.json
+++ b/core/test/tsconfig.worker.karma.json
@@ -11,7 +11,6 @@
         "noEmitHelpers": false,
         "alwaysStrict": true,
         "declaration": false,
-        "suppressImplicitAnyIndexErrors": true,
         "allowSyntheticDefaultImports": true,
         "removeComments": true,
         "esModuleInterop": true

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -12,7 +12,6 @@
         "alwaysStrict": true,
         "declaration": false,
         "outDir": "./build/base",
-        "suppressImplicitAnyIndexErrors": true,
         "allowSyntheticDefaultImports": true,
         "removeComments": true
     },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
         "node": ">= 0.8.0"
     },
     "dependencies": {
-        "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
+        "@nevware21/ts-utils": ">= 0.12.2 < 2.x"
     },
     "devDependencies": {
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
@@ -88,7 +88,8 @@
         "grunt-cli": "^1.4.3",
         "nyc": "^17.0.0",
         "puppeteer": "^24.4.0",
-        "typedoc": "^0.26.2",
-        "typescript": "^4.9.5"
+        "typedoc": "^0.28.2",
+        "typedoc-github-theme": "^0.3.0",
+        "typescript": "~5.2.2"
     }
 }

--- a/shim/chai/package.json
+++ b/shim/chai/package.json
@@ -59,7 +59,7 @@
         "node": ">= 0.8.0"
     },
     "dependencies": {
-        "@nevware21/ts-utils": ">= 0.11.8 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.2 < 2.x",
         "@nevware21/ts-async": ">= 0.5.2 < 2.x",
         "@nevware21/tripwire": "0.1.2"
     },
@@ -91,8 +91,9 @@
         "rollup-plugin-istanbul": "^4.0.0",
         "rollup-plugin-cleanup": "^3.2.1",
         "ts-mocha": "^10.0.0",
-        "typedoc": "^0.26.2",
-        "typescript": "^4.9.5",
+        "typedoc": "^0.28.2",
+        "typedoc-github-theme": "^0.3.0",
+        "typescript": "~5.2.2",
         "uglify-js": "^3.15.5",
         "copyfiles": "^2.4.1"
     }

--- a/shim/chai/test/src/chaiAssert.test.ts
+++ b/shim/chai/test/src/chaiAssert.test.ts
@@ -72,40 +72,40 @@ describe("assert", function () {
 
     it("isOk / ok", function () {
         ["isOk", "ok"].forEach(function (isOk) {
-            assert[isOk](true);
-            assert[isOk](1);
-            assert[isOk]("test");
+            (assert as any)[isOk](true);
+            (assert as any)[isOk](1);
+            (assert as any)[isOk]("test");
 
             err(function () {
-                assert[isOk](false, "blah");
+                (assert as any)[isOk](false, "blah");
             }, "blah: expected false to be truthy");
 
             err(function () {
-                assert[isOk](0);
+                (assert as any)[isOk](0);
             }, "expected 0 to be truthy");
 
             err(function () {
-                assert[isOk]("");
+                (assert as any)[isOk]("");
             }, "expected \"\" to be truthy");
         });
     });
 
     it("isNotOk, notOk", function () {
         ["isNotOk", "notOk"].forEach(function (isNotOk) {
-            assert[isNotOk](false);
-            assert[isNotOk](0);
-            assert[isNotOk]("");
+            (assert as any)[isNotOk](false);
+            (assert as any)[isNotOk](0);
+            (assert as any)[isNotOk]("");
 
             err(function () {
-                assert[isNotOk](true, "blah");
+                (assert as any)[isNotOk](true, "blah");
             }, "blah: not expected true to be truthy");
 
             err(function () {
-                assert[isNotOk](1);
+                (assert as any)[isNotOk](1);
             }, "not expected 1 to be truthy");
 
             err(function () {
-                assert[isNotOk]("test");
+                (assert as any)[isNotOk]("test");
             }, "not expected \"test\" to be truthy");
         });
     });
@@ -1052,7 +1052,7 @@ describe("assert", function () {
         var enumProp1 = "enumProp1"
             , enumProp2 = "enumProp2"
             , nonEnumProp = "nonEnumProp"
-            , obj = {};
+            , obj: any = {};
 
         obj[enumProp1] = "enumProp1";
         obj[enumProp2] = "enumProp2";
@@ -1069,7 +1069,7 @@ describe("assert", function () {
             , sym2 = Symbol("sym2")
             , sym3 = Symbol("sym3")
             , str = "str"
-            , obj = {};
+            , obj: any = {};
 
         obj[sym1] = "sym1";
         obj[sym2] = "sym2";
@@ -1648,101 +1648,101 @@ describe("assert", function () {
         class CustomError extends Error {}
 
         ["throws", "throw", "Throw"].forEach(function (throws) {
-            assert[throws](function() {
+            (assert as any)[throws](function() {
                 throw new Error("foo");
             });
-            assert[throws](function() {
+            (assert as any)[throws](function() {
                 throw new Error("");
             }, "");
-            assert[throws](function() {
+            (assert as any)[throws](function() {
                 throw new Error("bar");
             }, "bar");
-            assert[throws](function() {
+            (assert as any)[throws](function() {
                 throw new Error("bar");
             }, /bar/);
-            assert[throws](function() {
+            (assert as any)[throws](function() {
                 throw new Error("bar");
             }, Error);
-            assert[throws](function() {
+            (assert as any)[throws](function() {
                 throw new Error("bar");
             }, Error, "bar");
-            assert[throws](function() {
+            (assert as any)[throws](function() {
                 throw new Error("");
             }, Error, "");
-            assert[throws](function() {
+            (assert as any)[throws](function() {
                 throw new Error("foo")
             }, "");
-            assert[throws](function() {
+            (assert as any)[throws](function() {
                 throw "";
             }, "");
-            assert[throws](function() {
+            (assert as any)[throws](function() {
                 throw "";
             }, /^$/);
-            assert[throws](function() {
+            (assert as any)[throws](function() {
                 throw new Error("");
             }, /^$/);
-            assert[throws](function() {
+            (assert as any)[throws](function() {
                 throw undefined;
             });
-            assert[throws](function() {
+            (assert as any)[throws](function() {
                 throw new CustomError("foo");
             });
-            assert[throws](function() {
+            (assert as any)[throws](function() {
                 throw (() => {});
             });
 
-            var thrownErr = assert[throws](function() {
+            var thrownErr = (assert as any)[throws](function() {
                 throw new Error("foo");
             });
             assert(thrownErr instanceof Error, "assert." + throws + " returns error");
             assert(thrownErr.message === "foo", "assert." + throws + " returns error message");
 
             err(function () {
-                assert[throws](function() {
+                (assert as any)[throws](function() {
                     throw new Error("foo")
                 }, TypeError);
             }, "expected [Function] to throw an error of type TypeError() but threw [Error:\"foo\"]")
 
             err(function () {
-                assert[throws](function() {
+                (assert as any)[throws](function() {
                     throw new Error("foo")
                 }, "bar");
             }, "expected [Function] to throw an error with a message containing \"bar\" but it was \"foo\"")
 
             err(function () {
-                assert[throws](function() {
+                (assert as any)[throws](function() {
                     throw new Error("foo")
                 }, Error, "bar", "blah");
             }, "blah: expected [Function] to throw an error of type Error() with a message containing \"bar\" but [Error:\"foo\"] was thrown")
 
             err(function () {
-                assert[throws](function() {
+                (assert as any)[throws](function() {
                     throw new Error("foo")
                 }, TypeError, "bar", "blah");
             }, "blah: expected [Function] to throw an error of type TypeError() with a message containing \"bar\" but [Error:\"foo\"] was thrown")
 
             err(function () {
-                assert[throws](function() {});
+                (assert as any)[throws](function() {});
             }, "expected [Function] to throw an error");
 
             err(function () {
-                assert[throws](function() {
+                (assert as any)[throws](function() {
                     throw new Error("")
                 }, "bar");
             }, " expected [Function] to throw an error with a message containing \"bar\" but it was \"\"");
 
             err(function () {
-                assert[throws](function() {
+                (assert as any)[throws](function() {
                     throw new Error("")
                 }, /bar/);
             }, "expected [Function] to throw an error with a message matching /bar/ but it was \"\"");
 
             err(function () {
-                assert[throws]({});
+                (assert as any)[throws]({});
             }, "expected {} to be a function");
 
             err(function () {
-                assert[throws]({}, Error, "testing", "blah");
+                (assert as any)[throws]({}, Error, "testing", "blah");
             }, "blah: expected {} to be a function");
         });
     });
@@ -2610,32 +2610,32 @@ describe("assert", function () {
         ["isExtensible", "extensible"].forEach(function (isExtensible) {
             var nonExtensibleObject = Object.preventExtensions({});
 
-            assert[isExtensible]({});
+            (assert as any)[isExtensible]({});
 
             err(function() {
-                assert[isExtensible](nonExtensibleObject, "blah");
+                (assert as any)[isExtensible](nonExtensibleObject, "blah");
             }, "blah: expected {} to be extensible");
 
             // Making sure ES6-like Object.isExtensible response is respected for all primitive types
 
             err(function() {
-                assert[isExtensible](42);
+                (assert as any)[isExtensible](42);
             }, "expected 42 to be extensible");
 
             err(function() {
-                assert[isExtensible](null);
+                (assert as any)[isExtensible](null);
             }, "expected null to be extensible");
 
             err(function() {
-                assert[isExtensible]("foo");
+                (assert as any)[isExtensible]("foo");
             }, "expected \"foo\" to be extensible");
 
             err(function() {
-                assert[isExtensible](false);
+                (assert as any)[isExtensible](false);
             }, "expected false to be extensible");
 
             err(function() {
-                assert[isExtensible](undefined);
+                (assert as any)[isExtensible](undefined);
             }, "expected undefined to be extensible");
 
             var proxy = new Proxy({}, {
@@ -2646,7 +2646,7 @@ describe("assert", function () {
 
             err(function() {
                 // isExtensible should not suppress errors, thrown in proxy traps
-                assert[isExtensible](proxy);
+                (assert as any)[isExtensible](proxy);
             }, { name: "TypeError" }, true);
         });
     });
@@ -2655,20 +2655,20 @@ describe("assert", function () {
         ["isNotExtensible", "notExtensible"].forEach(function (isNotExtensible) {
             var nonExtensibleObject = Object.preventExtensions({});
 
-            assert[isNotExtensible](nonExtensibleObject);
+            (assert as any)[isNotExtensible](nonExtensibleObject);
 
             err(function() {
-                assert[isNotExtensible]({}, "blah");
+                (assert as any)[isNotExtensible]({}, "blah");
             }, "blah: not expected {} to be extensible");
 
             // Making sure ES6-like Object.isExtensible response is respected for all primitive types
 
-            assert[isNotExtensible](42);
-            assert[isNotExtensible](null);
-            assert[isNotExtensible]("foo");
-            assert[isNotExtensible](false);
-            assert[isNotExtensible](undefined);
-            assert[isNotExtensible](Symbol());
+            (assert as any)[isNotExtensible](42);
+            (assert as any)[isNotExtensible](null);
+            (assert as any)[isNotExtensible]("foo");
+            (assert as any)[isNotExtensible](false);
+            (assert as any)[isNotExtensible](undefined);
+            (assert as any)[isNotExtensible](Symbol());
 
             var proxy = new Proxy({}, {
                 isExtensible: function() {
@@ -2678,7 +2678,7 @@ describe("assert", function () {
 
             err(function() {
                 // isNotExtensible should not suppress errors, thrown in proxy traps
-                assert[isNotExtensible](proxy);
+                (assert as any)[isNotExtensible](proxy);
             }, { name: "TypeError" }, true);
         });
     });
@@ -2687,20 +2687,20 @@ describe("assert", function () {
         ["isSealed", "sealed"].forEach(function (isSealed) {
             var sealedObject = Object.seal({});
 
-            assert[isSealed](sealedObject);
+            (assert as any)[isSealed](sealedObject);
 
             err(function() {
-                assert[isSealed]({}, "blah");
+                (assert as any)[isSealed]({}, "blah");
             }, "blah: expected {} to be sealed");
 
             // Making sure ES6-like Object.isSealed response is respected for all primitive types
 
-            assert[isSealed](42);
-            assert[isSealed](null);
-            assert[isSealed]("foo");
-            assert[isSealed](false);
-            assert[isSealed](undefined);
-            assert[isSealed](Symbol());
+            (assert as any)[isSealed](42);
+            (assert as any)[isSealed](null);
+            (assert as any)[isSealed]("foo");
+            (assert as any)[isSealed](false);
+            (assert as any)[isSealed](undefined);
+            (assert as any)[isSealed](Symbol());
 
             var proxy = new Proxy({}, {
                 ownKeys: function() {
@@ -2713,7 +2713,7 @@ describe("assert", function () {
 
             err(function() {
                 // isSealed should not suppress errors, thrown in proxy traps
-                assert[isSealed](proxy);
+                (assert as any)[isSealed](proxy);
             }, { name: "TypeError" }, true);
         });
     });
@@ -2722,32 +2722,32 @@ describe("assert", function () {
         ["isNotSealed", "notSealed"].forEach(function (isNotSealed) {
             var sealedObject = Object.seal({});
 
-            assert[isNotSealed]({});
+            (assert as any)[isNotSealed]({});
 
             err(function() {
-                assert[isNotSealed](sealedObject, "blah");
+                (assert as any)[isNotSealed](sealedObject, "blah");
             }, "blah: not expected {} to be sealed");
 
             // Making sure ES6-like Object.isSealed response is respected for all primitive types
 
             err(function() {
-                assert[isNotSealed](42);
+                (assert as any)[isNotSealed](42);
             }, "not expected 42 to be sealed");
 
             err(function() {
-                assert[isNotSealed](null);
+                (assert as any)[isNotSealed](null);
             }, "not expected null to be sealed");
 
             err(function() {
-                assert[isNotSealed]("foo");
+                (assert as any)[isNotSealed]("foo");
             }, "not expected \"foo\" to be sealed");
 
             err(function() {
-                assert[isNotSealed](false);
+                (assert as any)[isNotSealed](false);
             }, "not expected false to be sealed");
 
             err(function() {
-                assert[isNotSealed](undefined);
+                (assert as any)[isNotSealed](undefined);
             }, "not expected undefined to be sealed");
 
             var proxy = new Proxy({}, {
@@ -2761,7 +2761,7 @@ describe("assert", function () {
 
             err(function() {
                 // isNotSealed should not suppress errors, thrown in proxy traps
-                assert[isNotSealed](proxy);
+                (assert as any)[isNotSealed](proxy);
             }, { name: "TypeError" }, true);
         });
     });
@@ -2770,20 +2770,20 @@ describe("assert", function () {
         ["isFrozen", "frozen"].forEach(function (isFrozen) {
             var frozenObject = Object.freeze({});
 
-            assert[isFrozen](frozenObject);
+            (assert as any)[isFrozen](frozenObject);
 
             err(function() {
-                assert[isFrozen]({}, "blah");
+                (assert as any)[isFrozen]({}, "blah");
             }, "blah: expected {} to be frozen");
 
             // Making sure ES6-like Object.isFrozen response is respected for all primitive types
 
-            assert[isFrozen](42);
-            assert[isFrozen](null);
-            assert[isFrozen]("foo");
-            assert[isFrozen](false);
-            assert[isFrozen](undefined);
-            assert[isFrozen](Symbol());
+            (assert as any)[isFrozen](42);
+            (assert as any)[isFrozen](null);
+            (assert as any)[isFrozen]("foo");
+            (assert as any)[isFrozen](false);
+            (assert as any)[isFrozen](undefined);
+            (assert as any)[isFrozen](Symbol());
 
             var proxy = new Proxy({}, {
                 ownKeys: function() {
@@ -2796,7 +2796,7 @@ describe("assert", function () {
 
             err(function() {
                 // isFrozen should not suppress errors, thrown in proxy traps
-                assert[isFrozen](proxy);
+                (assert as any)[isFrozen](proxy);
             }, { name: "TypeError" }, true);
         });
     });
@@ -2805,32 +2805,32 @@ describe("assert", function () {
         ["isNotFrozen", "notFrozen"].forEach(function (isNotFrozen) {
             var frozenObject = Object.freeze({});
 
-            assert[isNotFrozen]({});
+            (assert as any)[isNotFrozen]({});
 
             err(function() {
-                assert[isNotFrozen](frozenObject, "blah");
+                (assert as any)[isNotFrozen](frozenObject, "blah");
             }, "blah: not expected {} to be frozen", true);
 
             // Making sure ES6-like Object.isFrozen response is respected for all primitive types
 
             err(function() {
-                assert[isNotFrozen](42);
+                (assert as any)[isNotFrozen](42);
             }, "not expected 42 to be frozen");
 
             err(function() {
-                assert[isNotFrozen](null);
+                (assert as any)[isNotFrozen](null);
             }, "not expected null to be frozen");
 
             err(function() {
-                assert[isNotFrozen]("foo");
+                (assert as any)[isNotFrozen]("foo");
             }, "not expected \"foo\" to be frozen");
 
             err(function() {
-                assert[isNotFrozen](false);
+                (assert as any)[isNotFrozen](false);
             }, "not expected false to be frozen");
 
             err(function() {
-                assert[isNotFrozen](undefined);
+                (assert as any)[isNotFrozen](undefined);
             }, "not expected undefined to be frozen");
 
             var proxy = new Proxy({}, {
@@ -2844,7 +2844,7 @@ describe("assert", function () {
 
             err(function() {
                 // isNotFrozen should not suppress errors, thrown in proxy traps
-                assert[isNotFrozen](proxy);
+                (assert as any)[isNotFrozen](proxy);
             }, { name: "TypeError" }, true);
         });
     });
@@ -2854,89 +2854,89 @@ describe("assert", function () {
             const FakeArgs: any = function (this: any) {}
             FakeArgs.prototype.length = 0;
 
-            assert[isEmpty]("");
-            assert[isEmpty]([]);
-            assert[isEmpty](new FakeArgs());
-            assert[isEmpty]({});
+            (assert as any)[isEmpty]("");
+            (assert as any)[isEmpty]([]);
+            (assert as any)[isEmpty](new FakeArgs());
+            (assert as any)[isEmpty]({});
 
             // err(function(){
-            //     assert[isEmpty](new WeakMap(), "blah");
+            //     (assert as any)[isEmpty](new WeakMap(), "blah");
             // }, "blah: .empty was passed a weak collection");
 
             // err(function(){
-            //     assert[isEmpty](new WeakSet(), "blah");
+            //     (assert as any)[isEmpty](new WeakSet(), "blah");
             // }, "blah: .empty was passed a weak collection");
 
-            assert[isEmpty](new Map());
+            (assert as any)[isEmpty](new Map());
 
             var map = new Map() as any;
             map.key = "val";
-            assert[isEmpty](map);
-            assert[isEmpty](new Set());
+            (assert as any)[isEmpty](map);
+            (assert as any)[isEmpty](new Set());
 
             var set = new Set() as any;
             set.key = "val";
-            assert[isEmpty](set);
+            (assert as any)[isEmpty](set);
 
             err(function(){
-                assert[isEmpty]("foo", "blah");
+                (assert as any)[isEmpty]("foo", "blah");
             }, "blah: expected \"foo\" to be empty");
 
             err(function(){
-                assert[isEmpty](["foo"]);
+                (assert as any)[isEmpty](["foo"]);
             }, "expected [\"foo\"] to be empty");
 
             err(function(){
-                assert[isEmpty]({arguments: 0});
+                (assert as any)[isEmpty]({arguments: 0});
             }, "expected {arguments:0} to be empty");
 
             err(function(){
-                assert[isEmpty]({foo: "bar"});
+                (assert as any)[isEmpty]({foo: "bar"});
             }, "expected {foo:\"bar\"} to be empty");
 
             err(function(){
-                assert[isEmpty](null, "blah");
+                (assert as any)[isEmpty](null, "blah");
             }, "blah: unsupported primitive null");
 
             err(function(){
-                assert[isEmpty](undefined);
+                (assert as any)[isEmpty](undefined);
             }, "unsupported primitive undefined");
 
             err(function(){
-                assert[isEmpty]();
+                (assert as any)[isEmpty]();
             }, "unsupported primitive undefined");
 
             err(function(){
-                assert[isEmpty](0);
+                (assert as any)[isEmpty](0);
             }, "unsupported primitive 0");
 
             err(function(){
-                assert[isEmpty](1);
+                (assert as any)[isEmpty](1);
             }, "unsupported primitive 1");
 
             err(function(){
-                assert[isEmpty](true);
+                (assert as any)[isEmpty](true);
             }, "unsupported primitive true");
 
             err(function(){
-                assert[isEmpty](false);
+                (assert as any)[isEmpty](false);
             }, "unsupported primitive false");
 
             err(function(){
-                assert[isEmpty](Symbol());
+                (assert as any)[isEmpty](Symbol());
             }, "unsupported primitive [Symbol()]");
 
             err(function(){
-                assert[isEmpty](Symbol.iterator);
+                (assert as any)[isEmpty](Symbol.iterator);
             }, "unsupported primitive [Symbol(Symbol.iterator)]");
 
             err(function(){
-                assert[isEmpty](function() {}, "blah");
+                (assert as any)[isEmpty](function() {}, "blah");
             }, "blah: unsupported [Function]");
 
             if (FakeArgs.name === "FakeArgs") {
                 err(function(){
-                    assert[isEmpty](FakeArgs);
+                    (assert as any)[isEmpty](FakeArgs);
                 }, "unsupported [Function:FakeArgs]");
             }
         });
@@ -2950,94 +2950,94 @@ describe("assert", function () {
             }
             FakeArgs.prototype.length = 0;
 
-            assert[isNotEmpty]("foo");
-            assert[isNotEmpty](["foo"]);
-            assert[isNotEmpty]({arguments: 0});
-            assert[isNotEmpty]({foo: "bar"});
+            (assert as any)[isNotEmpty]("foo");
+            (assert as any)[isNotEmpty](["foo"]);
+            (assert as any)[isNotEmpty]({arguments: 0});
+            (assert as any)[isNotEmpty]({foo: "bar"});
 
             // err(function(){
-            //     assert[isNotEmpty](new WeakMap(), "blah");
+            //     (assert as any)[isNotEmpty](new WeakMap(), "blah");
             // }, "blah: .empty was passed a weak collection");
 
             // err(function(){
-            //     assert[isNotEmpty](new WeakSet(), "blah");
+            //     (assert as any)[isNotEmpty](new WeakSet(), "blah");
             // }, "blah: .empty was passed a weak collection");
 
             var map = new Map();
             map.set("a", 1);
-            assert[isNotEmpty](map);
+            (assert as any)[isNotEmpty](map);
 
             err(function(){
-                assert[isNotEmpty](new Map());
+                (assert as any)[isNotEmpty](new Map());
             }, "not expected [Map:{}] to be empty");
 
             var set = new Set();
             set.add(1);
-            assert[isNotEmpty](set);
+            (assert as any)[isNotEmpty](set);
 
             err(function(){
-                assert[isNotEmpty](new Set());
+                (assert as any)[isNotEmpty](new Set());
             }, "not expected [Set:{}] to be empty");
 
             err(function(){
-                assert[isNotEmpty]("", "blah");
+                (assert as any)[isNotEmpty]("", "blah");
             }, "blah: not expected \"\" to be empty");
 
             err(function(){
-                assert[isNotEmpty]([]);
+                (assert as any)[isNotEmpty]([]);
             }, "not expected [] to be empty");
 
             err(function(){
-                assert[isNotEmpty]((new FakeArgs()) as any);
+                (assert as any)[isNotEmpty]((new FakeArgs()) as any);
             }, "not expected [FakeArgs:{}] to be empty");
 
             err(function(){
-                assert[isNotEmpty]({});
+                (assert as any)[isNotEmpty]({});
             }, "not expected {} to be empty");
 
             err(function(){
-                assert[isNotEmpty](null, "blah");
+                (assert as any)[isNotEmpty](null, "blah");
             }, "blah: unsupported primitive null");
 
             err(function(){
-                assert[isNotEmpty](undefined);
+                (assert as any)[isNotEmpty](undefined);
             }, "unsupported primitive undefined");
 
             err(function(){
-                assert[isNotEmpty]();
+                (assert as any)[isNotEmpty]();
             }, "unsupported primitive undefined");
 
             err(function(){
-                assert[isNotEmpty](0);
+                (assert as any)[isNotEmpty](0);
             }, "unsupported primitive 0");
 
             err(function(){
-                assert[isNotEmpty](1);
+                (assert as any)[isNotEmpty](1);
             }, "unsupported primitive 1");
 
             err(function(){
-                assert[isNotEmpty](true);
+                (assert as any)[isNotEmpty](true);
             }, "unsupported primitive true");
 
             err(function(){
-                assert[isNotEmpty](false);
+                (assert as any)[isNotEmpty](false);
             }, "unsupported primitive false");
 
             err(function(){
-                assert[isNotEmpty](Symbol());
+                (assert as any)[isNotEmpty](Symbol());
             }, "unsupported primitive [Symbol()]");
 
             err(function(){
-                assert[isNotEmpty](Symbol.iterator);
+                (assert as any)[isNotEmpty](Symbol.iterator);
             }, "unsupported primitive [Symbol(Symbol.iterator)]");
 
             err(function(){
-                assert[isNotEmpty](function() {}, "blah");
+                (assert as any)[isNotEmpty](function() {}, "blah");
             }, "blah: unsupported [Function]");
 
             if (FakeArgs.name === "FakeArgs") {
                 err(function(){
-                    assert[isNotEmpty](FakeArgs);
+                    (assert as any)[isNotEmpty](FakeArgs);
                 }, "unsupported [Function:FakeArgs]");
             }
         });

--- a/shim/chai/test/tsconfig.browser.karma.json
+++ b/shim/chai/test/tsconfig.browser.karma.json
@@ -10,7 +10,6 @@
         "importHelpers": false,
         "noEmitHelpers": false,
         "alwaysStrict": true,
-        "suppressImplicitAnyIndexErrors": true,
         "allowSyntheticDefaultImports": true,
         "removeComments": true,
         "esModuleInterop": true

--- a/shim/chai/test/tsconfig.test.json
+++ b/shim/chai/test/tsconfig.test.json
@@ -10,7 +10,6 @@
         "importHelpers": false,
         "noEmitHelpers": false,
         "alwaysStrict": true,
-        "suppressImplicitAnyIndexErrors": true,
         "allowSyntheticDefaultImports": true,
         "removeComments": true,
         "esModuleInterop": true

--- a/shim/chai/test/tsconfig.worker.karma.json
+++ b/shim/chai/test/tsconfig.worker.karma.json
@@ -10,7 +10,6 @@
         "importHelpers": false,
         "noEmitHelpers": false,
         "alwaysStrict": true,
-        "suppressImplicitAnyIndexErrors": true,
         "allowSyntheticDefaultImports": true,
         "removeComments": true,
         "esModuleInterop": true

--- a/shim/chai/tsconfig.json
+++ b/shim/chai/tsconfig.json
@@ -12,7 +12,6 @@
         "alwaysStrict": true,
         "declaration": false,
         "outDir": "./build/base",
-        "suppressImplicitAnyIndexErrors": true,
         "allowSyntheticDefaultImports": true,
         "removeComments": true
     },


### PR DESCRIPTION
Bump to typedoc ^0.28.2, Bump to typescript ~5.2.2
- Use github theme
- tag alias constants as functions

Bump to typescript ~5.2.2
- remove `suppressImplicitAnyIndexErrors`

Set runs-on to ubuntu-22.04

Update @nevware21/ts-utils to 0.12.2