### PR TITLE
feat: Add finalize option for post-processing formatted output

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,6 +27,7 @@
         "no-trailing-spaces": [ "warn", { "skipBlankLines": true }],// Enabled for auto fixing
         "no-const-assign": "error",
         "comma-dangle": [ "error", "never" ],                       // Enabled for auto fixing
+        "semi": [ "error", "always" ],                              // Enabled for auto fixing
         "security/detect-object-injection": "off",                  // Suppress Warning -- need to Review Later
         "@typescript-eslint/ban-types": "off",
         "@typescript-eslint/no-unused-vars": [ "warn", { "vars": "all", "args": "none", "argsIgnorePattern": "^_", "ignoreRestSiblings": true } ],

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,91 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 5
+    groups:
+      nevware21:
+        patterns:
+          - "@nevware21/*"
+      types:
+        patterns:
+          - "@types/*"
+      grunt:
+        patterns:
+          - "grunt*"
+      puppeteer:
+        patterns:
+          - "puppeteer"
+      rollup:
+        patterns:
+          - "rollup*"
+          - "@rollup/*"
+      typescript:
+        patterns:
+          - "typescript*"
+          - "typedoc"
+          - "karma-typescript"
+          - "nyc"
+          - "@istanbuljs/nyc-config-typescript"
+          - "*mocha*"
 
   - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/lib" # Location of package manifests
+    directory: "/core" # Location of package manifests
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 5
+    groups:
+      nevware21:
+        patterns:
+          - "@nevware21/*"
+      types:
+        patterns:
+          - "@types/*"
+      grunt:
+        patterns:
+          - "grunt*"
+      puppeteer:
+        patterns:
+          - "puppeteer"
+      rollup:
+        patterns:
+          - "rollup*"
+          - "@rollup/*"
+      typescript:
+        patterns:
+          - "typescript*"
+          - "typedoc"
+          - "karma-typescript"
+          - "nyc"
+          - "@istanbuljs/nyc-config-typescript"
+          - "*mocha*"
+
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/shim" # Location of package manifests
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    groups:
+      nevware21:
+        patterns:
+          - "@nevware21/*"
+      types:
+        patterns:
+          - "@types/*"
+      grunt:
+        patterns:
+          - "grunt*"
+      puppeteer:
+        patterns:
+          - "puppeteer"
+      rollup:
+        patterns:
+          - "rollup*"
+          - "@rollup/*"
+      typescript:
+        patterns:
+          - "typescript*"
+          - "typedoc"
+          - "karma-typescript"
+          - "nyc"
+          - "@istanbuljs/nyc-config-typescript"
+          - "*mocha*"

--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@microsoft/api-extractor": "^7.34.4",
-        "@nevware21/chromacon": ">= 0.1.2 < 2.x",
+        "@nevware21/chromacon": ">= 0.1.3 < 2.x",
         "@nevware21/coverage-tools": "^0.1.3",
         "@nevware21/publish-npm": "^0.1.3",
         "@nevware21/ts-async": ">= 0.5.4 < 2.x",
@@ -562,9 +562,9 @@
       }
     },
     "node_modules/@nevware21/chromacon": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@nevware21/chromacon/-/chromacon-0.1.2.tgz",
-      "integrity": "sha512-3YKroR3ibfLDqCueiMpb//brhd9Uv3F8kGVlpi5ZZiPgoo68Oda+O7yrNBjgo5hyHWpj7vGAYBWvQvya2Svegg==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@nevware21/chromacon/-/chromacon-0.1.3.tgz",
+      "integrity": "sha512-/DgFHg8R+O264zLNFHAX1Sf5Ib01s/GwnNFhpGxMqsV6tcfPg6BivDZdHULbjMYVyX4uQeZG56QgMk1inAIR6Q==",
       "dependencies": {
         "@nevware21/ts-utils": ">= 0.11.8 < 2.x"
       },
