### PR TITLE
feat: add isFinite assertion for finite number validation

### DIFF
--- a/core/src/assert/assertClass.ts
+++ b/core/src/assert/assertClass.ts
@@ -207,6 +207,10 @@ export function createAssert(): IAssertClass {
         isNaN: createExprAdapter("is.nan"),
         isNotNaN: createExprAdapter("not.is.nan"),
             
+
+        isFinite: createExprAdapter("is.finite"),
+        isNotFinite: createExprAdapter("not.is.finite"),
+            
         throws: { scopeFn: throwsFunc, nArgs: 3 },
 
         match: { scopeFn: matchFunc, nArgs: 2 },

--- a/core/src/assert/funcs/equal.ts
+++ b/core/src/assert/funcs/equal.ts
@@ -6,7 +6,7 @@
  * Licensed under the MIT license.
  */
 
-import { arrForEach, arrMap, asString, isDate, isFunction, isObject, isPlainObject, isPrimitive, iterForOf, objGetOwnPropertyDescriptor, objGetOwnPropertySymbols, objIs, objToString, strLower } from "@nevware21/ts-utils";
+import { arrForEach, arrMap, asString, isDate, isFunction, isObject, isPlainObject, isPrimitive, isSymbol, iterForOf, objGetOwnPropertyDescriptor, objGetOwnPropertySymbols, objIs, objToString, strLower } from "@nevware21/ts-utils";
 import { MsgSource } from "../interface/types";
 import { IAssertScope } from "../interface/IAssertScope";
 import { _formatValue } from "../internal/_formatValue";
@@ -519,7 +519,7 @@ function _deepEquals<T>(value: T, expected: T, options: IEqualOptions): boolean 
 
 function _mapKeys(values: Array<string | number | symbol>): Array<string|number> {
     return arrMap(values, (key) => {
-        if (typeof key === "symbol") {
+        if (isSymbol(key)) {
             return key.toString();
         }
         

--- a/core/src/assert/funcs/is.ts
+++ b/core/src/assert/funcs/is.ts
@@ -208,7 +208,22 @@ export function isNaNFunc<R>(this: IAssertScope, evalMsg?: MsgSource): R {
     let context = this.context;
     let value = context.value;
 
-    context.eval(typeof value === "number" && isNaN(value), evalMsg || "expected {value} to be NaN");
+    context.eval(isNumber(value) && isNaN(value), evalMsg || "expected {value} to be NaN");
+
+    return this.that;
+}
+
+/**
+ * Is the current value a finite number (not NaN, not Infinity, not -Infinity)
+ * @param this - The current {@link IAssertScope} object
+ * @param evalMsg - The message to display if the value is not a finite number
+ * @returns The current {@link IAssertScope.that} (`this`) object
+ */
+export function isFiniteFunc<R>(this: IAssertScope, evalMsg?: MsgSource): R {
+    let context = this.context;
+    let value = context.value;
+
+    context.eval(isNumber(value) && isFinite(value), evalMsg || "expected {value} to be finite");
 
     return this.that;
 }

--- a/core/src/assert/interface/IAssertClass.ts
+++ b/core/src/assert/interface/IAssertClass.ts
@@ -1089,6 +1089,47 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
     isNotNaN(value: any, initMsg?: MsgSource): AssertInst;
 
     /**
+     * Asserts that the given value is a finite number (not NaN, not Infinity, not -Infinity).
+     * @param value - The value to check.
+     * @param initMsg - The custom message to display if the assertion fails.
+     * @throws {AssertionError} If the value is not a finite number.
+     * @example
+     * ```typescript
+     * assert.isFinite(123); // Passes
+     * assert.isFinite(0); // Passes
+     * assert.isFinite(-456.789); // Passes
+     * assert.isFinite(NaN); // Throws AssertionError
+     * assert.isFinite(Infinity); // Throws AssertionError
+     * assert.isFinite(-Infinity); // Throws AssertionError
+     * assert.isFinite("123"); // Throws AssertionError
+     * assert.isFinite(null); // Throws AssertionError
+     * assert.isFinite(undefined); // Throws AssertionError
+     * ```
+     */
+    isFinite(value: any, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the given value is not a finite number (e.g., NaN, Infinity, -Infinity, or non-numeric).
+     * @param value - The value to check.
+     * @param initMsg - The custom message to display if the assertion fails.
+     * @throws {AssertionError} If the value is a finite number.
+     * @example
+     * ```typescript
+     * assert.isNotFinite(NaN); // Passes
+     * assert.isNotFinite(Infinity); // Passes
+     * assert.isNotFinite(-Infinity); // Passes
+     * assert.isNotFinite("123"); // Passes
+     * assert.isNotFinite(null); // Passes
+     * assert.isNotFinite(undefined); // Passes
+     * assert.isNotFinite({}); // Passes
+     * assert.isNotFinite(123); // Throws AssertionError
+     * assert.isNotFinite(0); // Throws AssertionError
+     * assert.isNotFinite(-456.789); // Throws AssertionError
+     * ```
+     */
+    isNotFinite(value: any, initMsg?: MsgSource): AssertInst;
+
+    /**
      * Asserts that the given function throws an error that matches the specified error constructor,
      * error instance, and / or the message includes the content or matches the regex pattern.
      * If the function does not throw an error, or if the thrown error does not

--- a/core/src/assert/interface/ops/ITypeOp.ts
+++ b/core/src/assert/interface/ops/ITypeOp.ts
@@ -184,4 +184,12 @@ export interface IIsTypeOp<R> {
      * @throws {@link AssertionFailure} - If the assertion fails.
      */
     nan: AssertFn<R>;
+
+    /**
+     * Asserts that the value is a finite number (not NaN, not Infinity, not -Infinity).
+     * @param evalMsg - The custom message to display on evaluation.
+     * @returns The current {@link IAssertScope.that} object.
+     * @throws {@link AssertionFailure} - If the assertion fails.
+     */
+    finite: AssertFn<R>;
 }

--- a/core/src/assert/ops/isOp.ts
+++ b/core/src/assert/ops/isOp.ts
@@ -8,7 +8,7 @@
 
 import { IIsOp } from "../interface/ops/IIsOp";
 import {
-    isArrayFunc, isBooleanFunc, isFalseFunc, isFunctionFunc, isNaNFunc, isNullFunc, isNumberFunc,
+    isArrayFunc, isBooleanFunc, isFalseFunc, isFunctionFunc, isNaNFunc, isFiniteFunc, isNullFunc, isNumberFunc,
     isObjectFunc, isPlainObjectFunc, isStringFunc, isTrueFunc, isTruthyFunc, isUndefinedFunc
 } from "../funcs/is";
 import { isErrorFunc } from "../funcs/throws";
@@ -57,6 +57,7 @@ export function isOp<R>(scope: IAssertScope): IIsOp<R> {
         extensible: { scopeFn: isExtensibleFunc },
         iterable: { scopeFn: hasSymbolFunc(Symbol.iterator) },
         nan: { scopeFn: isNaNFunc },
+        finite: { scopeFn: isFiniteFunc },
 
         // Numeric comparison operations
         above: { scopeFn: aboveFunc },

--- a/core/test/src/assert/assert.isFinite.test.ts
+++ b/core/test/src/assert/assert.isFinite.test.ts
@@ -1,0 +1,297 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2024-2026 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { assert } from "../../../src/assert/assertClass";
+import { expect } from "../../../src/assert/expect";
+import { checkError } from "../support/checkError";
+
+describe("assert.isFinite", function () {
+    it("examples", function () {
+        assert.isFinite(123);
+        assert.isFinite(0);
+        assert.isFinite(-456.789);
+
+        checkError(function () {
+            assert.isFinite(NaN);
+        }, "expected NaN to be finite");
+
+        checkError(function () {
+            assert.isFinite(Infinity);
+        }, "expected Infinity to be finite");
+
+        checkError(function () {
+            assert.isFinite(-Infinity);
+        }, "expected -Infinity to be finite");
+
+        checkError(function () {
+            assert.isFinite("123");
+        }, "expected \"123\" to be finite");
+
+        checkError(function () {
+            assert.isFinite(null);
+        }, "expected null to be finite");
+
+        checkError(function () {
+            assert.isFinite(undefined);
+        }, "expected undefined to be finite");
+    });
+
+    it("check various numbers", function () {
+        assert.isFinite(0);
+        assert.isFinite(1);
+        assert.isFinite(-1);
+        assert.isFinite(3.14);
+        assert.isFinite(-3.14);
+        assert.isFinite(Number.MAX_VALUE);
+        assert.isFinite(Number.MIN_VALUE);
+        assert.isFinite(Number.EPSILON);
+        assert.isFinite(Number.MAX_SAFE_INTEGER);
+        assert.isFinite(Number.MIN_SAFE_INTEGER);
+    });
+
+    it("check non-finite numbers", function () {
+        checkError(function () {
+            assert.isFinite(NaN);
+        }, "expected NaN to be finite");
+
+        checkError(function () {
+            assert.isFinite(Infinity);
+        }, "expected Infinity to be finite");
+
+        checkError(function () {
+            assert.isFinite(-Infinity);
+        }, "expected -Infinity to be finite");
+
+        checkError(function () {
+            assert.isFinite(Number.POSITIVE_INFINITY);
+        }, "expected Infinity to be finite");
+
+        checkError(function () {
+            assert.isFinite(Number.NEGATIVE_INFINITY);
+        }, "expected -Infinity to be finite");
+    });
+
+    it("check non-numeric types", function () {
+        checkError(function () {
+            assert.isFinite("string");
+        }, "expected \"string\" to be finite");
+
+        checkError(function () {
+            assert.isFinite("123");
+        }, "expected \"123\" to be finite");
+
+        checkError(function () {
+            assert.isFinite(true);
+        }, "expected true to be finite");
+
+        checkError(function () {
+            assert.isFinite(false);
+        }, "expected false to be finite");
+
+        checkError(function () {
+            assert.isFinite(null);
+        }, "expected null to be finite");
+
+        checkError(function () {
+            assert.isFinite(undefined);
+        }, "expected undefined to be finite");
+
+        checkError(function () {
+            assert.isFinite({});
+        }, "expected {} to be finite");
+
+        checkError(function () {
+            assert.isFinite([]);
+        }, "expected [] to be finite");
+
+        checkError(function () {
+            assert.isFinite(function () {});
+        }, "expected [Function] to be finite");
+    });
+
+    it("custom message", function () {
+        checkError(function () {
+            assert.isFinite(NaN, "custom message");
+        }, "custom message: expected NaN to be finite");
+
+        checkError(function () {
+            assert.isFinite(Infinity, "value should be finite");
+        }, "value should be finite: expected Infinity to be finite");
+    });
+});
+
+describe("assert.isNotFinite", function () {
+    it("examples", function () {
+        assert.isNotFinite(NaN);
+        assert.isNotFinite(Infinity);
+        assert.isNotFinite(-Infinity);
+        assert.isNotFinite("123");
+        assert.isNotFinite(null);
+        assert.isNotFinite(undefined);
+        assert.isNotFinite({});
+
+        checkError(function () {
+            assert.isNotFinite(123);
+        }, "not expected 123 to be finite");
+
+        checkError(function () {
+            assert.isNotFinite(0);
+        }, "not expected 0 to be finite");
+
+        checkError(function () {
+            assert.isNotFinite(-456.789);
+        }, "not expected -456.789 to be finite");
+    });
+
+    it("check finite numbers", function () {
+        checkError(function () {
+            assert.isNotFinite(0);
+        }, "not expected 0 to be finite");
+
+        checkError(function () {
+            assert.isNotFinite(1);
+        }, "not expected 1 to be finite");
+
+        checkError(function () {
+            assert.isNotFinite(-1);
+        }, "not expected -1 to be finite");
+
+        checkError(function () {
+            assert.isNotFinite(3.14);
+        }, "not expected 3.14 to be finite");
+
+        checkError(function () {
+            assert.isNotFinite(-3.14);
+        }, "not expected -3.14 to be finite");
+
+        checkError(function () {
+            assert.isNotFinite(Number.MAX_VALUE);
+        }, "not expected 1.7976931348623157e+308 to be finite");
+
+        checkError(function () {
+            assert.isNotFinite(Number.MIN_VALUE);
+        }, "not expected 5e-324 to be finite");
+    });
+
+    it("check non-finite values", function () {
+        assert.isNotFinite(NaN);
+        assert.isNotFinite(Infinity);
+        assert.isNotFinite(-Infinity);
+        assert.isNotFinite(Number.POSITIVE_INFINITY);
+        assert.isNotFinite(Number.NEGATIVE_INFINITY);
+    });
+
+    it("check non-numeric types", function () {
+        assert.isNotFinite("string");
+        assert.isNotFinite("123");
+        assert.isNotFinite(true);
+        assert.isNotFinite(false);
+        assert.isNotFinite(null);
+        assert.isNotFinite(undefined);
+        assert.isNotFinite({});
+        assert.isNotFinite([]);
+        assert.isNotFinite(function () {});
+    });
+
+    it("custom message", function () {
+        checkError(function () {
+            assert.isNotFinite(123, "custom message");
+        }, "custom message: not expected 123 to be finite");
+
+        checkError(function () {
+            assert.isNotFinite(0, "value should not be finite");
+        }, "value should not be finite: not expected 0 to be finite");
+    });
+});
+
+describe("expect.is.finite", function () {
+    it("positive cases", function () {
+        expect(123).is.finite();
+        expect(0).to.be.finite();
+        expect(-456.789).is.finite();
+        expect(Number.MAX_VALUE).is.finite();
+        expect(Number.MIN_VALUE).is.finite();
+    });
+
+    it("negative cases", function () {
+        checkError(function () {
+            expect(NaN).is.finite();
+        }, "expected NaN to be finite");
+
+        checkError(function () {
+            expect(Infinity).is.finite();
+        }, "expected Infinity to be finite");
+
+        checkError(function () {
+            expect(-Infinity).is.finite();
+        }, "expected -Infinity to be finite");
+
+        checkError(function () {
+            expect("123").is.finite();
+        }, "expected \"123\" to be finite");
+
+        checkError(function () {
+            expect(null).is.finite();
+        }, "expected null to be finite");
+
+        checkError(function () {
+            expect(undefined).is.finite();
+        }, "expected undefined to be finite");
+    });
+
+    it("custom message", function () {
+        checkError(function () {
+            expect(NaN, "custom message").is.finite();
+        }, "custom message: expected NaN to be finite");
+    });
+});
+
+describe("expect.is.not.finite", function () {
+    it("positive cases", function () {
+        expect(NaN).is.not.finite();
+        expect(Infinity).to.not.be.finite();
+        expect(-Infinity).is.not.finite();
+        expect("123").is.not.finite();
+        expect(null).is.not.finite();
+        expect(undefined).is.not.finite();
+        expect({}).is.not.finite();
+    });
+
+    it("negative cases", function () {
+        checkError(function () {
+            expect(123).is.not.finite();
+        }, "not expected 123 to be finite");
+
+        checkError(function () {
+            expect(0).is.not.finite();
+        }, "not expected 0 to be finite");
+
+        checkError(function () {
+            expect(-456.789).is.not.finite();
+        }, "not expected -456.789 to be finite");
+
+        checkError(function () {
+            expect(Number.MAX_VALUE).is.not.finite();
+        }, "not expected 1.7976931348623157e+308 to be finite");
+    });
+
+    it("custom message", function () {
+        checkError(function () {
+            expect(123, "custom message").is.not.finite();
+        }, "custom message: not expected 123 to be finite");
+    });
+
+    it("with not operator", function () {
+        expect(123).to.not.be.not.finite();
+        expect(0).is.not.not.finite();
+        
+        checkError(function () {
+            expect(NaN).to.not.be.not.finite();
+        }, "expected NaN to be finite");
+    });
+});

--- a/shim/chai/src/assert/chaiAssert.ts
+++ b/shim/chai/src/assert/chaiAssert.ts
@@ -96,7 +96,7 @@ function _createChaiAssert(): IChaiAssert {
         isNotString: "is.not.string",
         isNumber: "is.number",
         isNotNumber: "is.not.number",
-        isFinite: notImplemented, // TODO: Implement isFinite in tripwire core
+        isFinite: "is.finite",
         isBoolean: "is.boolean",
         isNotBoolean: "is.not.boolean",
         typeOf: notImplemented, // TODO: Implement typeOf in tripwire core

--- a/shim/chai/test/src/chaiAssert.test.ts
+++ b/shim/chai/test/src/chaiAssert.test.ts
@@ -645,30 +645,30 @@ describe("assert", function () {
         }, "blah: not expected 4 to be a number");
     });
 
-    // it("isFinite", function() {
-    //     assert.isFinite(4);
-    //     assert.isFinite(-10);
+    it("isFinite", function() {
+        assert.isFinite(4);
+        assert.isFinite(-10);
 
-    //     err(function(){
-    //         assert.isFinite(NaN, "blah");
-    //     }, "blah: expected NaN to be a finite number");
+        err(function(){
+            assert.isFinite(NaN, "blah");
+        }, "blah: expected NaN to be finite");
 
-    //     err(function(){
-    //         assert.isFinite(Infinity);
-    //     }, "expected Infinity to be a finite number");
+        err(function(){
+            assert.isFinite(Infinity);
+        }, "expected Infinity to be finite");
 
-    //     err(function(){
-    //         assert.isFinite("foo");
-    //     }, "expected \"foo\" to be a finite number");
+        err(function(){
+            assert.isFinite("foo");
+        }, "expected \"foo\" to be finite");
 
-    //     err(function(){
-    //         assert.isFinite([]);
-    //     }, "expected [] to be a finite number");
+        err(function(){
+            assert.isFinite([]);
+        }, "expected [] to be finite");
 
-    //     err(function(){
-    //         assert.isFinite({});
-    //     }, "expected {} to be a finite number");
-    // })
+        err(function(){
+            assert.isFinite({});
+        }, "expected {} to be finite");
+    });
 
     it("isBoolean", function() {
         assert.isBoolean(true);


### PR DESCRIPTION
Implements finite number checking functionality to support Chai v5.x compatibility in the tripwire-chai shim.

- Added `isFiniteFunc()` to `core/src/assert/funcs/is.ts` - validates that a value is a finite number (excludes NaN, Infinity, and -Infinity)
- Extended `IIsTypeOp` interface with `finite: AssertFn<R>` property
- Wired `isFiniteFunc` into the `isOp` operation
- Added `assert.isFinite()` and `assert.isNotFinite()` methods via `createExprAdapter`
- Extended `IAssertClass` interface with comprehensive JSDoc documentation

**API:**
- `assert.isFinite(value, msg?)` - assert value is finite number
- `assert.isNotFinite(value, msg?)` - assert value is not finite number
- `expect(value).is.finite()` - fluent API support
- `expect(value).to.not.be.finite()` - negation support

**Chai shim integration:**
- Changed `isFinite` from `notImplemented` to `"is.finite"` in chaiAssert.ts