### PR TITLE
Remove git config for dependabot user

### DIFF
--- a/.github/workflows/sync-rush-versions.yml
+++ b/.github/workflows/sync-rush-versions.yml
@@ -68,8 +68,6 @@ jobs:
 
       - name: Commit changes
         run: |
-          git config --global user.name "dependabot-sync[bot]"
-          git config --global user.email "dependabot-sync[bot]@users.noreply.github.com"
           # Add files that exist
           if [ -f rush.json ]; then git add rush.json; fi
           if [ -f common-versions.json ]; then git add common-versions.json; fi


### PR DESCRIPTION
Removed global git config commands for user name and email.