@@ -870,18 +870,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.9.5.tgz",
-      "integrity": "sha512-Dq1bqBdLaZ1Gb/l2e5/+o3B18+8TI9ANlA1SkejZqDgdU/jK/ThYaMPMJpVMMXy2uRHvGKbkz9vheVGdq3cJfA==",
-      "cpu": [
-        "x64"
-      ],
-      "optional": true,
-      "os": [
-        "linux"
-      ]
     },
     "node_modules/@rush-temp/tripwire": {
       "version": "0.0.0",
@@ -3131,19 +3119,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",

--- a/core/karma.browser.conf.js
+++ b/core/karma.browser.conf.js
@@ -11,7 +11,8 @@ module.exports = function (config) {
             { pattern: "test/src/**/*.ts" }
         ],
         preprocessors: {
-            "**/*.ts": [ "karma-typescript" ]
+            "src/**/*.ts": [ "karma-typescript" ],
+            "test/src/**/*.ts": [ "karma-typescript" ]
         },
         karmaTypescriptConfig: {
             tsconfig: "./test/tsconfig.browser.karma.json",

--- a/core/karma.debug.worker.conf.js
+++ b/core/karma.debug.worker.conf.js
@@ -4,6 +4,7 @@ module.exports = function (config) {
     const typescript = require("@rollup/plugin-typescript");
     const plugin = require("@rollup/plugin-node-resolve");
     const commonjs = require("@rollup/plugin-commonjs");
+    
     config.set({
         browsers: ["Chromium_without_security"],
         listenAddress: 'localhost',
@@ -21,9 +22,9 @@ module.exports = function (config) {
                 typescript({
                     tsconfig: "./test/tsconfig.worker.karma.json"
                 }),
-                // plugin.nodeResolve({
-                //     browser: true
-                // }),
+                plugin.nodeResolve({
+                    browser: true
+                })
                 // commonjs()
             ],
             output: {

--- a/core/karma.worker.conf.js
+++ b/core/karma.worker.conf.js
@@ -27,12 +27,17 @@ module.exports = function (config) {
                 }),
                 //commonjs(),
                 istanbul({
-                    exclude: [ "**/test/**", "**/node_modules/**" ]
+                    exclude: [ 
+                        "**/index.ts",
+                        "**/test/**",
+                        "**/checkError.ts",
+                        "**/node_modules/**"
+                    ]
                 })
             ],
             output: {
                 format: "iife",
-                dir: "../test-dist",
+                dir: "./test-dist",
                 sourcemap: true
             }
         },

--- a/core/package.json
+++ b/core/package.json
@@ -60,7 +60,7 @@
     "dependencies": {
         "@nevware21/ts-utils": ">= 0.12.3 < 2.x",
         "@nevware21/ts-async": ">= 0.5.4 < 2.x",
-        "@nevware21/chromacon": ">= 0.1.2 < 2.x",
+        "@nevware21/chromacon": ">= 0.1.3 < 2.x",
         "tslib": "^2.3.0"
     },
     "devDependencies": {

--- a/core/src/assert/adapters/evalAdapter.ts
+++ b/core/src/assert/adapters/evalAdapter.ts
@@ -53,9 +53,9 @@ export function createEvalAdapter(evalFn: EvalFn, evalMsg?: MsgSource, funcName?
         }
     
         theArgs.unshift(context.value);
-        context.eval(evalFn.apply(scope.that || scope, theArgs), evalMsg)
+        context.eval(evalFn.apply(scope.that || scope, theArgs), evalMsg);
     
-        return scope.that
+        return scope.that;
     }
 
     return _blockLength(_evalFn, funcName, [], _evalFn);

--- a/core/src/assert/adapters/exprAdapter.ts
+++ b/core/src/assert/adapters/exprAdapter.ts
@@ -136,7 +136,7 @@ function _runExpr(theAssert: any, scope: IAssertScope, steps: IStepDef[], scopeF
 
         if (!(step.name in scope.that)) {
             throw new AssertionError(
-                `${idx} Invalid step: ${step.name} for [${steps.map(s => s.name).join("->")}] available steps: [${objKeys(scope.that).join(";")}] - ${_formatValue(scope.that)}`,
+                `${idx} Invalid step: ${step.name} for [${steps.map(s => s.name).join("->")}] available steps: [${objKeys(scope.that).join(";")}] - ${_formatValue(scope.context, scope.that)}`,
                 null,
                 context._$stackFn);
         }
@@ -176,7 +176,7 @@ function _processFn(scope: IAssertScope, scopeFn: IScopeFn, theArgs: any[], theR
     if (scopeFn) {
         // Track the operation path and set the stack start position
         if (scope.context.opts.isVerbose) {
-            let theScopeName = scopeFn.name || (scopeFn as any)["displayName"] || "anonymous"
+            let theScopeName = scopeFn.name || (scopeFn as any)["displayName"] || "anonymous";
             scope.context.setOp("[[" + theScopeName + "]]");
         }
 

--- a/core/src/assert/assertClass.ts
+++ b/core/src/assert/assertClass.ts
@@ -23,6 +23,7 @@ import { hasPropertyFunc } from "./funcs/hasProperty";
 import { AssertionError, AssertionFailure } from "./assertionError";
 import { createContext } from "./scopeContext";
 import { createAssertScope } from "./assertScope";
+import { assertConfig } from "./config";
 import { IScopeFn } from "./interface/IScopeFuncs";
 import { createExprAdapter } from "./adapters/exprAdapter";
 import { isSealedFunc } from "./funcs/isSealed";
@@ -344,7 +345,7 @@ function _createAliasFunc(alias: string) {
 
 function _createProxyFunc(theAssert: IAssertClass, assertName: string, def: IAssertClassDef, internalErrorStackStart: Function, responseHandler: (result: any) => any): IScopeFn {
     // let steps: IStepDef[];
-    let scopeFn: IScopeFn = def.scopeFn
+    let scopeFn: IScopeFn = def.scopeFn;
     let mIdx: number = def.mIdx || -1;
     let numArgs: number = isNullOrUndefined(def.nArgs) ? 1 : def.nArgs;
 
@@ -370,7 +371,7 @@ function _createProxyFunc(theAssert: IAssertClass, assertName: string, def: IAss
 
         // Create the initial scope `expect(value, initMsg)` and run any defined steps
         // Using either the current alias entry point or the current function
-        let newScope = createAssertScope(createContext(actualValue, initMsg, _aliasStackStart || _assertFunc, orgArgs));
+        let newScope = createAssertScope(createContext(actualValue, initMsg, _aliasStackStart || _assertFunc, orgArgs, assertConfig));
         newScope.context._$stackFn.push(_aliasStackStart || _assertFunc);
 
         newScope.context.setOp(assertName + "()");

--- a/core/src/assert/assertScope.ts
+++ b/core/src/assert/assertScope.ts
@@ -18,6 +18,7 @@ import { AssertInstHandlers } from "./interface/IAssertInstHandlers";
 import { _createLazyInstHandler, _setAssertScope } from "./internal/_instCreator";
 import { _tripwireAssertHandlers } from "./internal/_tripwireInst";
 import { _failFn, _fatalFn } from "./internal/_failFn";
+import { useScope } from "./useScope";
 
 
 /**
@@ -103,7 +104,7 @@ export function createAssertScope(context: IScopeContext, handlerCreator?: Asser
      */
     function updateCtx<T>(value: T, overrides?: IScopeContextOverrides): IAssertScope {
         if (value !== _context.value || overrides) {
-            _context = _context.new(value, overrides)
+            _context = _context.new(value, overrides);
         }
     
         return theScope;
@@ -125,7 +126,9 @@ export function createAssertScope(context: IScopeContext, handlerCreator?: Asser
         _context.set(EXEC, theFuncName);
         _context._$stackFn.push(_exec);
 
-        return fn.apply(theScope, args);
+        return useScope(_context, () => {
+            return fn.apply(theScope, args);
+        });
     }
 
     function fail(failMsg: MsgSource, details?: any): never;

--- a/core/src/assert/config.ts
+++ b/core/src/assert/config.ts
@@ -6,47 +6,124 @@
  * Licensed under the MIT license.
  */
 
-import { objAssign, objDefine, objForEachKey } from "@nevware21/ts-utils";
+import { arrIndexOf, arrSlice, isArray, isNullOrUndefined, isObject, objDefine, objForEachKey } from "@nevware21/ts-utils";
 import { IAssertConfig, IAssertConfigDefaults } from "./interface/IAssertConfig";
+import { cyan } from "@nevware21/chromacon";
+import { IFormatter } from "./interface/IFormatter";
+
+function _noOpFn() {
+    // No operation function
+}
 
 /**
  * @internal
  * @ignore
  * The default configuration values.
+ * Note: formatters defaults to empty array - default formatters are automatically
+ * used as fallback internally by the formatting logic.
+ *
+ * Default finalize is false - when set to true without finalizeFn, uses
+ * [escapeAnsi](https://nevware21.github.io/chromacon/typedoc/core/functions/escapeAnsi.html)
+ * from [@nevware21/chromacon](https://nevware21.github.io/chromacon/).
  */
-const DEFAULT_CONFIG: IAssertConfig = {
+const DEFAULT_CONFIG: IAssertConfig = (/* $__PURE__ */{
     isVerbose: false,
     fullStack: false,
     defAssertMsg: "assertion failure",
-    defFatalMsg: "fatal assertion failure"
-};
+    defFatalMsg: "fatal assertion failure",
+    format: {
+        finalize: false,
+        finalizeFn: undefined,
+        formatters: []
+    },
+    circularMsg: () => cyan("[<Circular>]")
+});
 
-export const assertConfig: IAssertConfigDefaults = (function() {
-    let theValues = objAssign({}, DEFAULT_CONFIG);
+function _mergeConfig(target: any, source: any) {
+    objForEachKey(source, (key: string) => {
+        if (isArray(source[key])) {
+            target[key] = arrSlice(source[key], 0)
+        } else if (isObject(source[key])) {
+            if (!isObject(target[key])) {
+                target[key] = {};
+            }
+
+            _mergeConfig(target[key], source[key]);
+        } else {
+            target[key] = source[key];
+        }
+    });
+
+    return target;
+}
+
+function _defineProp(target: any, values: any, defaults: any, key: string) {
+    objDefine(target, key, {
+        g: () => values[key],
+        s: (value) => {
+            if (isArray(values[key])) {
+                values[key] = (isNullOrUndefined(value) ? arrSlice(defaults[key], 0) : value);
+            } else if (isObject(values[key])) {
+                _mergeConfig(values[key], (isNullOrUndefined(value) ? defaults[key] : value));
+            } else {
+                values[key] = (isNullOrUndefined(value) ? defaults[key] : value);
+            }
+        }
+    });
+}
+
+export const assertConfig: IAssertConfigDefaults = (/* #__PURE__*/function() {
+    let theValues: IAssertConfig =  _mergeConfig({}, DEFAULT_CONFIG);
+
+    function _removeFormatter(formatter: IFormatter) {
+        let formatters = theValues.format.formatters;
+        if (formatters) {
+            const index = arrIndexOf(formatters, formatter);
+            if (index !== -1) {
+                formatters.splice(index, 1);
+            }
+        }
+    }
+
+    function _setupProps() {
+        // Provide an accessor for each of the supported configuration values.
+        objForEachKey(DEFAULT_CONFIG, (key: keyof IAssertConfig) => {
+            _defineProp(theConfig, theValues, DEFAULT_CONFIG, key);
+        });
+    }
+
     let theConfig: IAssertConfigDefaults = {
+        reset: () => {
+            theValues = _mergeConfig({}, DEFAULT_CONFIG);
+            _setupProps();
+        },
         clone: (options?: IAssertConfig) => {
-            let newConfig: any = {};
-
             // Copy all of the values from the current config to the new config.
-            objForEachKey(DEFAULT_CONFIG, (key: keyof IAssertConfig) => {
-                if (options && options[key] !== undefined) {
-                    newConfig[key] = options[key];
-                } else {
-                    newConfig[key] = theConfig[key];
-                }
-            });
+            let newConfig = _mergeConfig({}, theValues);
+            if (options) {
+                _mergeConfig(newConfig, options);
+            }
 
             return newConfig;
-        }
+        },
+        addFormatter: (formatter: IFormatter) => {
+            let rmFn: () => void;
+            let formatters = theValues.format.formatters;
+            if (arrIndexOf(formatters, formatter) === -1) {
+                formatters?.push(formatter);
+                rmFn = function () {
+                    _removeFormatter(formatter);
+                };
+            }
+
+            return {
+                rm: rmFn || _noOpFn
+            };
+        },
+        removeFormatter: _removeFormatter
     };
-    
-    // Provide an accessor for each of the supported configuration values.
-    objForEachKey(DEFAULT_CONFIG, (key: keyof IAssertConfig) => {
-        objDefine(theConfig, key, {
-            g: () => theValues[key],
-            s: (value) => theValues[key] = value
-        });
-    });
+
+    _setupProps();
 
     return theConfig;
 })();

--- a/core/src/assert/funcs/equal.ts
+++ b/core/src/assert/funcs/equal.ts
@@ -271,7 +271,7 @@ function _isVisiting<T>(value: any, options: IEqualOptions, cb: () => T): T {
     let tracking = false;
     try {
         if (!isPrimitive(value)) {
-            let visitCount = 0
+            let visitCount = 0;
             arrForEach(options.visiting, (visitValue) => {
                 if (_strictEquals(visitValue, value) === true) {
                     visitCount++;
@@ -279,7 +279,7 @@ function _isVisiting<T>(value: any, options: IEqualOptions, cb: () => T): T {
             });
 
             if (visitCount > 10) {
-                options.context.fail("Unresolvable Circular reference detected for " + _formatValue(options.visiting[0]) + " @ depth " + options.visiting.length + " reference count: " + visitCount);
+                options.context.fail("Unresolvable Circular reference detected for " + _formatValue(options.context, options.visiting[0]) + " @ depth " + options.visiting.length + " reference count: " + visitCount);
             }
 
             options.visiting.push(value);

--- a/core/src/assert/funcs/hasProperty.ts
+++ b/core/src/assert/funcs/hasProperty.ts
@@ -221,7 +221,7 @@ export function hasPropertyDescriptorFunc(this: IAssertScope, name: string | sym
         scope.newScope(desc).exec(deepEqualsFunc, [ descriptor, evalMsg || "expected {value} to equal property descriptor {descriptor}" ]);
     }
 
-    return propertyResultOp(scope, desc)
+    return propertyResultOp(scope, desc);
 }
 
 /**
@@ -245,5 +245,5 @@ export function hasOwnPropertyDescriptorFunc(this: IAssertScope, name: string | 
         scope.newScope(desc).exec(deepEqualsFunc, [ descriptor, evalMsg  || "expected {value} to equal property descriptor {descriptor}"]);
     }
 
-    return propertyResultOp(scope, desc)
+    return propertyResultOp(scope, desc);
 }

--- a/core/src/assert/funcs/keysFunc.ts
+++ b/core/src/assert/funcs/keysFunc.ts
@@ -70,7 +70,7 @@ function _getArgKeys(scope: IAssertScope, theArgs: any[]): string[] {
         }
     }
 
-    return theKeys
+    return theKeys;
 }
 
 export function anyKeysFunc<R>(_scope: IAssertScope): KeysFn<R> {

--- a/core/src/assert/funcs/throws.ts
+++ b/core/src/assert/funcs/throws.ts
@@ -203,7 +203,7 @@ function _isErrorMessageCompatible(errorValue: Error, msgMatch: string | RegExp)
         return {
             result: message == msgMatch || strIndexOf(message, msgMatch) >= 0,
             matchError: MatchError.MessageContains
-        }
+        };
     }
 
     if (isRegExp(msgMatch)) {

--- a/core/src/assert/funcs/valuesFunc.ts
+++ b/core/src/assert/funcs/valuesFunc.ts
@@ -76,7 +76,7 @@ function _getArgValues(scope: IAssertScope, theArgs: any[]): any[] {
         }
     }
 
-    return theValues
+    return theValues;
 }
 
 export function anyValuesFunc<R>(_scope: IAssertScope): ValuesFn<R> {
@@ -88,7 +88,7 @@ export function anyValuesFunc<R>(_scope: IAssertScope): ValuesFn<R> {
         let expectedValues = _getArgValues(scope, args);
         let theValue = context.value;
         let checkValue: any = theValue;
-        let checkLength: number = 1
+        let checkLength: number = 1;
         let compareFn: (theArray: any, searchElement: any) => number;
         if (isString(theValue)) {
             compareFn = strIndexOf;
@@ -100,7 +100,7 @@ export function anyValuesFunc<R>(_scope: IAssertScope): ValuesFn<R> {
         } else {
             compareFn = (value: any, match: any) => {
                 return value === match ? 0 : -1;
-            }
+            };
         }
 
         // if (expectedValues.length === 0) {
@@ -134,8 +134,8 @@ export function allValuesFunc<R>(_scope: IAssertScope): ValuesFn<R> {
         let expectedValues = _getArgValues(scope, args);
         let theValue = context.value;
         let checkValue: any = theValue;
-        let checkLength: number = 1
-        let compareFn: (theArray: any, searchElement: any) => number = strIndexOf
+        let checkLength: number = 1;
+        let compareFn: (theArray: any, searchElement: any) => number = strIndexOf;
         if (isString(theValue)) {
             compareFn = strIndexOf;
         } else if (isArray(theValue) || isObject(theValue)) {
@@ -146,7 +146,7 @@ export function allValuesFunc<R>(_scope: IAssertScope): ValuesFn<R> {
         } else {
             compareFn = (value: any, match: any) => {
                 return value === match ? 0 : -1;
-            }
+            };
         }
 
         // if (expectedValues.length === 0) {

--- a/core/src/assert/interface/IAssertConfig.ts
+++ b/core/src/assert/interface/IAssertConfig.ts
@@ -7,6 +7,8 @@
  */
 
 import { MsgSource } from "./types";
+import { IFormatter, IFormatterOptions } from "./IFormatter";
+import { IRemovable } from "./IRemovable";
 
 /**
  * Provides the options for the current context
@@ -39,13 +41,100 @@ export interface IAssertConfig {
      * @remarks This is used for fatal errors that are not assertion failures.
      */
     defFatalMsg?: MsgSource;
+
+    /**
+     * Options for configuring value formatting.
+     * @remarks These options allow you to customize how values are formatted in assertion error messages.
+     * You can provide custom formatters to override the default formatting behavior for specific types.
+     * These formatters will be checked before the default formatters, allowing you to provide specialized
+     * formatting for certain value types.
+     *
+     * Additionally, you can control post-processing of the formatted output using {@link IFormatterOptions.finalize}
+     * and {@link IFormatterOptions.finalizeFn} to escape ANSI codes, wrap output, or apply other transformations.
+     *
+     * @since 0.1.3
+     * @example
+     * ```typescript
+     * import { assertConfig } from '@nevware21/tripwire';
+     * import { eFormatResult } from '@nevware21/tripwire';
+     * import { escapeAnsi, gray, replaceAnsi } from '@nevware21/chromacon';
+     *
+     * // Example 1: Custom formatters with default ANSI escaping
+     * assertConfig.format = {
+     *     finalize: true,  // Enable default escapeAnsi
+     *     formatters: [
+     *         {
+     *             name: "stringFormatter",
+     *             value: (ctx, value) => {
+     *                 if (typeof value === 'string') {
+     *                     return { res: eFormatResult.Ok, val: `'${value}'` };
+     *                 }
+     *                 return { res: eFormatResult.Skip };
+     *             }
+     *         }
+     *     ]
+     * };
+     *
+     * // Example 2: Custom formatters with custom finalization
+     * assertConfig.format = {
+     *     finalize: true,
+     *     finalizeFn: (value) => replaceAnsi(value, (match) => gray(escapeAnsi(match))),
+     *     formatters: [
+     *         {
+     *             name: "arrayFormatter",
+     *             value: (ctx, value) => {
+     *                 if (Array.isArray(value)) {
+     *                     return { res: eFormatResult.Ok, val: `[${value.length} items]` };
+     *                 }
+     *                 return { res: eFormatResult.Skip };
+     *             }
+     *         }
+     *     ]
+     * };
+     * ```
+     */
+    format?: IFormatterOptions;
+
+    /**
+     * Defines a custom message to display when a circular reference is detected in a value.
+     * The default is a function that returns the string "[<Circular>]" in cyan color using @nevware21/chromacon.
+     * @remarks This is used to provide a more descriptive message for circular references in assertion errors.
+     * @since 0.1.3
+     * @example
+     * ```typescript
+     * const config = {
+     *     circularMsg: () => "Circular reference detected"
+     * };
+     * ```
+     */
+    circularMsg?: () => string;
 }
 
 export interface IAssertConfigDefaults extends IAssertConfig {
+
+    /**
+     * Resets the current config options to their default values removing any customizations
+     * @remarks This will restore all config options to their original default values as
+     * defined in package defaults.
+     */
+    reset: () => void;
     
     /**
-     * Returns the current context options in a new plain object
-     * @param options - The options to override the current context options
+     * Returns the current config options in a new plain object
+     * @param options - The options to override the current config options
      */
     clone: (options?: IAssertConfig) => IAssertConfig;
+
+    /**
+     * Adds a new default value formatter that will be used to for all new assertion contexts
+     * @param formatter - The value formatter to add
+     * @remarks The returned IRemovable can be used to remove the formatter when it is no longer needed.
+     */
+    addFormatter: (formatter: IFormatter) => IRemovable;
+    
+    /**
+     * Removes a value formatter from the current context options
+     * @param formatter - The value formatter to remove
+     */
+    removeFormatter: (formatter: IFormatter) => void;
 }

--- a/core/src/assert/interface/IFormatter.ts
+++ b/core/src/assert/interface/IFormatter.ts
@@ -1,0 +1,313 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { IScopeContext } from "./IScopeContext";
+
+/**
+ * Indicates the result of a formatting operation.
+ *
+ * @since 0.1.3
+ * @group Formatter
+ */
+export const enum eFormatResult {
+    /**
+     * The value was successfully formatted and should be used.
+     */
+    Ok = 0,
+    
+    /**
+     * The value was formatted, but continue trying other formatters to find a better result.
+     */
+    Continue = 1,
+
+    /**
+     * The formatter could not format this value. Try the next formatter.
+     */
+    Skip = 2,
+    
+    /**
+     * An error occurred while formatting the value, this indicates a failure in the formatting process
+     * either explicitly set by the formatter or due to an exception being thrown.
+     */
+    Failed = 3
+}
+
+/**
+ * Result of formatting a value.
+ *
+ * @since 0.1.3
+ * @group Formatter
+ */
+export interface IFormattedValue {
+    /**
+     * Indicates the result of the formatting operation.
+     */
+    res: eFormatResult;
+    
+    /**
+     * The formatted string representation of the value.
+     * Only meaningful when {@link res} is {@link eFormatResult.Ok} or {@link eFormatResult.Continue}.
+     */
+    val?: string;
+    
+    /**
+     * The Error that occurred during formatting, set when {@link res} is {@link eFormatResult.Failed}
+     * This can be either an error explicitly thrown by the formatter or an error that occurred
+     * internally during the formatting process.
+     * Only meaningful when {@link res} is {@link eFormatResult.Failed}.
+     */
+    err?: any;
+}
+
+/**
+ * Formatting context passed to the _formatValue function.
+ * Provides a format function that uses the configured IFormatters.
+ *
+ * @since 0.1.3
+ * @group Formatter
+ */
+export interface IFormatCtx {
+    /**
+     * The current scope context, providing information about the current assertion scope.
+     */
+    readonly ctx: IScopeContext;
+
+    /**
+     * Formats a value using the configured formatters.
+     * @param value - The value to format
+     * @returns A string representation of the value
+     */
+    format(value: any): string;
+}
+
+/**
+ * Represents a value formatter for display in assertion error messages.
+ * Formatters attempt to format a value and indicate the result of the formatting operation.
+ *
+ * Multiple formatters can be chained together, with user-supplied formatters
+ * checked before built-in defaults.
+ *
+ * @example
+ * ```typescript
+ * const customStringFormatter: IFormatter = {
+ *     name: "stringFormatter",
+ *     value: (ctx, value) => {
+ *         if (typeof value === 'string') {
+ *             return { res: eFormatResult.Ok, val: `'${value}'` };
+ *         }
+ *         return { res: eFormatResult.Skip, val: '' };
+ *     }
+ * };
+ *
+ * const customArrayFormatter: IFormatter = {
+ *     name: "arrayFormatter",
+ *     value: (ctx, value) => {
+ *         if (Array.isArray(value)) {
+ *             return { res: eFormatResult.Ok, val: `[${value.length} items]` };
+ *         }
+ *         return { res: eFormatResult.Skip, val: '' };
+ *     }
+ * };
+ *
+ * const partialFormatter: IFormatter = {
+ *     name: "partialFormatter",
+ *     value: (ctx, value) => {
+ *         // Provide a basic format but allow other formatters to potentially improve it
+ *         if (value && typeof value === 'object') {
+ *             return { res: eFormatResult.Continue, val: Object.prototype.toString.call(value) };
+ *         }
+ *         return { res: eFormatResult.Skip, val: '' };
+ *     }
+ * };
+ * ```
+ *
+ * @since 0.1.3
+ * @group Formatter
+ */
+export interface IFormatter {
+    /**
+     * Name for the formatter, useful for debugging and identification.
+     */
+    readonly name: string;
+
+    /**
+     * Attempts to format the value into a string representation.
+     * @param ctx - The formatting context containing config, visited tracking, and the format function
+     * @param value - The value to format
+     * @returns An object with {@link IFormattedValue.res} indicating the formatting result and {@link IFormattedValue.val} containing the formatted string,
+     * or `undefined`/`null` if the formatter cannot handle the value.
+     */
+    value(ctx: IFormatCtx, value: any): IFormattedValue | undefined | null;
+}
+
+/**
+ * Options for configuring value formatters.
+ *
+ * @since 0.1.3
+ * @group Formatter
+ * @example
+ * ```typescript
+ * import { assertConfig } from '@nevware21/tripwire';
+ * import { escapeAnsi, gray, replaceAnsi } from '@nevware21/chromacon';
+ *
+ * // Example 1: Enable default ANSI escaping
+ * assertConfig.format = {
+ *     finalize: true  // Uses escapeAnsi to escape ANSI codes
+ * };
+ *
+ * // Example 2: Custom finalization that wraps output
+ * assertConfig.format = {
+ *     finalize: true,
+ *     finalizeFn: (value) => `[Formatted: ${escapeAnsi(value)}]`
+ * };
+ *
+ * // Example 3: Colorize escaped ANSI codes in gray
+ * assertConfig.format = {
+ *     finalize: true,
+ *     finalizeFn: (value) => replaceAnsi(value, (match) => gray(escapeAnsi(match)))
+ * };
+ *
+ * // Example 4: Convert to HTML-safe format
+ * assertConfig.format = {
+ *     finalize: true,
+ *     finalizeFn: (value) => {
+ *         return escapeAnsi(value)
+ *             .replace(/</g, '&lt;')
+ *             .replace(/>/g, '&gt;')
+ *             .replace(/&/g, '&amp;');
+ *     }
+ * };
+ * ```
+ */
+export interface IFormatterOptions {
+    /**
+     * Indicates whether to finalize the resulting formatted string value. When enabled without
+     * a custom {@link IFormatterOptions.finalizeFn}, ANSI escape codes will be escaped so they are
+     * displayed as literal characters rather than being interpreted by the terminal.
+     *
+     * This enables post-processing of the complete formatted output after all formatters have been applied.
+     *
+     * @default false
+     * @example
+     * ```typescript
+     * // Enable default ANSI escaping
+     * assertConfig.format = {
+     *     finalize: true
+     * };
+     *
+     * // Disable finalization (ANSI codes will be rendered)
+     * assertConfig.format = {
+     *     finalize: false
+     * };
+     * ```
+     */
+    finalize?: boolean;
+
+    /**
+     * A custom function to finalize the resulting formatted string value. This function is called
+     * once on the complete formatted output (not on individual components) when {@link IFormatterOptions.finalize} is `true`.
+     *
+     * Use this to apply custom transformations to the entire formatted message, such as:
+     * - Custom escaping strategies
+     * - Wrapping or decorating the output
+     * - Converting to different formats (HTML, Markdown, etc.)
+     * - Colorizing escaped codes while keeping them visible
+     *
+     * @param value - The complete formatted string to finalize
+     * @returns The finalized string
+     * @default undefined
+     * @remarks When not provided and {@link IFormatterOptions.finalize} is `true`, defaults to using
+     * [escapeAnsi](https://nevware21.github.io/chromacon/typedoc/core/functions/escapeAnsi.html) from [@nevware21/chromacon](https://nevware21.github.io/chromacon/)
+     * to escape ANSI codes. You can provide a custom function for other transformations like HTML encoding,
+     * wrapping, or colorizing escaped codes.
+     * @example
+     * ```typescript
+     * import { escapeAnsi, gray, replaceAnsi } from '@nevware21/chromacon';
+     *
+     * // Colorize ANSI escape sequences in gray
+     * assertConfig.format = {
+     *     finalize: true,
+     *     finalizeFn: (value) => {
+     *         return replaceAnsi(value, (match) => gray(escapeAnsi(match)));
+     *     }
+     * };
+     *
+     * // Wrap the entire output in brackets
+     * assertConfig.format = {
+     *     finalize: true,
+     *     finalizeFn: (value) => `[OUTPUT: ${escapeAnsi(value)}]`
+     * };
+     *
+     * // Convert to HTML entities for web display
+     * assertConfig.format = {
+     *     finalize: true,
+     *     finalizeFn: (value) => {
+     *         return escapeAnsi(value)
+     *             .replace(/</g, '&lt;')
+     *             .replace(/>/g, '&gt;')
+     *             .replace(/&/g, '&amp;');
+     *     }
+     * };
+     * ```
+     */
+    finalizeFn?: (value: string) => string;
+
+    /**
+     * Custom value formatter functions to be used for formatting values in error messages.
+     * These formatters will be checked before the default formatters. Each formatter should
+     * implement `value` which returns an {@link IFormattedValue} object indicating whether
+     * the value was formatted and the formatted result.
+     *
+     * User-supplied formatters are checked first, allowing you to override default formatting
+     * behavior for specific types.
+     *
+     * @remarks These formatters are only used for formatting values in assertion error messages
+     * and do not affect any system colors or other formatting.
+     *
+     * @example
+     * ```typescript
+     * const customStringFormatter: IFormatter = {
+     *     name: "stringFormatter",
+     *     value: (ctx, value) => {
+     *         if (typeof value === 'string') {
+     *             return { res: eFormatResult.Ok, val: `'${value}'` };
+     *         }
+     *         return { res: eFormatResult.Skip };
+     *     }
+     * };
+     *
+     * const customArrayFormatter: IFormatter = {
+     *     name: "arrayFormatter",
+     *     value: (ctx, value) => {
+     *         if (Array.isArray(value)) {
+     *             return { res: eFormatResult.Ok, val: `[${value.length} items]` };
+     *         }
+     *         return { res: eFormatResult.Skip };
+     *     }
+     * };
+     *
+     * const partialFormatter: IFormatter = {
+     *     name: "partialFormatter",
+     *     value: (ctx, value) => {
+     *         // Provide a basic format but allow other formatters to potentially improve it
+     *         if (value && typeof value === 'object') {
+     *             return { res: eFormatResult.Continue, val: Object.prototype.toString.call(value) };
+     *         }
+     *         return { res: eFormatResult.Skip };
+     *     }
+     * };
+     *
+     * let customFormatters: IFormatter[] = [customStringFormatter, customArrayFormatter, partialFormatter];
+     *
+     * const config: IFormatterOptions = {
+     *     formatters: customFormatters
+     * };
+     * ```
+     */
+    formatters?: IFormatter[];
+}

--- a/core/src/assert/interface/IRemovable.ts
+++ b/core/src/assert/interface/IRemovable.ts
@@ -1,0 +1,30 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+/**
+ * Represents an object that can be removed/unregistered.
+ * This interface is used for various registration mechanisms where an object
+ * can be added and later removed using the returned handle.
+ *
+ * @since 0.1.3
+ * @group Core
+ */
+export interface IRemovable {
+    /**
+     * Removes/unregisters the associated object.
+     * After calling this method, the object will no longer be active or used.
+     *
+     * @example
+     * ```typescript
+     * const handle = addValueFormatter(myFormatter);
+     * // ... use the formatter
+     * handle.rm(); // Remove the formatter
+     * ```
+     */
+    rm(): void;
+}

--- a/core/src/assert/internal/_formatValue.ts
+++ b/core/src/assert/internal/_formatValue.ts
@@ -8,9 +8,297 @@
 
 import {
     arrForEach, arrIndexOf, asString, dumpObj, isArray, isError, isFunction, isPlainObject, isPrimitive,
-    isRegExp, isStrictNullOrUndefined, isString, isSymbol, objForEachKey, objGetOwnPropertySymbols, objGetPrototypeOf
+    isRegExp, isStrictNullOrUndefined, isString, isSymbol, objDefine, objForEachKey, objGetOwnPropertySymbols, objGetPrototypeOf
 } from "@nevware21/ts-utils";
 import { EMPTY_STRING } from "./const";
+import { eFormatResult, IFormatCtx, IFormattedValue, IFormatter } from "../interface/IFormatter";
+import { IScopeContext } from "../interface/IScopeContext";
+import { escapeAnsi, yellow } from "@nevware21/chromacon";
+
+/**
+ * @internal
+ * @ignore
+ * Default formatter for array values
+ */
+const _defaultArrayFormatter: IFormatter = {
+    name: "Array",
+    value: (ctx: IFormatCtx, value: any) => {
+        let result: IFormattedValue;
+        if (isArray(value)) {
+            let resultStr = "[";
+            if (value && value.length > 0) {
+                try {
+                    arrForEach(value, (item, index) => {
+                        resultStr += (index > 0 ? "," : EMPTY_STRING) + ctx.format(item);
+                    });
+                } catch (e) {
+                    resultStr += "...";
+                }
+            }
+
+            resultStr += "]";
+            result = {
+                res: eFormatResult.Ok,
+                val: resultStr
+            };
+        }
+
+        return result;
+    }
+};
+
+/**
+ * @internal
+ * @ignore
+ * Default formatter for string values
+ */
+const _defaultStringFormatter: IFormatter = {
+    name: "String",
+    value: (ctx: IFormatCtx, value: any) => {
+        let result: IFormattedValue;
+        if (isString(value)) {
+            result = {
+                res: eFormatResult.Ok,
+                val: "\"" + value + "\""
+            };
+        }
+
+        return result;
+    }
+};
+
+/**
+ * @internal
+ * @ignore
+ * Default formatter for RegExp values
+ */
+const _defaultRegExpFormatter: IFormatter = {
+    name: "RegExp",
+    value: (ctx: IFormatCtx, value: any) => {
+        let result: IFormattedValue;
+        if (isRegExp(value)) {
+            result = {
+                res: eFormatResult.Ok,
+                val: value.toString()
+            };
+        }
+        return result;
+    }
+};
+
+/**
+ * @internal
+ * @ignore
+ * Default formatter for Symbol values
+ */
+const _defaultSymbolFormatter: IFormatter = {
+    name: "Symbol",
+    value: (ctx: IFormatCtx, value: any) => {
+        let result: IFormattedValue;
+        if (isSymbol(value)) {
+            result = {
+                res: eFormatResult.Ok,
+                val: "[" + value.toString() + "]"
+            };
+        }
+        return result;
+    }
+};
+
+/**
+ * @internal
+ * @ignore
+ * Default formatter for plain object values
+ */
+const _defaultPlainObjectFormatter: IFormatter = {
+    name: "PlainObject",
+    value: (ctx: IFormatCtx, value: any) => {
+        let result: IFormattedValue;
+        if (isPlainObject(value)) {
+            let theValue = "{";
+            let idx = 0;
+            arrForEach(_getObjKeys(value), (key) => {
+                let formattedValue = ctx.format(value[key]);
+                
+                if (isSymbol(key)) {
+                    theValue += (idx > 0 ? "," : EMPTY_STRING) + "[" + asString(key) + "]:" + formattedValue;
+                } else {
+                    theValue += (idx > 0 ? "," : EMPTY_STRING) + asString(key) + ":" + formattedValue;
+                }
+
+                idx++;
+            });
+
+            theValue += "}";
+
+            result = {
+                res: eFormatResult.Ok,
+                val: theValue
+            };
+        }
+
+        return result;
+    }
+};
+
+/**
+ * @internal
+ * @ignore
+ * Default formatter for Error instances
+ */
+const _defaultErrorFormatter: IFormatter = {
+    name: "Error",
+    value: (ctx: IFormatCtx, value: any) => {
+        let result: IFormattedValue;
+        if (isError(value) || (value && value instanceof Error)) {
+            result = {
+                res: eFormatResult.Ok,
+                val: "[" + (value.name || "Error") + ":" + ctx.format(value.message) + "]"
+            };
+        }
+
+        return result;
+    }
+};
+
+/**
+ * @internal
+ * @ignore
+ * Default formatter for Error types (constructors)
+ */
+const _defaultErrorTypeFormatter: IFormatter = {
+    name: "ErrorType",
+    value: (ctx: IFormatCtx, value: any) => {
+        let result: IFormattedValue;
+        if (_isErrorType(value)) {
+            result = {
+                res: eFormatResult.Ok,
+                val: (value.name || "Error") + "()"
+            };
+        }
+
+        return result;
+    }
+};
+
+/**
+ * @internal
+ * @ignore
+ * Default formatter for Function values
+ */
+const _defaultFunctionFormatter: IFormatter = {
+    name: "Function",
+    value: (ctx: IFormatCtx, value: any) => {
+        let result: IFormattedValue;
+        if (isFunction(value)) {
+            let funcName = value.name || (value as any)["displayName"];
+            result = {
+                res: eFormatResult.Ok,
+                val: "[Function" + (funcName ? ":" + funcName : EMPTY_STRING) + "]"
+            };
+        }
+
+        return result;
+    }
+};
+
+/**
+ * @internal
+ * @ignore
+ * Default formatter for objects with constructor
+ */
+const _defaultConstructorFormatter: IFormatter = {
+    name: "Constructor",
+    value: (ctx: IFormatCtx, value: any) => {
+        let result: IFormattedValue;
+
+        try {
+            if (value && ("constructor" in value && value.constructor && value.constructor.name)) {
+                result = {
+                    res: eFormatResult.Ok,
+                    val: "[" + value.constructor.name + ":" + (JSON.stringify(value) || "").replace(/"(\w+)"\s*:\s{0,1}/g, "$1:") + "]"
+                };
+            }
+        } catch (e) {
+            // Ignore any errors that occur during formatting
+        }
+
+        if (!result) {
+            try {
+                if (value && ("name" in value && value.constructor && value.constructor.name)) {
+                    result = {
+                        res: eFormatResult.Ok,
+                        val: "[" + value.name + ":" + (JSON.stringify(value) || "").replace(/"(\w+)"\s*:\s{0,1}/g, "$1:") + "]"
+                    };
+                }
+            } catch (e) {
+                // ignore
+            }
+        }
+
+        return result;
+    }
+};
+
+/**
+ * @internal
+ * @ignore
+ * Default formatter for objects with toString method
+ */
+const _defaultToStringFormatter: IFormatter = {
+    name: "ToString",
+    value: (ctx: IFormatCtx, value: any) => {
+        let result: IFormattedValue;
+        if (value && isFunction(value.toString)) {
+            result = {
+                res: eFormatResult.Ok,
+                val: value.toString()
+            };
+        }
+
+        return result;
+    }
+};
+
+/**
+ * @internal
+ * @ignore
+ * Fallback formatter for any remaining values
+ */
+const _defaultFallbackFormatter: IFormatter = {
+    name: "Fallback",
+    value: (ctx: IFormatCtx, value: any) => {
+        let actualValue = value;
+
+        if (!isPrimitive(actualValue)) {
+            actualValue = dumpObj(actualValue);
+        }
+
+        return {
+            res: eFormatResult.Ok,
+            val: asString(actualValue)
+        };
+    }
+};
+
+/**
+ * @internal
+ * @ignore
+ * Default formatters in order of precedence
+ */
+const _defaultFormatters: IFormatter[] = [
+    _defaultArrayFormatter,
+    _defaultStringFormatter,
+    _defaultRegExpFormatter,
+    _defaultSymbolFormatter,
+    _defaultPlainObjectFormatter,
+    _defaultErrorFormatter,
+    _defaultErrorTypeFormatter,
+    _defaultFunctionFormatter,
+    _defaultConstructorFormatter,
+    _defaultToStringFormatter,
+    _defaultFallbackFormatter
+];
 
 function _getObjKeys<T>(target: T): (keyof T)[] {
     let keys: any[] = [];
@@ -76,115 +364,132 @@ function _isVisited(value: any, visited: any[]): boolean {
     return false;
 }
 
+function _processFormatters(formatters: IFormatter[], formatCtx: IFormatCtx, value: any): IFormattedValue {
+    let formattedValue: IFormattedValue;
+
+    if (formatters) {
+        let idx = 0;
+        while(idx < formatters.length) {
+            let formatter = formatters[idx];
+            if (formatter) {
+                try {
+                    let fn = formatter.value;
+                    if (isFunction(fn)) {
+                        let formatted = fn(formatCtx, value);
+                        if (formatted && (formatted.res === eFormatResult.Ok || formatted.res === eFormatResult.Continue)) {
+                            formattedValue = formatted;
+                            if (formatted.res === eFormatResult.Ok) {
+                                break;
+                            }
+                        }
+                    }
+                } catch (e) {
+                    formattedValue = {
+                        res: eFormatResult.Failed,
+                        err: e,
+                        val: asString(value)
+                    };
+                }
+            }
+            
+            idx++;
+        }
+    }
+
+    return formattedValue;
+}
+
+/**
+ * Perform the default formatting of a value using the provided format context.
+ * @param formatCtx The format context to use for formatting the value.
+ * @param value The value to format.
+ * @returns A string representation of the value.
+ */
+function _doFormat(formatCtx: IFormatCtx, value: any): string {
+    let result: string;
+
+    let formatOpts = formatCtx.ctx.opts.format;
+    try {
+        let formattedValue: IFormattedValue = _processFormatters(formatOpts.formatters || [], formatCtx, value);
+        if (!formattedValue || formattedValue.res !== eFormatResult.Ok) {
+            // Iterate through the default formatters to find one that can format the value
+            formattedValue = _processFormatters(_defaultFormatters, formatCtx, value);
+        }
+
+        if (formattedValue) {
+            if (formattedValue.res === eFormatResult.Ok || formattedValue.res === eFormatResult.Continue) {
+                result = formattedValue.val;
+            } else if (formattedValue.res === eFormatResult.Failed) {
+                result = dumpObj(formattedValue.err);
+            } else {
+                result = asString(value);
+            }
+        } else {
+            result = asString(value);
+        }
+    } catch (e) {
+        result = yellow("(" + _doFormat(formatCtx, e) + ")");
+    }
+
+    return result;
+}
+
+/**
+ * @internal
+ * @ignore
+ * Creates a format context bound to the supplied scope context.
+ * The returned context handles circular references while formatting values.
+ * @param ctx - The scope context used to resolve formatting options.
+ * @returns A format context that can be passed to `_doFormat` or used via its `format` method.
+ */
+function _createFormatCtx(ctx: IScopeContext): IFormatCtx {
+    let visited: any[] = [];
+
+    let formatCtx: IFormatCtx = {
+        ctx: ctx,
+        format: (value: any): string => {
+            let isVisited = _isVisited(value, visited);
+            if (isVisited) {
+                // Circular reference detected
+                return ctx.opts.circularMsg ? ctx.opts.circularMsg() : EMPTY_STRING;
+            }
+
+            visited.push(value);
+
+            let formattedValue: string;
+            try {
+                formattedValue = _doFormat(formatCtx, value);
+            } finally {
+                visited.pop();
+            }
+
+            return formattedValue;
+        }
+    };
+
+    return objDefine(formatCtx, "ctx", { v: ctx, w: false });
+}
+
 /**
  * @internal
  * @ignore
  * Internal helper to format a value for display in an error messages.
+ * @param ctx - Format context containing the formatters to use.
  * @param value - The value to format.
  * @returns - A string representation of the value.
  */
-export function _formatValue(value: any, visited?: any[]): string {
-
-    if (!visited) {
-        visited = [];
-    }
-
-    if (isArray(value)) {
-        let result = "[";
-        if (value && value.length > 0) {
-            try {
-                arrForEach(value, (item, index) => {
-                    let formattedValue = "(c)";
-                    if (!_isVisited(item, visited)) {
-                        visited.push(item);
-                        formattedValue = _formatValue(item, visited);
-                        visited.pop();
-                    }
-
-                    result += (index > 0 ? "," : EMPTY_STRING) + formattedValue;
-                });
-            } catch (e) {
-                result += "...";
-            }
+export function _formatValue(ctx: IScopeContext, value: any): string {
+    let formatCtx = _createFormatCtx(ctx);
+    let formatOpts = formatCtx.ctx.opts.format;
+    let result = _doFormat(formatCtx, value);
+    
+    if (formatOpts && formatOpts.finalize) {
+        if (isFunction(formatOpts.finalizeFn)) {
+            result = formatOpts.finalizeFn(result);
+        } else {
+            result = escapeAnsi(result);
         }
-
-        result += "]";
-        return result;
-    }
-    
-    if (isString(value)) {
-        return "\"" + value + "\"";
-    }
-    
-    if (isRegExp(value)) {
-        return value.toString();
-    }
-    
-    if (isSymbol(value)) {
-        return "[" + value.toString() + "]";
     }
 
-    if (isPlainObject(value)) {
-        let theValue = "{";
-        let idx = 0;
-        arrForEach(_getObjKeys(value), (key) => {
-            let formattedValue = "(c)";
-            let propValue = value[key];
-            if (!_isVisited(propValue, visited)) {
-                visited.push(propValue);
-                formattedValue = _formatValue(propValue, visited);
-                visited.pop();
-            }
-
-            if (isSymbol(key)) {
-                theValue += (idx > 0 ? "," : EMPTY_STRING) + "[" + asString(key) + "]:" + formattedValue;
-            } else {
-                theValue += (idx > 0 ? "," : EMPTY_STRING) + asString(key) + ":" + formattedValue;
-            }
-
-            idx++;
-        });
-        theValue += "}";
-
-        return theValue;
-    }
-    
-    if (isError(value) || (value && value instanceof Error)) {
-        return "[" + (value.name || "Error") + ":\"" + value.message + "\"]";
-    }
-
-    if (_isErrorType(value)) {
-        return (value.name || "Error") + "()";
-    }
-    
-    if (isFunction(value)) {
-        let funcName = value.name || (value as any)["displayName"];
-        return "[Function" + (funcName ? ":" + funcName : EMPTY_STRING) + "]";
-    }
-
-    try {
-        if (value && ("constructor" in value && value.constructor && value.constructor.name)) {
-            return "[" + value.constructor.name + ":" + (JSON.stringify(value) || "").replace(/"(\w+)"\s*:\s{0,1}/g, "$1:") + "]";
-        }
-    } catch (e) {
-        // ignore
-    }
-        
-    try {
-        if (value && ("name" in value && value.constructor && value.constructor.name)) {
-            return "[" + value.name + ":" + (JSON.stringify(value) || "").replace(/"(\w+)"\s*:\s{0,1}/g, "$1:") + "]";
-        }
-    } catch (e) {
-        // ignore
-    }
-
-    if (value && isFunction(value.toString)) {
-        return value.toString();
-    }
-
-    if (!isPrimitive(value)) {
-        value = dumpObj(value);
-    }
-
-    return asString(value);
+    return result;
 }

--- a/core/src/assert/internal/_handleResult.ts
+++ b/core/src/assert/internal/_handleResult.ts
@@ -35,7 +35,7 @@ function _createResultAdapter(scope: IAssertScope, target: any, key: string | nu
         }
 
         return _handleResult(theResult, scope, funcName);
-    }
+    };
 }
 
 export function _handleResult<T>(result: T, scope: IAssertScope, funcName?: string): T {
@@ -46,7 +46,7 @@ export function _handleResult<T>(result: T, scope: IAssertScope, funcName?: stri
         return scope.that as any;
     }
 
-    scope.that = result
+    scope.that = result;
 
     if (_isAssertInst(result)) {
         return result;

--- a/core/src/assert/ops/propertyResultOp.ts
+++ b/core/src/assert/ops/propertyResultOp.ts
@@ -22,7 +22,7 @@ export function propertyResultOp<V>(scope: IAssertScope, value: V): IPropertyRes
     let newInst = scope.newInst();
 
     function valueOp(scope: IAssertScope): IAssertInst {
-        scope.that = scope.newInst(value)
+        scope.that = scope.newInst(value);
 
         return scope.that;
     }

--- a/core/src/assert/useScope.ts
+++ b/core/src/assert/useScope.ts
@@ -1,0 +1,42 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { IScopeContext } from "./interface/IScopeContext";
+
+/**
+ * Global scope context that can be set to provide context information to errors
+ */
+let _globalScopeContext: IScopeContext | null = null;
+
+/**
+ * Executes a callback function with the specified scope context set as the global scope.
+ * The previous global scope context is automatically restored after the callback completes.
+ * @param scope - The scope context to set as global during callback execution
+ * @param callback - The function to execute with the scope context set
+ * @returns The return value of the callback function
+ * @group Scope
+ * @since 0.1.3
+ */
+export function useScope<T>(scope: IScopeContext, callback: () => T): T {
+    let previousScope = _globalScopeContext;
+    _globalScopeContext = scope;
+    try {
+        return callback();
+    } finally {
+        _globalScopeContext = previousScope;
+    }
+}
+
+/**
+ * Gets the current global scope context.
+ * @returns The current global scope context, or null if not set
+ * @internal
+ */
+export function _getGlobalScopeContext(): IScopeContext | null {
+    return _globalScopeContext;
+}

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -8,6 +8,7 @@
 
 import { AssertClassDef, assert, addAssertFunc, addAssertFuncs, createAssert } from "./assert/assertClass";
 import { AssertionError, AssertionErrorConstructor, AssertionFailure, AssertionFailureConstructor, AssertionFatal, AssertionFatalConstructor } from "./assert/assertionError";
+import { useScope, _getGlobalScopeContext } from "./assert/useScope";
 import { addAssertInstFuncDefs, addAssertInstFunc, addAssertInstFuncDef } from "./assert/assertInst";
 import { expect } from "./assert/expect";
 import { IAssertClass, IExtendedAssert } from "./assert/interface/IAssertClass";
@@ -44,14 +45,16 @@ import { AssertFn } from "./assert/interface/funcs/AssertFn";
 import { ErrorLikeFn } from "./assert/interface/funcs/ErrorLikeFn";
 import { assertConfig } from "./assert/config";
 import { IAssertConfig, IAssertConfigDefaults } from "./assert/interface/IAssertConfig";
+import { IFormatCtx, IFormatter, IFormattedValue, IFormatterOptions, eFormatResult } from "./assert/interface/IFormatter";
 import { createEvalAdapter, EvalFn } from "./assert/adapters/evalAdapter";
 import { IPropertyResultOp } from "./assert/interface/ops/IPropertyResultOp";
 import { createExprAdapter } from "./assert/adapters/exprAdapter";
 import { createAssertScope } from "./assert/assertScope";
 import { AssertInstHandlers, IAssertInstHandlers } from "./assert/interface/IAssertInstHandlers";
 import { CHECK_INTERNAL_STACK_FRAME_REGEX } from "./assert/const";
-import { getScopeContext } from "./assert/scopeContext";
+import { getScopeContext, createContext } from "./assert/scopeContext";
 import { SymbolFn } from "./assert/interface/funcs/SymbolFn";
+import { IRemovable } from "./assert/interface/IRemovable";
 
 /**
  * Export the Error classes
@@ -76,6 +79,10 @@ export {
     IAssertConfigDefaults,
     IScopeContext,
     IScopeContextOverrides,
+    IFormatCtx,
+    IFormattedValue,
+    IFormatter,
+    IFormatterOptions,
     IAssertClassDef,
     IAssertScope,
     IAssertInst,
@@ -99,7 +106,8 @@ export {
     IStrictlyOp,
     IThrowOp,
     IToOp,
-    IIsTypeOp
+    IIsTypeOp,
+    IRemovable
 };
 
 /**
@@ -123,6 +131,13 @@ export {
 };
 
 /**
+ * Export the enums
+ */
+export {
+    eFormatResult
+};
+
+/**
  * Export the functions (and global `assert`)
  */
 export {
@@ -138,7 +153,10 @@ export {
     createEvalAdapter,
     createExprAdapter,
     createAssertScope,
-    getScopeContext
+    createContext,
+    getScopeContext,
+    useScope,
+    _getGlobalScopeContext
 };
 
 /**
@@ -146,4 +164,4 @@ export {
  */
 export {
     CHECK_INTERNAL_STACK_FRAME_REGEX
-}
+};

--- a/core/src/internal/captureStack.ts
+++ b/core/src/internal/captureStack.ts
@@ -33,7 +33,7 @@ export function captureStack(func: Function): IParsedStack {
             }
         }
 
-        return parsedStack
+        return parsedStack;
     } finally {
         // Restore the stack trace limit
         if ("stackTraceLimit" in Error) {

--- a/core/src/internal/parseStack.ts
+++ b/core/src/internal/parseStack.ts
@@ -105,7 +105,7 @@ export function parseStack(stack: string | undefined): IParsedStack {
         trailMessage: {
             g: () => {
                 _parseStackDetail();
-                return trailingMessage || EMPTY_STRING
+                return trailingMessage || EMPTY_STRING;
             },
             s: (value: string) => {
                 _parseStackDetail();
@@ -125,7 +125,7 @@ export function parseStack(stack: string | undefined): IParsedStack {
             g: () => {
                 return function (maxLines?: number) {
                     return _formatStack(this.message, this.lines, this.trailMessage, maxLines);
-                }
+                };
             }
         },
         trimStack: {
@@ -156,7 +156,7 @@ export function parseStack(stack: string | undefined): IParsedStack {
                         }
                     }
 
-                    return parsedStack
+                    return parsedStack;
                 };
             }
         }
@@ -177,7 +177,7 @@ function _formatStack(message: string, lines: string[], trailMessage: string, ma
         formattedStack += trailMessage;
     }
 
-    return formattedStack
+    return formattedStack;
 }
 
 /**

--- a/core/test/src/assert/assert.empty.test.ts
+++ b/core/test/src/assert/assert.empty.test.ts
@@ -15,7 +15,7 @@ describe("assert.isEmpty", () => {
     it("should pass when the value is an empty string", () => {
         assert.isEmpty("");
 
-        expect("").is.empty()
+        expect("").is.empty();
     });
 
     it("should pass when the value is an empty array", () => {

--- a/core/test/src/assert/assert.format.test.ts
+++ b/core/test/src/assert/assert.format.test.ts
@@ -1,0 +1,617 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { assert } from "../../../src/assert/assertClass";
+import { assertConfig } from "../../../src/assert/config";
+import { checkError } from "../support/checkError";
+import { IFormatter, eFormatResult } from "../../../src/assert/interface/IFormatter";
+import { escapeAnsi, gray, red, replaceAnsi } from "@nevware21/chromacon";
+import { isString } from "@nevware21/ts-utils";
+
+describe("assert format options", function () {
+    describe("finalize", function () {
+        let originalFormat: any;
+
+        beforeEach(function () {
+            originalFormat = assertConfig.format;
+        });
+
+        afterEach(function () {
+            assertConfig.format = originalFormat;
+        });
+
+        it("should escape ANSI codes when finalize is true", function () {
+            assertConfig.format = {
+                finalize: true
+            };
+
+            // Create an object with ANSI escape codes in a string value
+            const objWithAnsi = { message: "\x1b[31mRed Text\x1b[0m" };
+
+            checkError(function () {
+                assert.equal(objWithAnsi, { message: "Different" });
+            }, "expected {message:\"\\x1b[31mRed Text\\x1b[0m\"} to equal {message:\"Different\"}");
+        });
+
+        it("should not escape ANSI codes when finalize is false", function () {
+            assertConfig.format = {
+                finalize: false
+            };
+
+            // Create an object with ANSI escape codes in a string value
+            const objWithAnsi = { message: "\x1b[31mRed Text\x1b[0m" };
+
+            checkError(function () {
+                assert.equal(objWithAnsi, { message: "Different" });
+            }, /expected \{message:".*Red Text.*"\} to equal \{message:"Different"\}/);
+        });
+
+        it("should escape ANSI codes in circular references when finalize is true", function () {
+            assertConfig.format = {
+                finalize: true
+            };
+
+            const obj1: any = { a: 1 };
+            obj1.self = obj1;
+
+            const obj2: any = { a: 2 };
+            obj2.self = obj2;
+
+            checkError(function () {
+                assert.deepEqual(obj1, obj2);
+            }, /expected \{a:1,self:\{a:1,self:.*\}\} to deeply equal \{a:2,self:\{a:2,self:.*\}\}/);
+        });
+
+        it("should handle escapeAnsi with deeply nested objects", function () {
+            assertConfig.format = {
+                finalize: true
+            };
+
+            const obj1 = {
+                nested: {
+                    deep: {
+                        value: "\x1b[32mGreen\x1b[0m"
+                    }
+                }
+            };
+
+            const obj2 = {
+                nested: {
+                    deep: {
+                        value: "Plain"
+                    }
+                }
+            };
+
+            checkError(function () {
+                assert.deepEqual(obj1, obj2);
+            }, "expected {nested:{deep:{value:\"\\x1b[32mGreen\\x1b[0m\"}}} to deeply equal {nested:{deep:{value:\"Plain\"}}}");
+        });
+
+        it("should handle escapeAnsi with arrays containing ANSI codes", function () {
+            assertConfig.format = {
+                finalize: true
+            };
+
+            const arr1 = ["\x1b[34mBlue\x1b[0m", "normal"];
+            const arr2 = ["different", "normal"];
+
+            checkError(function () {
+                assert.deepEqual(arr1, arr2);
+            }, "expected [\"\\x1b[34mBlue\\x1b[0m\",\"normal\"] to deeply equal [\"different\",\"normal\"]");
+        });
+
+        it("should handle escapeAnsi being set to undefined (default behavior)", function () {
+            assertConfig.format = {
+                finalize: undefined
+            };
+
+            const obj = { value: "\x1b[35mMagenta\x1b[0m" };
+
+            checkError(function () {
+                assert.equal(obj, { value: "Plain" });
+            }, /expected \{value:".*Magenta.*"\} to equal \{value:"Plain"\}/);
+        });
+
+        it("should handle escapeAnsi with complex objects", function () {
+            assertConfig.format = {
+                finalize: true
+            };
+
+            const complex = {
+                strings: ["\x1b[31mError\x1b[0m", "\x1b[32mSuccess\x1b[0m"],
+                nested: {
+                    message: "\x1b[33mWarning\x1b[0m"
+                },
+                number: 42
+            };
+
+            const expected = {
+                strings: ["Different", "Values"],
+                nested: {
+                    message: "Plain"
+                },
+                number: 100
+            };
+
+            checkError(function () {
+                assert.deepEqual(complex, expected);
+            }, "expected {strings:[\"\\x1b[31mError\\x1b[0m\",\"\\x1b[32mSuccess\\x1b[0m\"],nested:{message:\"\\x1b[33mWarning\\x1b[0m\"},number:42} to deeply equal {strings:[\"Different\",\"Values\"],nested:{message:\"Plain\"},number:100}");
+        });
+    });
+
+    describe("custom formatters", function () {
+        let originalFormat: any;
+
+        beforeEach(function () {
+            originalFormat = assertConfig.format;
+        });
+
+        afterEach(function () {
+            assertConfig.format = originalFormat;
+        });
+
+        it("should use custom formatter that finalizes ANSI codes in gray", function () {
+            // Custom formatter that escapes ANSI codes and wraps them in gray
+            const ansiEscapeFormatter: IFormatter = {
+                name: "ansiEscapeFormatter",
+                value: (ctx, value) => {
+                    if (isString(value)) {
+                        // Escape ANSI codes and wrap in gray
+                        const escaped = replaceAnsi(value, (match) => gray(escapeAnsi(match)));
+                        return {
+                            res: eFormatResult.Ok,
+                            val: "\"" + escaped + "\""
+                        };
+                    }
+                    return { res: eFormatResult.Skip };
+                }
+            };
+
+            assertConfig.format = {
+                finalize: false,
+                formatters: [ansiEscapeFormatter]
+            };
+
+            const objWithAnsi = { message: red("Red Text") };
+            const expected =  gray("\\x1b[31m") + "Red Text" + gray("\\x1b[39m");
+
+            checkError(function () {
+                assert.equal(objWithAnsi, { message: "Different" });
+            }, `expected {message:"${expected}"} to equal {message:"Different"}`);
+        });
+
+        it("should chain formatters with Continue result", function () {
+            // First formatter provides basic formatting but signals Continue
+            const basicFormatter: IFormatter = {
+                name: "basicFormatter",
+                value: (ctx, value) => {
+                    if (isString(value)) {
+                        return {
+                            res: eFormatResult.Continue,
+                            val: `"${value}"`
+                        };
+                    }
+                    return { res: eFormatResult.Skip };
+                }
+            };
+
+            // Second formatter that enhances strings with ANSI codes
+            const ansiEnhancer: IFormatter = {
+                name: "ansiEnhancer",
+                value: (ctx, value) => {
+                    if (isString(value)) {
+                        const escaped = replaceAnsi(value, (match) => gray(escapeAnsi(match)));
+                        return {
+                            res: eFormatResult.Ok,
+                            val: "\"" + escaped + "\""
+                        };
+                    }
+                    return { res: eFormatResult.Skip };
+                }
+            };
+
+            assertConfig.format = {
+                formatters: [basicFormatter, ansiEnhancer]
+            };
+
+            const obj = { text: "\x1b[35mMagenta\x1b[0m" };
+
+            checkError(function () {
+                assert.equal(obj, { text: "Plain" });
+            }, "expected {text:\"\x1b[90m\\x1b[35m\x1b[39mMagenta\x1b[90m\\x1b[0m\x1b[39m\"} to equal {text:\"Plain\"}");
+        });
+
+        it("should use formatter that handles specific object types", function () {
+            class CustomClass {
+                constructor(public value: string) {}
+            }
+
+            const customClassFormatter: IFormatter = {
+                name: "customClassFormatter",
+                value: (ctx, value) => {
+                    if (value instanceof CustomClass) {
+                        return {
+                            res: eFormatResult.Ok,
+                            val: `[CustomClass: "${value.value}"]`
+                        };
+                    }
+                    return { res: eFormatResult.Skip };
+                }
+            };
+
+            assertConfig.format = {
+                formatters: [customClassFormatter]
+            };
+
+            const custom1 = new CustomClass("value1");
+            const custom2 = new CustomClass("value2");
+
+            checkError(function () {
+                assert.equal(custom1, custom2);
+            }, "expected [CustomClass: \"value1\"] to equal [CustomClass: \"value2\"]");
+        });
+
+        it("should use multiple custom formatters with escaping", function () {
+            // Formatter for numbers - prefix with "NUM:"
+            const numberFormatter: IFormatter = {
+                name: "numberFormatter",
+                value: (ctx, value) => {
+                    if (typeof value === "number") {
+                        return {
+                            res: eFormatResult.Ok,
+                            val: `NUM:${value}`
+                        };
+                    }
+                    return { res: eFormatResult.Skip };
+                }
+            };
+
+            // Formatter for strings with ANSI - escape and color gray
+            const stringAnsiFormatter: IFormatter = {
+                name: "stringAnsiFormatter",
+                value: (ctx, value) => {
+                    if (isString(value)) {
+                        const escaped = replaceAnsi(value, (match) => gray(escapeAnsi(match)));
+                        return {
+                            res: eFormatResult.Ok,
+                            val: `\"${escaped}\"`
+                        };
+                    }
+                    return { res: eFormatResult.Skip };
+                }
+            };
+
+            assertConfig.format = {
+                formatters: [numberFormatter, stringAnsiFormatter]
+            };
+
+            const obj = {
+                count: 42,
+                message: "\x1b[33mWarning\x1b[0m"
+            };
+
+            const expected = {
+                count: 100,
+                message: "Plain"
+            };
+
+            checkError(function () {
+                assert.deepEqual(obj, expected);
+            }, /expected \{count:NUM:42,message:.*\\x1b\[33m.*Warning.*\\x1b\[0m.*\} to deeply equal \{count:NUM:100,message:"Plain"\}/);
+        });
+
+        it("should handle formatter that returns Failed result", function () {
+            const failingFormatter: IFormatter = {
+                name: "failingFormatter",
+                value: (ctx, value) => {
+                    if (typeof value === "bigint") {
+                        return {
+                            res: eFormatResult.Failed,
+                            err: new Error("Cannot format bigint")
+                        };
+                    }
+                    return { res: eFormatResult.Skip };
+                }
+            };
+
+            assertConfig.format = {
+                formatters: [failingFormatter]
+            };
+
+            // This should fall back to default formatting since the formatter fails
+            const obj = { id: BigInt(12345) };
+            const expected = { id: BigInt(67890) };
+
+            checkError(function () {
+                assert.deepEqual(obj, expected);
+            }, /expected \{id:.*\} to deeply equal \{id:.*\}/);
+        });
+
+        it("should finalize ANSI in custom formatter with finalize option", function () {
+            const customFormatter: IFormatter = {
+                name: "customFormatter",
+                value: (ctx, value) => {
+                    if (typeof value === "string" && value.startsWith("SPECIAL:")) {
+                        const content = value.substring(8);
+                        return {
+                            res: eFormatResult.Ok,
+                            val: `[SPECIAL:${gray(content)}]`
+                        };
+                    }
+                    return { res: eFormatResult.Skip };
+                }
+            };
+
+            assertConfig.format = {
+                finalize: true,
+                formatters: [customFormatter]
+            };
+
+            const obj = { tag: "SPECIAL:\x1b[36mCyan\x1b[0m" };
+
+            checkError(function () {
+                assert.equal(obj, { tag: "Different" });
+            }, /expected \{tag:\[SPECIAL:.*Cyan.*\]\} to equal \{tag:"Different"\}/);
+        });
+    });
+
+    describe("custom finalizeFn", function () {
+        let originalFormat: any;
+
+        beforeEach(function () {
+            assertConfig.reset();
+            originalFormat = assertConfig.format;
+        });
+
+        afterEach(function () {
+            assertConfig.format = originalFormat;
+        });
+
+        it("should use custom finalizeFn when finalize is true", function () {
+            // Custom finalize function that wraps finalized content in brackets
+            const customEscape = (value: string): string => {
+                const escaped = escapeAnsi(value);
+                return `[ESCAPED:${escaped}]`;
+            };
+
+            assertConfig.format = {
+                finalize: true,
+                finalizeFn: customEscape
+            };
+
+            const objWithAnsi = { message: "\x1b[31mRed Text\x1b[0m" };
+
+            checkError(function () {
+                assert.equal(objWithAnsi, { message: "Different" });
+            }, "expected [ESCAPED:{message:\"\\x1b[31mRed Text\\x1b[0m\"}] to equal [ESCAPED:{message:\"Different\"}]");
+        });
+
+        it("should not call finalizeFn when finalize is false", function () {
+            let escapeCalled = false;
+            const customEscape = (value: string): string => {
+                escapeCalled = true;
+                return escapeAnsi(value);
+            };
+
+            assertConfig.format = {
+                finalize: false,
+                finalizeFn: customEscape
+            };
+
+            const objWithAnsi = { message: "\x1b[31mRed Text\x1b[0m" };
+
+            checkError(function () {
+                assert.equal(objWithAnsi, { message: "Different" });
+            }, /expected \{message:".*Red Text.*"\} to equal \{message:"Different"\}/);
+
+            assert.equal(escapeCalled, false, "finalizeFn should not be called when finalize is false");
+        });
+
+        it("should use finalizeFn with custom gray coloring", function () {
+            // Custom finalize that colors the escaped codes in gray
+            const customEscapeGray = (value: string): string => {
+                return replaceAnsi(value, (match) => gray(escapeAnsi(match)));
+            };
+
+            assertConfig.format = {
+                finalize: true,
+                finalizeFn: customEscapeGray
+            };
+
+            const obj = {
+                text: "\x1b[33mWarning\x1b[0m",
+                code: 404
+            };
+
+            checkError(function () {
+                assert.equal(obj, { text: "Plain", code: 200 });
+            }, /expected .*text:".*\\x1b\[33m.*Warning.*\\x1b\[0m.*",code:404.* to equal .*text:"Plain",code:200.*/);
+        });
+
+        it("should use finalizeFn with deeply nested objects", function () {
+            const customEscape = (value: string): string => {
+                return `<<${escapeAnsi(value)}>>`;
+            };
+
+            assertConfig.format = {
+                finalize: true,
+                finalizeFn: customEscape
+            };
+
+            const obj = {
+                level1: {
+                    level2: {
+                        message: "\x1b[32mSuccess\x1b[0m"
+                    }
+                }
+            };
+
+            checkError(function () {
+                assert.deepEqual(obj, { level1: { level2: { message: "Plain" } } });
+            }, "expected <<{level1:{level2:{message:\"\\x1b[32mSuccess\\x1b[0m\"}}}>> to deeply equal <<{level1:{level2:{message:\"Plain\"}}}>>");
+        });
+
+        it("should use finalizeFn with arrays", function () {
+            const customEscape = (value: string): string => {
+                const escaped = escapeAnsi(value);
+                return `{${escaped}}`;
+            };
+
+            assertConfig.format = {
+                finalize: true,
+                finalizeFn: customEscape
+            };
+
+            const arr1 = ["\x1b[34mBlue\x1b[0m", "\x1b[35mMagenta\x1b[0m"];
+            const arr2 = ["Different1", "Different2"];
+
+            checkError(function () {
+                assert.deepEqual(arr1, arr2);
+            }, "expected {[\"\\x1b[34mBlue\\x1b[0m\",\"\\x1b[35mMagenta\\x1b[0m\"]} to deeply equal {[\"Different1\",\"Different2\"]}");
+        });
+
+        it("should combine finalizeFn with custom formatters", function () {
+            const customEscape = (value: string): string => {
+                return `[${escapeAnsi(value)}]`;
+            };
+
+            const numberFormatter: IFormatter = {
+                name: "numberFormatter",
+                value: (ctx, value) => {
+                    if (typeof value === "number") {
+                        return {
+                            res: eFormatResult.Ok,
+                            val: `#${value}#`
+                        };
+                    }
+                    return { res: eFormatResult.Skip };
+                }
+            };
+
+            assertConfig.format = {
+                finalize: true,
+                finalizeFn: customEscape,
+                formatters: [numberFormatter]
+            };
+
+            const obj = {
+                id: 42,
+                status: "\x1b[31mError\x1b[0m"
+            };
+
+            checkError(function () {
+                assert.deepEqual(obj, { id: 100, status: "OK" });
+            }, "expected [{id:#42#,status:\"\\x1b[31mError\\x1b[0m\"}] to deeply equal [{id:#100#,status:\"OK\"}]");
+        });
+
+        it("should use finalizeFn that preserves colored text", function () {
+            // Finalize function that only escapes the codes but keeps the text colored
+            const customEscape = (value: string): string => {
+                return replaceAnsi(value, (match, offset, str) => {
+                    // Escape the ANSI code and wrap in a different color
+                    return red(escapeAnsi(match));
+                });
+            };
+
+            assertConfig.format = {
+                finalize: true,
+                finalizeFn: customEscape
+            };
+
+            const obj = { message: "\x1b[36mCyan Text\x1b[0m" };
+
+            checkError(function () {
+                assert.equal(obj, { message: "Plain" });
+            }, /expected .*message:".*\\x1b\[36m.*Cyan Text.*\\x1b\[0m.*".* to equal .*message:"Plain".*/);
+        });
+
+        it("should handle finalizeFn with circular references", function () {
+            const customEscape = (value: string): string => {
+                return `{ESC:${escapeAnsi(value)}}`;
+            };
+
+            assertConfig.format = {
+                finalize: true,
+                finalizeFn: customEscape
+            };
+
+            const obj1: any = {
+                name: "\x1b[32mCircular\x1b[0m"
+            };
+            obj1.self = obj1;
+
+            const obj2: any = {
+                name: "Different"
+            };
+            obj2.self = obj2;
+
+            checkError(function () {
+                assert.deepEqual(obj1, obj2);
+            }, /expected \{ESC:\{name:"\\x1b\[32mCircular\\x1b\[0m",self:\{name:"\\x1b\[32mCircular\\x1b\[0m".*\}\}\} to deeply equal/);
+        });
+
+        it("should use finalizeFn that converts ANSI to HTML entities", function () {
+            // Custom finalize function that converts to HTML-safe format
+            const customEscape = (value: string): string => {
+                return escapeAnsi(value)
+                    .replace(/&/g, "&amp;")
+                    .replace(/</g, "&lt;")
+                    .replace(/>/g, "&gt;");
+            };
+
+            assertConfig.format = {
+                finalize: true,
+                finalizeFn: customEscape
+            };
+
+            const obj = {
+                html: "\x1b[31m<div>Test</div>\x1b[0m"
+            };
+
+            checkError(function () {
+                assert.equal(obj, { html: "Plain" });
+            }, "expected {html:\"\\x1b[31m&lt;div&gt;Test&lt;/div&gt;\\x1b[0m\"} to equal {html:\"Plain\"}");
+        });
+
+        it("should handle undefined finalizeFn (fallback to default)", function () {
+            assertConfig.format = {
+                finalize: true,
+                finalizeFn: undefined
+            };
+
+            const obj = { message: "\x1b[31mRed\x1b[0m" };
+
+            checkError(function () {
+                assert.equal(obj, { message: "Different" });
+            }, "expected {message:\"\\x1b[31mRed\\x1b[0m\"} to equal {message:\"Different\"}");
+        });
+
+        it("should colorize embedded ANSI codes in gray with replaceAnsi", function () {
+            // Custom finalize function that colorizes ANSI escape codes in gray
+            const customEscape = (value: string): string => {
+                return replaceAnsi(value, (match) => gray(escapeAnsi(match)));
+            };
+
+            assertConfig.format = {
+                finalize: true,
+                finalizeFn: customEscape
+            };
+
+            const obj = {
+                message: "\x1b[31mError occurred\x1b[0m",
+                status: 500
+            };
+
+            checkError(function () {
+                assert.deepEqual(obj, { message: "Success", status: 200 });
+                // eslint-disable-next-line no-control-regex
+            }, /expected .*message:".*\x1b\[90m\\x1b\[31m\x1b\[39m.*Error occurred.*\x1b\[90m\\x1b\[0m\x1b\[39m.*",status:500.* to deeply equal .*message:"Success",status:200.*/);
+        });
+    });
+});

--- a/core/test/src/assert/assert.function.test.ts
+++ b/core/test/src/assert/assert.function.test.ts
@@ -8,10 +8,21 @@
 
 import { assert } from "../../../src/assert/assertClass";
 import { AssertionFailure } from "../../../src/assert/assertionError";
+import { assertConfig } from "../../../src/assert/config";
 import { expect } from "../../../src/assert/expect";
 import { checkError } from "../support/checkError";
 
 describe("assert.isFunction", () => {
+
+    beforeEach(() => {
+        // Setup code if needed
+        assertConfig.reset();
+    });
+
+    afterEach(() => {
+        // Teardown code if needed
+    });
+
     it("should pass when the value is an arrow function", () => {
         assert.isFunction(() => {});
     });

--- a/core/test/src/assert/context.test.ts
+++ b/core/test/src/assert/context.test.ts
@@ -23,7 +23,7 @@ describe("context", () => {
         assert.equal(ctx.value, 1, "value should be 1");
         assert.equal(ctx.getMessage(), "first", "message should be first");
         assert.equal(ctx.getDetails().actual, 1, "actual should be 1");
-        assert.equal(objKeys(ctx.getDetails()).length, 1, "details should have 1 key");
+        assert.equal(objKeys(ctx.getDetails()).length, 1, "details should have 1 key - " + JSON.stringify(ctx.getDetails()));
     });
 
     it("new child value", () => {
@@ -61,7 +61,7 @@ describe("context", () => {
             let ctx = createContext(1, "first");
 
             checkError(() => {
-                ctx.eval(false)
+                ctx.eval(false);
             }, "first");
 
             assert.equal(ctx.getMessage(), "first", "message should be first");
@@ -127,7 +127,7 @@ describe("context", () => {
                 });
                     
                 assert.equal(ctx.getMessage(), "darkness");
-                assert.equal(ctx.value, 1)
+                assert.equal(ctx.value, 1);
                 assert.equal(newCtx.getMessage(), "hello darkness");
                 assert.equal(newCtx.value, "newCtx");
                 assert.equal(subCtx.getMessage(), "hello darkness, my old friend");
@@ -155,7 +155,7 @@ describe("context", () => {
                 let newDetails = newCtx.getDetails();
                 
                 assert.equal(newDetails.actual, 2, "actual should be 2");
-                assert.equal(objKeys(newDetails).length, 2, "details should have 1 key");
+                assert.equal(objKeys(newDetails).length, 2, "details should have 2 keys");
                 checkError(() => {
                     assert.deepEqual(newDetails, { actual: 1, hello: "darkness" }, "details should be { actual: 1, hello: darkness }");
                 }, "details should be { actual: 1, hello: darkness }: expected {hello:\"darkness\",actual:2} to deeply equal {actual:1,hello:\"darkness\"}");

--- a/core/test/src/operations/keysOp.test.ts
+++ b/core/test/src/operations/keysOp.test.ts
@@ -26,7 +26,7 @@ describe("anyKeyFilter", () => {
         const keysOp = anyKeyFilterOp(scope);
 
         checkError(() => {
-            keysOp.keys.call(scope, "hello")
+            keysOp.keys.call(scope, "hello");
         }, "expected any key: [hello], found: []");
 
         expect(() => expect(null).has.any.keys("hello")).to.throw();
@@ -38,7 +38,7 @@ describe("anyKeyFilter", () => {
         const keysOp = anyKeyFilterOp(scope);
 
         checkError(() => {
-            keysOp.keys.call(scope, "hello")
+            keysOp.keys.call(scope, "hello");
         }, "expected any key: [hello], found: []");
 
         expect(() => expect(undefined).has.any.keys("hello")).to.throw();
@@ -50,7 +50,7 @@ describe("anyKeyFilter", () => {
         const keysOp = anyKeyFilterOp(scope);
 
         checkError(() => {
-            keysOp.keys.call(scope, "hello")
+            keysOp.keys.call(scope, "hello");
         }, "expected any key: [hello], found: []");
 
         expect(() => expect({}).has.any.keys("hello")).to.throw();
@@ -116,14 +116,14 @@ describe("anyKeyFilter", () => {
         const keysOp = anyKeyFilterOp(scope);
 
         // Passing cases
-        keysOp.keys.call(scope, "hello")
-        keysOp.keys.call(scope, "my")
+        keysOp.keys.call(scope, "hello");
+        keysOp.keys.call(scope, "my");
         expect(() => expect(obj).has.any.keys("hello")).to.not.throw();
         expect(() => expect(obj).has.any.keys("my")).to.not.throw();
 
         // Failing cases
         checkError(() => {
-            keysOp.keys.call(scope, "darkness")
+            keysOp.keys.call(scope, "darkness");
         }, /expected any key: \[darkness\], found: \[.*\]/);
 
         expect(() => expect({}).has.any.keys("darkness")).to.throw();
@@ -158,7 +158,7 @@ describe("allKeyFilter", () => {
         const keysOp = allKeyFilterOp(scope);
 
         checkError(() => {
-            keysOp.keys.call(scope, "hello")
+            keysOp.keys.call(scope, "hello");
         }, "expected all keys: [hello], missing: [hello], found: []");
 
         expect(() => expect(null).has.any.keys("hello")).to.throw();
@@ -170,7 +170,7 @@ describe("allKeyFilter", () => {
         const keysOp = allKeyFilterOp(scope);
 
         checkError(() => {
-            keysOp.keys.call(scope, "hello")
+            keysOp.keys.call(scope, "hello");
         }, "expected all keys: [hello], missing: [hello], found: []");
 
         expect(() => expect(undefined).has.any.keys("hello")).to.throw();
@@ -182,7 +182,7 @@ describe("allKeyFilter", () => {
         const keysOp = allKeyFilterOp(scope);
 
         checkError(() => {
-            keysOp.keys.call(scope, "hello")
+            keysOp.keys.call(scope, "hello");
         }, "expected all keys: [hello], missing: [hello], found: []");
 
         expect(() => expect({}).has.any.keys("hello")).to.throw();
@@ -247,14 +247,14 @@ describe("allKeyFilter", () => {
         const keysOp = allKeyFilterOp(scope);
 
         // Passing cases
-        keysOp.keys.call(scope, "hello")
-        keysOp.keys.call(scope, "my")
+        keysOp.keys.call(scope, "hello");
+        keysOp.keys.call(scope, "my");
         expect(() => expect(obj).has.any.keys("hello")).to.not.throw();
         expect(() => expect(obj).has.any.keys("my")).to.not.throw();
 
         // Failing cases
         checkError(() => {
-            keysOp.keys.call(scope, "darkness")
+            keysOp.keys.call(scope, "darkness");
         }, /expected all keys: \[darkness\], missing: \[darkness\], found: \[.*\]/);
 
         expect(() => expect({}).has.any.keys("darkness")).to.throw();

--- a/core/test/src/support/validate.symbol.test.ts
+++ b/core/test/src/support/validate.symbol.test.ts
@@ -15,7 +15,7 @@ describe("symbol check", () => {
 
     // Test case: null object
     it("Should fail for null object", () => {
-        const knownIterator = getKnownSymbol(WellKnownSymbols.iterator)
+        const knownIterator = getKnownSymbol(WellKnownSymbols.iterator);
 
         assert.strictEqual(knownIterator, Symbol.iterator);
     });

--- a/shim/chai/src/index.ts
+++ b/shim/chai/src/index.ts
@@ -20,4 +20,4 @@ export {
 export {
     chaiAssert as assert,
     chaiExpect as expect
-}
+};

--- a/shim/chai/test/src/chaiAssert.test.ts
+++ b/shim/chai/test/src/chaiAssert.test.ts
@@ -4,7 +4,8 @@
  * default operation of the original chai `assert` function.
  */
 
-import { assert } from "../../src/index"
+import { assertConfig } from "@nevware21/tripwire";
+import { assert } from "../../src/index";
 import { globalErr as err } from "./bootstrap/globalErr";
 
 describe("assert", function () {
@@ -424,10 +425,11 @@ describe("assert", function () {
 
         assert.deepEqual(circularObject, secondCircularObject);
 
+        let circularMsg = assertConfig.circularMsg?.();
         err(function() {
             secondCircularObject.field2 = secondCircularObject;
             assert.deepEqual(circularObject, secondCircularObject);
-        }, "expected {field:{field:(c)}} to deeply equal {field:{field:(c),field2:(c)},field2:{field:(c),field2:(c)}}");
+        }, "expected {field:{field:" + circularMsg + "}} to deeply equal {field:{field:" + circularMsg + ",field2:" + circularMsg + "},field2:{field:" + circularMsg + ",field2:" + circularMsg + "}}");
     });
 
     it("notDeepEqual", function() {
@@ -446,10 +448,11 @@ describe("assert", function () {
 
         assert.notDeepEqual(circularObject, secondCircularObject);
 
+        let circularMsg = assertConfig.circularMsg?.();
         err(function() {
             delete secondCircularObject.tea;
             assert.notDeepEqual(circularObject, secondCircularObject);
-        }, "not expected {field:{field:(c)}} to deeply equal {field:{field:(c)}}");
+        }, "not expected {field:{field:" + circularMsg + "}} to deeply equal {field:{field:" + circularMsg + "}}");
     });
 
     it("isNull", function() {
@@ -547,10 +550,10 @@ describe("assert", function () {
         var func1 = async function() {};
         assert.isCallable(func1);
 
-        var func2 = function* () {}
+        var func2 = function* () {};
         assert.isCallable(func2);
 
-        var func3 = async function* () {}
+        var func3 = async function* () {};
         assert.isCallable(func3);
 
         err(function () {
@@ -1670,7 +1673,7 @@ describe("assert", function () {
                 throw new Error("");
             }, Error, "");
             (assert as any)[throws](function() {
-                throw new Error("foo")
+                throw new Error("foo");
             }, "");
             (assert as any)[throws](function() {
                 throw "";
@@ -1699,27 +1702,27 @@ describe("assert", function () {
 
             err(function () {
                 (assert as any)[throws](function() {
-                    throw new Error("foo")
+                    throw new Error("foo");
                 }, TypeError);
-            }, "expected [Function] to throw an error of type TypeError() but threw [Error:\"foo\"]")
+            }, "expected [Function] to throw an error of type TypeError() but threw [Error:\"foo\"]");
 
             err(function () {
                 (assert as any)[throws](function() {
-                    throw new Error("foo")
+                    throw new Error("foo");
                 }, "bar");
-            }, "expected [Function] to throw an error with a message containing \"bar\" but it was \"foo\"")
+            }, "expected [Function] to throw an error with a message containing \"bar\" but it was \"foo\"");
 
             err(function () {
                 (assert as any)[throws](function() {
-                    throw new Error("foo")
+                    throw new Error("foo");
                 }, Error, "bar", "blah");
-            }, "blah: expected [Function] to throw an error of type Error() with a message containing \"bar\" but [Error:\"foo\"] was thrown")
+            }, "blah: expected [Function] to throw an error of type Error() with a message containing \"bar\" but [Error:\"foo\"] was thrown");
 
             err(function () {
                 (assert as any)[throws](function() {
-                    throw new Error("foo")
+                    throw new Error("foo");
                 }, TypeError, "bar", "blah");
-            }, "blah: expected [Function] to throw an error of type TypeError() with a message containing \"bar\" but [Error:\"foo\"] was thrown")
+            }, "blah: expected [Function] to throw an error of type TypeError() with a message containing \"bar\" but [Error:\"foo\"] was thrown");
 
             err(function () {
                 (assert as any)[throws](function() {});
@@ -1727,13 +1730,13 @@ describe("assert", function () {
 
             err(function () {
                 (assert as any)[throws](function() {
-                    throw new Error("")
+                    throw new Error("");
                 }, "bar");
             }, " expected [Function] to throw an error with a message containing \"bar\" but it was \"\"");
 
             err(function () {
                 (assert as any)[throws](function() {
-                    throw new Error("")
+                    throw new Error("");
                 }, /bar/);
             }, "expected [Function] to throw an error with a message matching /bar/ but it was \"\"");
 
@@ -2851,7 +2854,7 @@ describe("assert", function () {
 
     it("isEmpty / empty", function() {
         ["isEmpty", "empty"].forEach(function (isEmpty) {
-            const FakeArgs: any = function (this: any) {}
+            const FakeArgs: any = function (this: any) {};
             FakeArgs.prototype.length = 0;
 
             (assert as any)[isEmpty]("");


### PR DESCRIPTION
Add new `finalize` and `finalizeFn` options to control post-processing of formatted assertion error messages.

# Features

## Finalization Options
- `finalize` (boolean): Enable post-processing of formatted output
- `finalizeFn` (function): Custom function to transform the complete formatted string

## Default Behavior
When `finalize: true` without a custom `finalizeFn`, automatically uses [escapeAnsi](https://nevware21.github.io/chromacon/typedoc/core/functions/escapeAnsi.html) from @nevware21/chromacon to escape ANSI codes for display as literal characters.

## Use Cases
- Escape ANSI codes for terminal display
- Colorize escaped ANSI sequences (e.g., in gray)
- Convert output to HTML-safe format
- Wrap or decorate formatted messages
- Apply custom transformations to final output

## Core Changes
- Added `finalize` and `finalizeFn` to `IFormatterOptions` interface
- Implemented finalization in `_formatValue()` - applied once to complete output
- Updated `assertConfig` defaults with new options
- Reduced karma worker log level from DEBUG to INFO for faster test startup