### PR TITLE
feat: implement instanceOf assertion for type checking

### DIFF
--- a/core/src/assert/assertClass.ts
+++ b/core/src/assert/assertClass.ts
@@ -33,6 +33,7 @@ import { isIterableFunc } from "./funcs/isIterable";
 import { deepEqualsFunc, deepStrictEqualsFunc, equalsFunc, strictEqualsFunc } from "./funcs/equal";
 import { aboveFunc, belowFunc, leastFunc, mostFunc, withinFunc } from "./ops/numericOp";
 import { typeOfFunc } from "./funcs/typeOf";
+import { instanceOfFunc } from "./funcs/instanceOf";
 
 /**
  * @internal
@@ -80,7 +81,7 @@ export type AssertClassDef = IAssertClassDef | IScopeFn | string | string[];
  * The `assert` object is also a function that can be called directly with the following parameters:
  * @param expr - The expression to evaluate.
  * @param initMsg - The message to display if the assertion fails. This can be a string or a function that returns a string.
- * @throws {@link AssertionFailure} - If the expression is false.
+ * @throws An {@link AssertionFailure} if the expression is false.
  * @example
  * ```typescript
  * import { assert } from "@nevware21/tripwire";
@@ -214,6 +215,15 @@ export function createAssert(): IAssertClass {
 
         isFinite: createExprAdapter("is.finite"),
         isNotFinite: createExprAdapter("not.is.finite"),
+
+        /**
+         * @since 0.1.5
+         */
+        isInstanceOf: { scopeFn: instanceOfFunc, nArgs: 2 },
+        /**
+         * @since 0.1.5
+         */
+        isNotInstanceOf: { scopeFn: createExprAdapter("not", instanceOfFunc), nArgs: 2 },
             
         throws: { scopeFn: throwsFunc, nArgs: 3 },
 
@@ -246,7 +256,7 @@ export function createAssert(): IAssertClass {
  * @param fnDef - The definition of the function to add, this can be a string (`is.object`),
  * an array of strings (`["is", "obejct"]`) which identify the sequence of operations to perform
  * or a {@link IScopeFn} function, or an {@link IAssertClassDef} object.
- * @throws {@link AssertionError} - If the definition is invalid.
+ * @throws An {@link AssertionError} if the definition is invalid.
  * @example
  * ```typescript
  * addAssertFunc("isPositive", (value) => this._context.eval(value > 0, "Expected a positive number"));
@@ -273,7 +283,7 @@ export function addAssertFunc(target: any, name: string, fnDef: AssertClassDef, 
  *
  * @param target - The instance to add the functions to.
  * @param funcs - An object where the keys are the names of the functions to add, and the values are their definitions.
- * @throws {@link AssertionError} - If any of the definitions are invalid.
+ * @throws An {@link AssertionError} if any of the definitions are invalid.
  * @example
  * ```typescript
  * addAssertFuncs({

--- a/core/src/assert/assertionError.ts
+++ b/core/src/assert/assertionError.ts
@@ -376,8 +376,8 @@ export const AssertionError = createCustomError<AssertionErrorConstructor<any>>(
             }
         });
         
-        if(!isUndefined(self.props.expected)) {
-            objDefine(self, "expected",{
+        if (!isUndefined(self.props.expected)) {
+            objDefine(self, "expected", {
                 g: () => {
                     return self.props ? self.props.expected : undefined;
                 }

--- a/core/src/assert/funcs/hasProperty.ts
+++ b/core/src/assert/funcs/hasProperty.ts
@@ -112,8 +112,8 @@ export function _assertHasOwnProperty(context: IScopeContext, name: string | sym
  * @param value - The expected value of the property.
  * @param evalMsg - The message to display if the assertion fails.
  * @returns The new "instance" (object) to be used as the `this` for the chained operations.
- * @throws {@link AssertionFailure} if the current value does not have the specified property.
- * @throws {@link AssertionFailure} if the property value does not match the expected value.
+ * @throws An {@link AssertionFailure} if the current value does not have the specified property.
+ * @throws An {@link AssertionFailure} if the property value does not match the expected value.
  */
 export function hasPropertyFunc(this: IAssertScope, name: string | symbol | number, value?: any, evalMsg?: MsgSource): IPropertyResultOp {
     let scope = this;
@@ -136,8 +136,8 @@ export function hasPropertyFunc(this: IAssertScope, name: string | symbol | numb
  * @param value - The expected value of the property.
  * @param evalMsg - The message to display if the assertion fails.
  * @returns The new "instance" (object) to be used as the `this` for the chained operations.
- * @throws {@link AssertionFailure} if the current value does not have the specified own property.
- * @throws {@link AssertionFailure} if the property value does not match the expected value.
+ * @throws An {@link AssertionFailure} if the current value does not have the specified own property.
+ * @throws An {@link AssertionFailure} if the property value does not match the expected value.
  */
 export function hasOwnPropertyFunc(this: IAssertScope, name: string | symbol | number, value?: any, evalMsg?: MsgSource): IPropertyResultOp {
     let scope = this;
@@ -160,8 +160,8 @@ export function hasOwnPropertyFunc(this: IAssertScope, name: string | symbol | n
  * @param value - The expected value of the property.
  * @param evalMsg - The message to display if the assertion fails.
  * @returns The new "instance" (object) to be used as the `this` for the chained operations.
- * @throws {@link AssertionFailure} if the current value does not have the specified property.
- * @throws {@link AssertionFailure} if the property value does not match the expected value.
+ * @throws An {@link AssertionFailure} if the current value does not have the specified property.
+ * @throws An {@link AssertionFailure} if the property value does not match the expected value.
  */
 export function hasDeepPropertyFunc(this: IAssertScope, name: string | symbol | number, value?: any, evalMsg?: MsgSource): IPropertyResultOp {
     let scope = this;
@@ -184,8 +184,8 @@ export function hasDeepPropertyFunc(this: IAssertScope, name: string | symbol | 
  * @param value - The expected value of the property.
  * @param evalMsg - The message to display if the assertion fails.
  * @returns The new "instance" (object) to be used as the `this` for the chained operations.
- * @throws {@link AssertionFailure} if the current value does not have the specified own property.
- * @throws {@link AssertionFailure} if the property value does not match the expected value.
+ * @throws An {@link AssertionFailure} if the current value does not have the specified own property.
+ * @throws An {@link AssertionFailure} if the property value does not match the expected value.
  */
 export function hasDeepOwnPropertyFunc(this: IAssertScope, name: string | symbol | number, value?: any, evalMsg?: MsgSource): IPropertyResultOp {
     let scope = this;
@@ -207,8 +207,8 @@ export function hasDeepOwnPropertyFunc(this: IAssertScope, name: string | symbol
  * @param descriptor - The expected property descriptor.
  * @param evalMsg - The message to display if the assertion fails.
  * @returns The new "instance" (object) to be used as the `this` for the chained operations.
- * @throws {@link AssertionFailure} if the current value does not have the specified property descriptor.
- * @throws {@link AssertionFailure} if the property descriptor does not match the expected descriptor.
+ * @throws An {@link AssertionFailure} if the current value does not have the specified property descriptor.
+ * @throws An {@link AssertionFailure} if the property descriptor does not match the expected descriptor.
  */
 export function hasPropertyDescriptorFunc(this: IAssertScope, name: string | symbol | number, descriptor: PropertyDescriptor, evalMsg?: MsgSource): IPropertyResultOp {
     let scope = this;
@@ -231,8 +231,8 @@ export function hasPropertyDescriptorFunc(this: IAssertScope, name: string | sym
  * @param descriptor - The expected property descriptor.
  * @param evalMsg - The message to display if the assertion fails.
  * @returns The new "instance" (object) to be used as the `this` for the chained operations.
- * @throws {@link AssertionFailure} if the current value does not have the specified own property descriptor.
- * @throws {@link AssertionFailure} if the property descriptor does not match the expected descriptor.
+ * @throws An {@link AssertionFailure} if the current value does not have the specified own property descriptor.
+ * @throws An {@link AssertionFailure} if the property descriptor does not match the expected descriptor.
  */
 export function hasOwnPropertyDescriptorFunc(this: IAssertScope, name: string | symbol | number, descriptor: PropertyDescriptor,evalMsg?: MsgSource): IPropertyResultOp {
     let scope = this;

--- a/core/src/assert/funcs/hasSymbol.ts
+++ b/core/src/assert/funcs/hasSymbol.ts
@@ -19,7 +19,7 @@ import { isStrictNullOrUndefined, objHasOwnProperty } from "@nevware21/ts-utils"
  * @param this - The current {@link IAssertScope} assertion scope.
  * @param theSymbol - The symbol property to check.
  * @returns The new "instance" (object) to be used as the `this` for the chained operations.
- * @throws {@link AssertionFailure} if the current value does not have the specified symbol property.
+ * @throws An {@link AssertionFailure} if the current value does not have the specified symbol property.
  */
 export function hasSymbolFunc(theSymbol: symbol): SymbolFn {
     return function (this: IAssertScope, evalMsg?: MsgSource): IPropertyResultOp {
@@ -41,8 +41,8 @@ export function hasSymbolFunc(theSymbol: symbol): SymbolFn {
  * @param value - The expected value of the property.
  * @param evalMsg - The message to display if the assertion fails.
  * @returns The new "instance" (object) to be used as the `this` for the chained operations.
- * @throws {@link AssertionFailure} if the current value does not have the specified own property.
- * @throws {@link AssertionFailure} if the property value does not match the expected value.
+ * @throws An {@link AssertionFailure} if the current value does not have the specified own property.
+ * @throws An {@link AssertionFailure} if the property value does not match the expected value.
  */
 export function hasOwnSymbolFunc(theSymbol: symbol): SymbolFn {
     return function (this: IAssertScope, evalMsg?: MsgSource): IPropertyResultOp {

--- a/core/src/assert/funcs/instanceOf.ts
+++ b/core/src/assert/funcs/instanceOf.ts
@@ -1,0 +1,44 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2024-2026 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { MsgSource } from "../interface/types";
+import { IAssertScope } from "../interface/IAssertScope";
+import { isFunction } from "@nevware21/ts-utils";
+
+/**
+ * Checks if the current value is an instance of the specified constructor.
+ * Uses the JavaScript `instanceof` operator for type comparison.
+ *
+ * @param this - The current {@link IAssertScope} object
+ * @param constructor - The constructor function to check against (e.g., Array, Date, Error, custom class)
+ * @param evalMsg - The message to display if the value is not an instance of the constructor
+ * @returns The current {@link IAssertScope.that} (`this`) object
+ * @throws An {@link AssertionFailure} if the constructor is not a function or if the value is not an instance
+ * @since 0.1.5
+ */
+export function instanceOfFunc<R>(this: IAssertScope, constructor: Function, evalMsg?: MsgSource): R {
+    let context = this.context;
+    let value = context.value;
+    
+    // Validate that the constructor is a function
+    if (!isFunction(constructor)) {
+        context.fail("The instanceOf check requires the constructor to be a function, got " + typeof constructor);
+    }
+
+    let constructorName = constructor.name || "Anonymous";
+    
+    context.set("expected", constructorName);
+    context.set("constructorFn", constructor);
+
+    context.eval(
+        value instanceof constructor,
+        evalMsg || "expected {value} to be an instance of {expected}"
+    );
+
+    return this.that;
+}

--- a/core/src/assert/funcs/is.ts
+++ b/core/src/assert/funcs/is.ts
@@ -203,6 +203,7 @@ export function isStrictFalseFunc<R>(this: IAssertScope, evalMsg?: MsgSource): R
  * @param this - The current {@link IAssertScope} object
  * @param evalMsg - The message to display if the value is not NaN
  * @returns The current {@link IAssertScope.that} (`this`) object
+ * @since 0.1.5
  */
 export function isNaNFunc<R>(this: IAssertScope, evalMsg?: MsgSource): R {
     let context = this.context;
@@ -218,6 +219,7 @@ export function isNaNFunc<R>(this: IAssertScope, evalMsg?: MsgSource): R {
  * @param this - The current {@link IAssertScope} object
  * @param evalMsg - The message to display if the value is not a finite number
  * @returns The current {@link IAssertScope.that} (`this`) object
+ * @since 0.1.5
  */
 export function isFiniteFunc<R>(this: IAssertScope, evalMsg?: MsgSource): R {
     let context = this.context;

--- a/core/src/assert/funcs/typeOf.ts
+++ b/core/src/assert/funcs/typeOf.ts
@@ -33,6 +33,7 @@ import { isArray, isFunction, strLower } from "@nevware21/ts-utils";
  * @param type - The expected type string (e.g., "string", "number", "function")
  * @param evalMsg - The message to display if the value's type doesn't match
  * @returns The current {@link IAssertScope.that} (`this`) object
+ * @since 0.1.5
  */
 export function typeOfFunc<R>(this: IAssertScope, type: string, evalMsg?: MsgSource): R {
     let context = this.context;

--- a/core/src/assert/interface/IAssertClass.ts
+++ b/core/src/assert/interface/IAssertClass.ts
@@ -910,13 +910,13 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * Asserts that the value is a string.
      * @param value - The value to check.
      * @param initMsg - The custom message to display if the assertion fails.
-     * @throws {AssertionError} If the value is not a string.
+     * @throws An {@link AssertionFailure} if the value is not a string.
      * @example
      * ```typescript
      * assert.isString("hello"); // Passes
-     * assert.isString(123); // Throws AssertionError
-     * assert.isString(null); // Throws AssertionError
-     * assert.isString(undefined); // Throws AssertionError
+     * assert.isString(123); // Throws AssertionFailure
+     * assert.isString(null); // Throws AssertionFailure
+     * assert.isString(undefined); // Throws AssertionFailure
      * ```
      */
     isString(value: any, initMsg?: MsgSource): AssertInst;
@@ -925,12 +925,12 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * Asserts that the value is not a string.
      * @param value - The value to check.
      * @param initMsg - The custom message to display if the assertion fails.
-     * @throws {AssertionError} If the value is a string.
+     * @throws An {@link AssertionFailure} if the value is a string.
      * @example
      * ```typescript
      * assert.isNotString(123); // Passes
      * assert.isNotString({}); // Passes
-     * assert.isNotString("hello"); // Throws AssertionError
+     * assert.isNotString("hello"); // Throws AssertionFailure
      * assert.isNotString(null); // Passes
      * assert.isNotString(undefined); // Passes
      * ```
@@ -941,14 +941,14 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * Asserts that the value is an array.
      * @param value - The value to check.
      * @param initMsg - The custom message to display if the assertion fails.
-     * @throws {AssertionError} If the value is not a number.
+     * @throws An {@link AssertionFailure} if the value is not a number.
      * @example
      * ```typescript
      * assert.isArray([]); // Passes
      * assert.isArray([1, 2, 3]); // Passes
-     * assert.isArray({}); // Throws AssertionError
-     * assert.isArray(null); // Throws AssertionError
-     * assert.isArray(undefined); // Throws AssertionError
+     * assert.isArray({}); // Throws AssertionFailure
+     * assert.isArray(null); // Throws AssertionFailure
+     * assert.isArray(undefined); // Throws AssertionFailure
      * ```
      */
     isArray(value: any, initMsg?: MsgSource): AssertInst;
@@ -957,7 +957,7 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * Asserts that the value is not an array.
      * @param value - The value to check.
      * @param initMsg - The custom message to display if the assertion fails.
-     * @throws {AssertionError} If the value is an array.
+     * @throws An {@link AssertionFailure} if the value is an array.
      * @example
      * ```typescript
      * assert.isNotArray({}); // Passes
@@ -965,8 +965,8 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * assert.isNotArray("hello"); // Passes
      * assert.isNotArray(null); // Passes
      * assert.isNotArray(undefined); // Passes
-     * assert.isNotArray([]); // Throws AssertionError
-     * assert.isNotArray([1, 2, 3]); // Throws AssertionError
+     * assert.isNotArray([]); // Throws AssertionFailure
+     * assert.isNotArray([1, 2, 3]); // Throws AssertionFailure
      * ```
      */
     isNotArray(value: any, initMsg?: MsgSource): AssertInst;
@@ -977,14 +977,14 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * Primive values are not extensible.
      * @param value - The value to check.
      * @param initMsg - The custom message to display if the assertion fails.
-     * @throws {AssertionError} If the value is not extensible.
+     * @throws An {@link AssertionFailure} if the value is not extensible.
      * @example
      * ```typescript
      * assert.isExtensible({}); // Passes
      * assert.isExtensible([]); // Passes
      * assert.isExtensible(Object.create(null)); // Passes
-     * assert.isExtensible(Object.freeze({})); // Throws AssertionError
-     * assert.isExtensible(Object.seal({})); // Throws AssertionError
+     * assert.isExtensible(Object.freeze({})); // Throws AssertionFailure
+     * assert.isExtensible(Object.seal({})); // Throws AssertionFailure
      * ```
      */
     isExtensible(value: any, initMsg?: MsgSource): AssertInst;
@@ -995,14 +995,14 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * Primive values are not extensible.
      * @param value - The value to check.
      * @param initMsg - The custom message to display if the assertion fails
-     * @throws {AssertionError} If the value is extensible.
+     * @throws An {@link AssertionFailure} if the value is extensible.
      * @example
      * ```typescript
      * assert.isNotExtensible(Object.freeze({})); // Passes
      * assert.isNotExtensible(Object.seal({})); // Passes
-     * assert.isNotExtensible({}); // Throws AssertionError
-     * assert.isNotExtensible([]); // Throws AssertionError
-     * assert.isNotExtensible(Object.create(null)); // Throws AssertionError
+     * assert.isNotExtensible({}); // Throws AssertionFailure
+     * assert.isNotExtensible([]); // Throws AssertionFailure
+     * assert.isNotExtensible(Object.create(null)); // Throws AssertionFailure
      * ```
      */
     isNotExtensible(value: any, initMsg?: MsgSource): AssertInst;
@@ -1012,16 +1012,16 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * Symbol.iterator property.
      * @param value - The value to check.
      * @param initMsg - The custom message to display if the assertion fails.
-     * @throws {AssertionError} If the value is not an iterable.
+     * @throws An {@link AssertionFailure} if the value is not an iterable.
      * @example
      * ```typescript
      * assert.isIterable([]); // Passes
      * assert.isIterable(new Map()); // Passes
      * assert.isIterable(new Set()); // Passes
      * assert.isIterable({ [Symbol.iterator]: () => {} }); // Passes
-     * assert.isIterable({}); // Throws AssertionError
-     * assert.isIterable(null); // Throws AssertionError
-     * assert.isIterable(undefined); // Throws AssertionError
+     * assert.isIterable({}); // Throws AssertionFailure
+     * assert.isIterable(null); // Throws AssertionFailure
+     * assert.isIterable(undefined); // Throws AssertionFailure
      * ```
      */
     isIterable(value: any, initMsg?: MsgSource): AssertInst;
@@ -1031,16 +1031,16 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * Symbol.iterator property.
      * @param value - The value to check.
      * @param initMsg - The custom message to display if the assertion fails.
-     * @throws {AssertionError} If the value is an iterable.
+     * @throws An {@link AssertionFailure} if the value is an iterable.
      * @example
      * ```typescript
      * assert.isNotIterable({}); // Passes
      * assert.isNotIterable(null); // Passes
      * assert.isNotIterable(undefined); // Passes
-     * assert.isNotIterable([]); // Throws AssertionError
-     * assert.isNotIterable(new Map()); // Throws AssertionError
-     * assert.isNotIterable(new Set()); // Throws AssertionError
-     * assert.isNotIterable({ [Symbol.iterator]: () => {} }); // Throws AssertionError
+     * assert.isNotIterable([]); // Throws AssertionFailure
+     * assert.isNotIterable(new Map()); // Throws AssertionFailure
+     * assert.isNotIterable(new Set()); // Throws AssertionFailure
+     * assert.isNotIterable({ [Symbol.iterator]: () => {} }); // Throws AssertionFailure
      * ```
      */
      isNotIterable(value: any, initMsg?: MsgSource): AssertInst;
@@ -1054,6 +1054,7 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * @param value - The value to check.
      * @param initMsg - The message to display if the assertion fails.
      * @asserts That the `value` is NaN and throws {@link AssertionFailure} if it is not.
+     * @since 0.1.5
      * @example
      * ```typescript
      * assert.isNaN(NaN); // Passes
@@ -1075,6 +1076,7 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * @param value - The value to check.
      * @param initMsg - The message to display if the assertion fails.
      * @asserts That the `value` is not NaN and throws {@link AssertionFailure} if it is.
+     * @since 0.1.5
      * @example
      * ```typescript
      * assert.isNotNaN(123); // Passes
@@ -1092,18 +1094,19 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * Asserts that the given value is a finite number (not NaN, not Infinity, not -Infinity).
      * @param value - The value to check.
      * @param initMsg - The custom message to display if the assertion fails.
-     * @throws {AssertionError} If the value is not a finite number.
+     * @throws An {@link AssertionFailure} if the value is not a finite number.
+     * @since 0.1.5
      * @example
      * ```typescript
      * assert.isFinite(123); // Passes
      * assert.isFinite(0); // Passes
      * assert.isFinite(-456.789); // Passes
-     * assert.isFinite(NaN); // Throws AssertionError
-     * assert.isFinite(Infinity); // Throws AssertionError
-     * assert.isFinite(-Infinity); // Throws AssertionError
-     * assert.isFinite("123"); // Throws AssertionError
-     * assert.isFinite(null); // Throws AssertionError
-     * assert.isFinite(undefined); // Throws AssertionError
+     * assert.isFinite(NaN); // Throws AssertionFailure
+     * assert.isFinite(Infinity); // Throws AssertionFailure
+     * assert.isFinite(-Infinity); // Throws AssertionFailure
+     * assert.isFinite("123"); // Throws AssertionFailure
+     * assert.isFinite(null); // Throws AssertionFailure
+     * assert.isFinite(undefined); // Throws AssertionFailure
      * ```
      */
     isFinite(value: any, initMsg?: MsgSource): AssertInst;
@@ -1112,7 +1115,8 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * Asserts that the given value is not a finite number (e.g., NaN, Infinity, -Infinity, or non-numeric).
      * @param value - The value to check.
      * @param initMsg - The custom message to display if the assertion fails.
-     * @throws {AssertionError} If the value is a finite number.
+     * @throws An {@link AssertionFailure} if the value is a finite number.
+     * @since 0.1.5
      * @example
      * ```typescript
      * assert.isNotFinite(NaN); // Passes
@@ -1122,9 +1126,9 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * assert.isNotFinite(null); // Passes
      * assert.isNotFinite(undefined); // Passes
      * assert.isNotFinite({}); // Passes
-     * assert.isNotFinite(123); // Throws AssertionError
-     * assert.isNotFinite(0); // Throws AssertionError
-     * assert.isNotFinite(-456.789); // Throws AssertionError
+     * assert.isNotFinite(123); // Throws AssertionFailure
+     * assert.isNotFinite(0); // Throws AssertionFailure
+     * assert.isNotFinite(-456.789); // Throws AssertionFailure
      * ```
      */
     isNotFinite(value: any, initMsg?: MsgSource): AssertInst;
@@ -1141,12 +1145,18 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * - "symbol"
      * - "undefined"
      * - "object" (includes null, arrays, and objects)
-     * - "function"
+     * - "null"
+     * - "array"
+     * - "function" (includes async, generator, and async generator functions)
+     * - "asyncfunction"
+     * - "generatorfunction"
+     * - "asyncgeneratorfunction"
      *
      * @param value - The value to check.
      * @param type - The expected type string (e.g., "string", "number", "function").
      * @param initMsg - The message to display if the assertion fails.
      * @asserts That the `value` is of the specified type and throws {@link AssertionFailure} if it is not.
+     * @since 0.1.5
      * @example
      * ```typescript
      * assert.typeOf("hello", "string"); // Passes
@@ -1175,12 +1185,18 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * - "symbol"
      * - "undefined"
      * - "object" (includes null, arrays, and objects)
-     * - "function"
+     * - "null"
+     * - "array"
+     * - "function" (includes async, generator, and async generator functions)
+     * - "asyncfunction"
+     * - "generatorfunction"
+     * - "asyncgeneratorfunction"
      *
      * @param value - The value to check.
      * @param type - The type string that the value should not match.
      * @param initMsg - The message to display if the assertion fails.
      * @asserts That the `value` is not of the specified type and throws {@link AssertionFailure} if it is.
+     * @since 0.1.5
      * @example
      * ```typescript
      * assert.notTypeOf("hello", "number"); // Passes
@@ -1192,6 +1208,52 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * ```
      */
     notTypeOf(value: any, type: string, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the given value is an instance of the specified constructor.
+     * Uses the JavaScript `instanceof` operator to check if the value is an instance of the constructor.
+     *
+     * @param value - The value to check.
+     * @param constructor - The constructor function to check against (e.g., Array, Date, Error, custom class).
+     * @param initMsg - The message to display if the assertion fails.
+     * @throws An {@link AssertionFailure} if the value is not an instance of the constructor.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.isInstanceOf(new Date(), Date); // Passes
+     * assert.isInstanceOf([], Array); // Passes
+     * assert.isInstanceOf(new Error(), Error); // Passes
+     * assert.isInstanceOf({}, Object); // Passes
+     * class MyClass {}
+     * assert.isInstanceOf(new MyClass(), MyClass); // Passes
+     * assert.isInstanceOf("hello", String); // Throws AssertionFailure
+     * assert.isInstanceOf(123, Number); // Throws AssertionFailure
+     * assert.isInstanceOf([], Object); // Passes (arrays are objects)
+     * assert.isInstanceOf({}, Array); // Throws AssertionFailure
+     * ```
+     */
+    isInstanceOf(value: any, constructor: Function, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the given value is not an instance of the specified constructor.
+     * Uses the JavaScript `instanceof` operator to check if the value is not an instance of the constructor.
+     *
+     * @param value - The value to check.
+     * @param constructor - The constructor function to check against (e.g., Array, Date, Error, custom class).
+     * @param initMsg - The message to display if the assertion fails.
+     * @throws An {@link AssertionFailure} if the value is an instance of the constructor.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.isNotInstanceOf("hello", Number); // Passes
+     * assert.isNotInstanceOf(123, String); // Passes
+     * assert.isNotInstanceOf({}, Array); // Passes
+     * assert.isNotInstanceOf([], Date); // Passes
+     * assert.isNotInstanceOf(new Date(), Date); // Throws AssertionFailure
+     * assert.isNotInstanceOf([], Array); // Throws AssertionFailure
+     * ```
+     */
+    isNotInstanceOf(value: any, constructor: Function, initMsg?: MsgSource): AssertInst;
 
     /**
      * Asserts that the given function throws an error that matches the specified error constructor,
@@ -1266,6 +1328,7 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * a string, array, or any other type that supports the `includes` method. If the
      * value does not include the match, it throws an {@link AssertionFailure} with the given message.
      *
+     * @since 0.1.2
      * @param value - The value to evaluate.
      * @param match - The value to check for inclusion.
      * @param initMsg - The message to display if the assertion fails.
@@ -1324,6 +1387,7 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * This method checks if the provided value is numerically greater than the expected value.
      * Works with both numbers and Date objects.
      *
+     * @since 0.1.5
      * @param value - The value to check.
      * @param expected - The expected value to compare against.
      * @param initMsg - The message to display if the assertion fails.
@@ -1343,6 +1407,7 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * This method checks if the provided value is not numerically greater than the expected value.
      * Works with both numbers and Date objects. This is the inverse of {@link isAbove}.
      *
+     * @since 0.1.5
      * @param value - The value to check.
      * @param expected - The expected value to compare against.
      * @param initMsg - The message to display if the assertion fails.
@@ -1362,6 +1427,7 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * This method checks if the provided value is numerically greater than or equal to the expected value.
      * Works with both numbers and Date objects.
      *
+     * @since 0.1.5
      * @param value - The value to check.
      * @param expected - The expected value to compare against.
      * @param initMsg - The message to display if the assertion fails.
@@ -1381,6 +1447,7 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * This method checks if the provided value is not numerically greater than or equal to the expected value.
      * Works with both numbers and Date objects. This is the inverse of {@link isAtLeast}.
      *
+     * @since 0.1.5
      * @param value - The value to check.
      * @param expected - The expected value to compare against.
      * @param initMsg - The message to display if the assertion fails.
@@ -1400,6 +1467,7 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * This method checks if the provided value is numerically less than the expected value.
      * Works with both numbers and Date objects.
      *
+     * @since 0.1.5
      * @param value - The value to check.
      * @param expected - The expected value to compare against.
      * @param initMsg - The message to display if the assertion fails.
@@ -1418,6 +1486,7 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * This method checks if the provided value is not numerically less than the expected value.
      * Works with both numbers and Date objects. This is the inverse of {@link isBelow}.
      *
+     * @since 0.1.5
      * @param value - The value to check.
      * @param expected - The expected value to compare against.
      * @param initMsg - The message to display if the assertion fails.
@@ -1437,6 +1506,7 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * This method checks if the provided value is numerically less than or equal to the expected value.
      * Works with both numbers and Date objects.
      *
+     * @since 0.1.5
      * @param value - The value to check.
      * @param expected - The expected value to compare against.
      * @param initMsg - The message to display if the assertion fails.
@@ -1456,6 +1526,7 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * This method checks if the provided value is not numerically less than or equal to the expected value.
      * Works with both numbers and Date objects. This is the inverse of {@link isAtMost}.
      *
+     * @since 0.1.5
      * @param value - The value to check.
      * @param expected - The expected value to compare against.
      * @param initMsg - The message to display if the assertion fails.
@@ -1475,6 +1546,7 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * This method checks if the provided value is between the start and finish values (inclusive).
      * Works with both numbers and Date objects.
      *
+     * @since 0.1.5
      * @param value - The value to check.
      * @param start - The start of the range (inclusive).
      * @param finish - The end of the range (inclusive).
@@ -1498,6 +1570,7 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * The range is inclusive, meaning the start and finish values are included.
      * Works with both numbers and Date objects. This is the inverse of {@link isWithin}.
      *
+     * @since 0.1.5
      * @param value - The value to check.
      * @param start - The start of the range (inclusive).
      * @param finish - The end of the range (inclusive).

--- a/core/src/assert/interface/IAssertInst.ts
+++ b/core/src/assert/interface/IAssertInst.ts
@@ -161,6 +161,7 @@ export interface IAssertInst extends INotOp<IAssertInst>, IAssertInstCore, IEqua
      * This operation allows you to assert that the target value includes the specified value(s).
      * It is useful for verifying that an array, string, or object contains certain elements or properties.
      *
+     * @since 0.1.2
      * @alias include
      * @example
      * ```typescript

--- a/core/src/assert/interface/IScopeContext.ts
+++ b/core/src/assert/interface/IScopeContext.ts
@@ -170,7 +170,7 @@ export interface IScopeContextOverrides {
      * Throws an `AssertionFailure` with the given message.
      * @param msg - The message to display.
      * @param details - The details (props) to include in the error
-     * @throws AssertionError
+     * @throws An {@link AssertionError} always
      */
     fail?: (parent: IScopeContext, msg: string, details: any, causedBy: Error) => void | never;
 }

--- a/core/src/assert/interface/funcs/DeltaFn.ts
+++ b/core/src/assert/interface/funcs/DeltaFn.ts
@@ -19,7 +19,7 @@ export interface DeltaFn<R> {
      * @param evalMsg - The message to evaluate
      * @returns The result of the operation, which will generally be the existing
      * {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails
+     * @throws An {@link AssertionFailure} if the assertion fails
      */
     (delta: number, evalMsg?: MsgSource): R;
 }

--- a/core/src/assert/interface/funcs/EqualFn.ts
+++ b/core/src/assert/interface/funcs/EqualFn.ts
@@ -25,7 +25,7 @@ export interface EqualFn<R> {
      * @typeParam T - The type of the expected value.
      * @param expected - The expected value.
      * @param evalMsg - The message to display if the values are strictly equal.
-     * @throws AssertionFailure - If the `expected` and `actual` values are strictly equal.
+     * @throws An {@link AssertionFailure} if the `expected` and `actual` values are strictly equal.
      * @example
      * assert.equal(1, 1); // Passes
      * assert.equal("a", "a"); // Passes

--- a/core/src/assert/interface/funcs/IncludeFn.ts
+++ b/core/src/assert/interface/funcs/IncludeFn.ts
@@ -10,6 +10,7 @@ import { MsgSource } from "../types";
 
 /**
  * Represents a function that asserts whether the value includes a matching value and an optional evaluation message.
+ * @since 0.1.2
  * @template R - The type of the result of the operation.
  * @param match - The single value to check if it is included within the value.
  * @param evalMsg - The optional evaluation message.

--- a/core/src/assert/interface/funcs/InstanceOfFn.ts
+++ b/core/src/assert/interface/funcs/InstanceOfFn.ts
@@ -11,6 +11,7 @@ import { MsgSource } from "../types";
 /**
  * Represents a function that performs an instance of check.
  * @template R - The type of the result of the operation.
+ * @since 0.1.5
  */
 export interface InstanceOfFn<R> {
 
@@ -20,6 +21,7 @@ export interface InstanceOfFn<R> {
      * @param evalMsg - The optional message source for evaluation.
      * @returns The result of the operation, which will generally be the existing
      * {@link IAssertScope.that} object.
+     * @since 0.1.5
      */
     (constructor: any, evalMsg?: MsgSource): R;
 }

--- a/core/src/assert/interface/funcs/PropertyFn.ts
+++ b/core/src/assert/interface/funcs/PropertyFn.ts
@@ -21,8 +21,8 @@ export interface PropertyFn {
      * @param value - The expected value of the property.
      * @param evalMsg - The evaluation message source.
      * @returns A new assertion instance `this` with the value of the property.
-     * @throws {@link AssertionFailure} if the property does not exist.
-     * @throws {@link AssertionFailure} if the property value does not match the expected value.
+     * @throws An {@link AssertionFailure} if the property does not exist.
+     * @throws An {@link AssertionFailure} if the property value does not match the expected value.
      */
     <T>(name: string | symbol | number, value?: T, evalMsg?: MsgSource): IPropertyResultOp;
 }
@@ -37,8 +37,8 @@ export interface PropertyDescriptorFn {
      * @param descriptor - The property descriptor to validate.
      * @param evalMsg - The evaluation message source.
      * @returns A new assertion instance `this` with the value of the property.
-     * @throws {@link AssertionFailure} if no property descriptor is found.
-     * @throws {@link AssertionFailure} if the property descriptor does not match the expected descriptor.
+     * @throws An {@link AssertionFailure} if no property descriptor is found.
+     * @throws An {@link AssertionFailure} if the property descriptor does not match the expected descriptor.
      */
     (name: string | symbol | number, descriptor?: PropertyDescriptor, evalMsg?: MsgSource): IPropertyResultOp;
 }

--- a/core/src/assert/interface/funcs/SymbolFn.ts
+++ b/core/src/assert/interface/funcs/SymbolFn.ts
@@ -21,8 +21,8 @@ export interface SymbolFn {
      * @template T - The type of the property value.
      * @param evalMsg - The evaluation message source.
      * @returns A new assertion instance `this` with the value of the property.
-     * @throws {@link AssertionFailure} if the symbol property does not exist.
-     * @throws {@link AssertionFailure} if the symbol property value does not match the expected value.
+     * @throws An {@link AssertionFailure} if the symbol property does not exist.
+     * @throws An {@link AssertionFailure} if the symbol property value does not match the expected value.
      */
     (this: IAssertScope, evalMsg?: MsgSource): IPropertyResultOp;
 }

--- a/core/src/assert/interface/funcs/TypeOfFn.ts
+++ b/core/src/assert/interface/funcs/TypeOfFn.ts
@@ -21,7 +21,7 @@ export interface TypeFn<R> {
      * @param evalMsg - The optional evaluation message.
      * @returns The result of the operation, which will generally be the existing
      * {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the value is not of the specified type.
+     * @throws An {@link AssertionFailure} if the value is not of the specified type.
      */
     (type: string, evalMsg?: MsgSource): R;
 }

--- a/core/src/assert/interface/funcs/WithinFn.ts
+++ b/core/src/assert/interface/funcs/WithinFn.ts
@@ -22,7 +22,7 @@ export interface WithinFn<R> {
      * @param evalMsg - The message to evaluate
      * @returns The result of the operation, which will generally be the existing
      * {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails
+     * @throws An {@link AssertionFailure} if the assertion fails
      */
     (start: number, finish: number, evalMsg?: MsgSource): R;
 
@@ -33,7 +33,7 @@ export interface WithinFn<R> {
      * @param evalMsg - The message to evaluate
      * @returns The result of the operation, which will generally be the existing
      * {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails
+     * @throws An {@link AssertionFailure} if the assertion fails
      */
     (start: Date, finish: Date, evalMsg?: MsgSource): R;
 }

--- a/core/src/assert/interface/ops/IDeltaOp.ts
+++ b/core/src/assert/interface/ops/IDeltaOp.ts
@@ -18,7 +18,7 @@ export interface IDeltaOp<R> {
      * @param delta - The delta to compare against
      * @param evalMsg - The message to evaluate
      * @returns The result of the operation
-     * @throws {@link AssertionFailure} - If the assertion fails
+     * @throws An {@link AssertionFailure} if the assertion fails
      */
     by: DeltaFn<R>;
 }

--- a/core/src/assert/interface/ops/IEqualOp.ts
+++ b/core/src/assert/interface/ops/IEqualOp.ts
@@ -25,7 +25,7 @@ export interface IEqualOp<R> {
      * @typeParam T - The type of the expected value.
      * @param expected - The expected value.
      * @param evalMsg - The message to display if the values are not strictly equal.
-     * @throws AssertionFailure - If the `expected` and `actual` values are not strictly equal.
+     * @throws An {@link AssertionFailure} if the `expected` and `actual` values are not strictly equal.
      * @example
      * assert.equal(1, 1); // Passes
      * assert.equal("a", "a"); // Passes
@@ -55,7 +55,7 @@ export interface IEqualOp<R> {
      * @typeParam T - The type of the expected value.
      * @param expected - The expected value.
      * @param evalMsg - The message to display if the values are strictly equal.
-     * @throws AssertionFailure - If the `expected` and `actual` values are strictly equal.
+     * @throws An {@link AssertionFailure} if the `expected` and `actual` values are strictly equal.
      * @example
      * assert.equals(1, 1); // Passes
      * assert.equals("a", "a"); // Passes
@@ -86,7 +86,7 @@ export interface IEqualOp<R> {
      * @typeParam T - The type of the expected value.
      * @param expected - The expected value.
      * @param evalMsg - The message to display if the values are strictly equal.
-     * @throws AssertionFailure - If the `expected` and `actual` values are strictly equal.
+     * @throws An {@link AssertionFailure} if the `expected` and `actual` values are strictly equal.
      * @example
      * assert.eq(1, 1); // Passes
      * assert.eq("a", "a"); // Passes

--- a/core/src/assert/interface/ops/IIncludeOp.ts
+++ b/core/src/assert/interface/ops/IIncludeOp.ts
@@ -12,6 +12,7 @@ import { IncludeFn } from "../funcs/IncludeFn";
 
 /**
  * Represents the include operations for the assertion scope.
+ * @since 0.1.2
  * @template R - The type of the result of the operation.
  */
 export interface IIncludeOp<R> extends IncludeFn<R> {

--- a/core/src/assert/interface/ops/INumericOp.ts
+++ b/core/src/assert/interface/ops/INumericOp.ts
@@ -9,6 +9,9 @@
 import { NumberFn } from "../funcs/NumericFn";
 import { WithinFn } from "../funcs/WithinFn";
 
+/**
+ * @since 0.1.5
+ */
 export interface INumericOp<R> {
     above: NumberFn<R>;
     gt: NumberFn<R>;

--- a/core/src/assert/interface/ops/IStrictlyOp.ts
+++ b/core/src/assert/interface/ops/IStrictlyOp.ts
@@ -23,7 +23,7 @@ export interface IStrictlyOp<R> extends INotOp<IStrictlyOp<R>>, IEqualOp<R> {
      * @param evalMsg - Optional. The message to display if the assertion fails.
      * @returns The result of the operation, which will generally be the existing
      * {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the current {@link IScopeContext.value}
+     * @throws An {@link AssertionFailure} if the current {@link IScopeContext.value}
      * is not strictly equal to `true`.
      */
     true: AssertFn<R>;
@@ -34,7 +34,7 @@ export interface IStrictlyOp<R> extends INotOp<IStrictlyOp<R>>, IEqualOp<R> {
      * @param evalMsg - Optional. The message to display if the assertion fails.
      * @returns The result of the operation, which will generally be the existing
      * {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the current {@link IScopeContext.value}
+     * @throws An {@link AssertionFailure} if the current {@link IScopeContext.value}
      * is not strictly equal to `false`.
      */
     false: AssertFn<R>;

--- a/core/src/assert/interface/ops/IThrowOp.ts
+++ b/core/src/assert/interface/ops/IThrowOp.ts
@@ -21,9 +21,9 @@ export interface IThrowOp {
      * @param msgMatch - Optional. The message to match.
      * @param evalMsg - Optional. The message to display if the assertion fails.
      * @returns The result of the operation.
-     * @throws {@link AssertionFailure} - If the function does not throw an error.
-     * @throws {@link AssertionError} - If the error thrown does not match the expected error.
-     * @throws {@link AssertionError} - If the error message does not match the expected message.
+     * @throws An {@link AssertionFailure} if the function does not throw an error.
+     * @throws An {@link AssertionError} if the error thrown does not match the expected error.
+     * @throws An {@link AssertionError} if the error message does not match the expected message.
      */
     throws: ThrowFn;
 }

--- a/core/src/assert/interface/ops/IToOp.ts
+++ b/core/src/assert/interface/ops/IToOp.ts
@@ -82,6 +82,7 @@ export interface IToOp<R> extends INotOp<IToOp<R>> {
      * This operation allows you to assert that the target value includes the specified value(s).
      * It is useful for verifying that an array, string, or object contains certain elements or properties.
      *
+     * @since 0.1.2
      * @alias include
      * @example
      * ```typescript
@@ -172,7 +173,7 @@ export interface IToOp<R> extends INotOp<IToOp<R>> {
      * that when executed will throw an error.
      * @param evalMsg - Optional. The message to display if the assertion fails.
      * @returns The result of the operation.
-     * @throws {@link AssertionFailure} - If the function does not throw an error.
+     * @throws An {@link AssertionFailure} if the function does not throw an error.
      */
     throw: ThrowFn;
 

--- a/core/src/assert/interface/ops/ITypeOp.ts
+++ b/core/src/assert/interface/ops/ITypeOp.ts
@@ -10,6 +10,7 @@ import { IStrictlyOp } from "./IStrictlyOp";
 import { AssertFn } from "../funcs/AssertFn";
 import { ErrorLikeFn } from "../funcs/ErrorLikeFn";
 import { MsgSource } from "../types";
+import { InstanceOfFn } from "../funcs/InstanceOfFn";
 
 /**
  * Represents an interface for operations to assert the type of a value.
@@ -29,7 +30,7 @@ export interface IIsTypeOp<R> {
      * Asserts that the value is truthy.
      * @param evalMsg - The custom message to display on evaluation.
      * @returns The current {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails.
+     * @throws An {@link AssertionFailure} if the assertion fails.
      */
     ok: AssertFn<R>;
 
@@ -37,7 +38,7 @@ export interface IIsTypeOp<R> {
      * Asserts that the value is an array.
      * @param evalMsg - The custom message to display on evaluation.
      * @returns The current {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails.
+     * @throws An {@link AssertionFailure} if the assertion fails.
      */
     array: AssertFn<R>;
 
@@ -45,7 +46,7 @@ export interface IIsTypeOp<R> {
      * Asserts that the value is an object.
      * @param evalMsg - The custom message to display on evaluation.
      * @returns The current {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails.
+     * @throws An {@link AssertionFailure} if the assertion fails.
      */
     object: AssertFn<R>;
 
@@ -53,7 +54,7 @@ export interface IIsTypeOp<R> {
      * Asserts that the value is a plain object.
      * @param evalMsg - The custom message to display on evaluation.
      * @returns The current {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails.
+     * @throws An {@link AssertionFailure} if the assertion fails.
      */
     plainObject: AssertFn<R>;
 
@@ -61,7 +62,7 @@ export interface IIsTypeOp<R> {
      * Asserts that the value is a function.
      * @param evalMsg - The custom message to display on evaluation.
      * @returns The current {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails.
+     * @throws An {@link AssertionFailure} if the assertion fails.
      */
     function: AssertFn<R>;
 
@@ -69,7 +70,7 @@ export interface IIsTypeOp<R> {
      * Asserts that the value is a string.
      * @param evalMsg - The custom message to display on evaluation.
      * @returns The current {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails.
+     * @throws An {@link AssertionFailure} if the assertion fails.
      */
     string: AssertFn<R>;
 
@@ -77,7 +78,7 @@ export interface IIsTypeOp<R> {
      * Asserts that the value is a number.
      * @param evalMsg - The custom message to display on evaluation.
      * @returns The current {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails.
+     * @throws An {@link AssertionFailure} if the assertion fails.
      */
     number: AssertFn<R>;
 
@@ -85,7 +86,7 @@ export interface IIsTypeOp<R> {
      * Asserts that the value is a boolean.
      * @param evalMsg - The custom message to display on evaluation.
      * @returns The current {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails.
+     * @throws An {@link AssertionFailure} if the assertion fails.
      */
     boolean: AssertFn<R>;
 
@@ -93,7 +94,7 @@ export interface IIsTypeOp<R> {
      * Asserts that the value is undefined.
      * @param evalMsg - The custom message to display on evaluation.
      * @returns The current {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails.
+     * @throws An {@link AssertionFailure} if the assertion fails.
      */
     undefined: AssertFn<R>;
 
@@ -101,7 +102,7 @@ export interface IIsTypeOp<R> {
      * Asserts that the value is null.
      * @param evalMsg - The custom message to display on evaluation.
      * @returns The current {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails.
+     * @throws An {@link AssertionFailure} if the assertion fails.
      */
     null: AssertFn<R>;
 
@@ -109,7 +110,7 @@ export interface IIsTypeOp<R> {
      * Asserts that the value is truthy.
      * @param evalMsg - The custom message to display on evaluation.
      * @returns The current {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails.
+     * @throws An {@link AssertionFailure} if the assertion fails.
      */
     truthy: AssertFn<R>;
 
@@ -117,7 +118,7 @@ export interface IIsTypeOp<R> {
      * Asserts that the value is true.
      * @param evalMsg - The custom message to display on evaluation.
      * @returns The current {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails.
+     * @throws An {@link AssertionFailure} if the assertion fails.
      */
     true: AssertFn<R>;
 
@@ -125,7 +126,7 @@ export interface IIsTypeOp<R> {
      * Asserts that the value is false.
      * @param evalMsg - The custom message to display on evaluation.
      * @returns The current {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails.
+     * @throws An {@link AssertionFailure} if the assertion fails.
      */
     false: AssertFn<R>;
 
@@ -133,7 +134,7 @@ export interface IIsTypeOp<R> {
      * Asserts that the value is empty.
      * @param evalMsg - The custom message to display on evaluation.
      * @returns The current {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails.
+     * @throws An {@link AssertionFailure} if the assertion fails.
      */
     empty: AssertFn<R>;
 
@@ -141,7 +142,7 @@ export interface IIsTypeOp<R> {
      * Asserts that the value is sealed.
      * @param evalMsg - The custom message to display on evaluation.
      * @returns The current {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails.
+     * @throws An {@link AssertionFailure} if the assertion fails.
      */
     sealed: AssertFn<R>;
 
@@ -149,7 +150,7 @@ export interface IIsTypeOp<R> {
      * Asserts that the value is frozen.
      * @param evalMsg - The custom message to display on evaluation.
      * @returns The current {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails.
+     * @throws An {@link AssertionFailure} if the assertion fails.
      */
     frozen: AssertFn<R>;
 
@@ -158,7 +159,7 @@ export interface IIsTypeOp<R> {
      * @param errorLike - The error or error constructor to match.
      * @param evalMsg - The custom message to display on evaluation.
      * @returns The current {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails.
+     * @throws An {@link AssertionFailure} if the assertion fails.
      */
     error: ErrorLikeFn<R>;
 
@@ -166,7 +167,7 @@ export interface IIsTypeOp<R> {
      * Asserts that the value is extensible.
      * @param evalMsg - The custom message to display on evaluation.
      * @returns The current {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails.
+     * @throws An {@link AssertionFailure} if the assertion fails.
      */
     extensible: AssertFn<R>,
 
@@ -174,7 +175,7 @@ export interface IIsTypeOp<R> {
      * Asserts that the value is iterable.
      * @param evalMsg - The custom message to display on evaluation.
      * @returns The current {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails.
+     * @throws An {@link AssertionFailure} if the assertion fails.
      */
     iterable: AssertFn<R>,
 
@@ -182,7 +183,8 @@ export interface IIsTypeOp<R> {
      * Asserts that the value is NaN.
      * @param evalMsg - The custom message to display on evaluation.
      * @returns The current {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails.
+     * @throws An {@link AssertionFailure} if the assertion fails.
+     * @since 0.1.5
      */
     nan: AssertFn<R>;
 
@@ -190,7 +192,8 @@ export interface IIsTypeOp<R> {
      * Asserts that the value is a finite number (not NaN, not Infinity, not -Infinity).
      * @param evalMsg - The custom message to display on evaluation.
      * @returns The current {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails.
+     * @throws An {@link AssertionFailure} if the assertion fails.
+     * @since 0.1.5
      */
     finite: AssertFn<R>;
 
@@ -206,12 +209,18 @@ export interface IIsTypeOp<R> {
      * - "symbol"
      * - "undefined"
      * - "object" (includes null, arrays, and objects)
-     * - "function"
+     * - "null"
+     * - "array"
+     * - "function" (includes async, generator, and async generator functions)
+     * - "asyncfunction"
+     * - "generatorfunction"
+     * - "asyncgeneratorfunction"
      *
      * @param type - The expected type string (e.g., "string", "number", "function")
      * @param evalMsg - The custom message to display on evaluation.
      * @returns The current {@link IAssertScope.that} object.
-     * @throws {@link AssertionFailure} - If the assertion fails.
+     * @throws An {@link AssertionFailure} if the assertion fails.
+     * @since 0.1.5
      * @example
      * ```typescript
      * expect("hello").is.typeof("string");
@@ -221,4 +230,24 @@ export interface IIsTypeOp<R> {
      * ```
      */
     typeOf(type: string, evalMsg?: MsgSource): R;
+
+    /**
+     * Asserts that the value is an instance of the specified constructor.
+     * @param constructor - The constructor to check against (e.g., Array, Date, Error, custom class).
+     * @param evalMsg - The custom message to display on evaluation.
+     * @returns The current {@link IAssertScope.that} object.
+     * @throws An {@link AssertionFailure} if the assertion fails.
+     * @since 0.1.5
+     */
+    instanceof: InstanceOfFn<R>;
+
+    /**
+     * Asserts that the value is an instance of the specified constructor.
+     * @param constructor - The constructor to check against (e.g., Array, Date, Error, custom class).
+     * @param evalMsg - The custom message to display on evaluation.
+     * @returns The current {@link IAssertScope.that} object.
+     * @throws An {@link AssertionFailure} if the assertion fails.
+     * @since 0.1.5
+     */
+    instanceOf: InstanceOfFn<R>;
 }

--- a/core/src/assert/ops/isOp.ts
+++ b/core/src/assert/ops/isOp.ts
@@ -25,6 +25,7 @@ import { isExtensibleFunc } from "../funcs/isExtensible";
 import { hasSymbolFunc } from "../funcs/hasSymbol";
 import { aboveFunc, belowFunc, leastFunc, mostFunc, withinFunc } from "./numericOp";
 import { typeOfFunc } from "../funcs/typeOf";
+import { instanceOfFunc } from "../funcs/instanceOf";
 
 export function isOp<R>(scope: IAssertScope): IIsOp<R> {
     let props:  AssertScopeFuncDefs<IIsOp<R>> = {
@@ -59,6 +60,44 @@ export function isOp<R>(scope: IAssertScope): IIsOp<R> {
         iterable: { scopeFn: hasSymbolFunc(Symbol.iterator) },
         nan: { scopeFn: isNaNFunc },
         finite: { scopeFn: isFiniteFunc },
+        
+        /**
+         * Asserts that the value is an instance of the specified constructor.
+         * This is an alias for `instanceOf` to support the JavaScript `instanceof` keyword style.
+         *
+         * @since 0.1.5
+         * @example
+         * ```typescript
+         * expect(new Date()).is.instanceof(Date);
+         * expect([]).is.instanceof(Array);
+         * expect(new Error()).is.instanceof(Error);
+         * expect({}).is.instanceof(Object);
+         * ```
+         */
+        instanceof: { scopeFn: instanceOfFunc },
+        
+        /**
+         * Asserts that the value is an instance of the specified constructor.
+         * Uses the JavaScript `instanceof` operator for type checking.
+         *
+         * @since 0.1.5
+         * @example
+         * ```typescript
+         * expect(new Date()).is.instanceOf(Date);
+         * expect([]).to.be.instanceOf(Array);
+         * expect(new Error()).is.instanceOf(Error);
+         * expect({}).to.be.an.instanceOf(Object);
+         *
+         * // With negation
+         * expect("hello").is.not.instanceOf(Number);
+         * expect(123).to.not.be.instanceOf(String);
+         *
+         * // Custom classes
+         * class MyClass {}
+         * expect(new MyClass()).is.instanceOf(MyClass);
+         * ```
+         */
+        instanceOf: { scopeFn: instanceOfFunc },
 
         // Numeric comparison operations
         above: { scopeFn: aboveFunc },

--- a/core/src/assert/ops/numericOp.ts
+++ b/core/src/assert/ops/numericOp.ts
@@ -46,6 +46,7 @@ function _checkTypes(context: IScopeContext, value: unknown, expected: unknown, 
  * @param n - The value to compare against.
  * @param evalMsg - The message to display if the assertion fails.
  * @returns - The assert scope.
+ * @since 0.1.5
  */
 export function aboveFunc<R>(this: IAssertScope, n: number | Date, evalMsg?: MsgSource): R {
     let scope = this;
@@ -70,6 +71,7 @@ export function aboveFunc<R>(this: IAssertScope, n: number | Date, evalMsg?: Msg
  * @param n - The value to compare against.
  * @param evalMsg - The message to display if the assertion fails.
  * @returns - The assert scope.
+ * @since 0.1.5
  */
 export function leastFunc<R>(this: IAssertScope, n: number | Date, evalMsg?: MsgSource): R {
     let scope = this;
@@ -94,6 +96,7 @@ export function leastFunc<R>(this: IAssertScope, n: number | Date, evalMsg?: Msg
  * @param n - The value to compare against.
  * @param evalMsg - The message to display if the assertion fails.
  * @returns - The assert scope.
+ * @since 0.1.5
  */
 export function belowFunc<R>(this: IAssertScope, n: number | Date, evalMsg?: MsgSource): R {
     let scope = this;
@@ -118,6 +121,7 @@ export function belowFunc<R>(this: IAssertScope, n: number | Date, evalMsg?: Msg
  * @param n - The value to compare against.
  * @param evalMsg - The message to display if the assertion fails.
  * @returns - The assert scope.
+ * @since 0.1.5
  */
 export function mostFunc<R>(this: IAssertScope, n: number | Date, evalMsg?: MsgSource): R {
     let scope = this;
@@ -143,6 +147,7 @@ export function mostFunc<R>(this: IAssertScope, n: number | Date, evalMsg?: MsgS
  * @param finish - The end of the range.
  * @param evalMsg - The message to display if the assertion fails.
  * @returns - The assert scope.
+ * @since 0.1.5
  */
 export function withinFunc<R>(this: IAssertScope, start: number | Date, finish: number | Date, evalMsg?: MsgSource): R {
     let scope = this;

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -46,6 +46,7 @@ import { IAssertScope } from "./assert/interface/IAssertScope";
 import { EqualFn } from "./assert/interface/funcs/EqualFn";
 import { AssertFn } from "./assert/interface/funcs/AssertFn";
 import { ErrorLikeFn } from "./assert/interface/funcs/ErrorLikeFn";
+import { InstanceOfFn } from "./assert/interface/funcs/InstanceOfFn";
 import { assertConfig } from "./assert/config";
 import { IAssertConfig, IAssertConfigDefaults } from "./assert/interface/IAssertConfig";
 import { IFormatCtx, IFormatter, IFormattedValue, IFormatterOptions, eFormatResult } from "./assert/interface/IFormatter";
@@ -84,8 +85,8 @@ export {
  */
 export {
     AssertClassDef, AssertFn, AssertInstHandlers, AssertScopeFuncDefs, EqualFn, ErrorLikeFn,
-    EvalFn, IncludeFn, IScopeFn, KeysFn, MsgSource, NumberFn, SymbolFn, ThrowFn, ValuesFn,
-    WithinFn
+    EvalFn, IncludeFn, InstanceOfFn, IScopeFn, KeysFn, MsgSource, NumberFn, SymbolFn, ThrowFn,
+    ValuesFn, WithinFn
 };
 
 /**

--- a/core/test/src/assert/assert.isInstanceOf.test.ts
+++ b/core/test/src/assert/assert.isInstanceOf.test.ts
@@ -1,0 +1,363 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2024-2026 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { assert, AssertionFailure, expect } from "../../../src/index";
+
+describe("assert.isInstanceOf", () => {
+    
+    it("should pass for Date instance", () => {
+        assert.isInstanceOf(new Date(), Date);
+    });
+
+    it("should pass for Array instance", () => {
+        assert.isInstanceOf([], Array);
+        assert.isInstanceOf([1, 2, 3], Array);
+    });
+
+    it("should pass for Error instance", () => {
+        assert.isInstanceOf(new Error(), Error);
+        assert.isInstanceOf(new TypeError(), TypeError);
+        assert.isInstanceOf(new RangeError(), RangeError);
+    });
+
+    it("should pass for Object instance", () => {
+        assert.isInstanceOf({}, Object);
+        assert.isInstanceOf([], Object); // Arrays are objects
+        assert.isInstanceOf(new Date(), Object); // Dates are objects
+    });
+
+    it("should pass for custom class instance", () => {
+        class MyClass {}
+        class MySubClass extends MyClass {}
+        
+        assert.isInstanceOf(new MyClass(), MyClass);
+        assert.isInstanceOf(new MySubClass(), MySubClass);
+        assert.isInstanceOf(new MySubClass(), MyClass); // Inheritance
+    });
+
+    it("should pass for RegExp instance", () => {
+        assert.isInstanceOf(/test/, RegExp);
+        assert.isInstanceOf(new RegExp("test"), RegExp);
+    });
+
+    it("should pass for Map and Set instances", () => {
+        assert.isInstanceOf(new Map(), Map);
+        assert.isInstanceOf(new Set(), Set);
+        assert.isInstanceOf(new WeakMap(), WeakMap);
+        assert.isInstanceOf(new WeakSet(), WeakSet);
+    });
+
+    it("should pass for Promise instance", () => {
+        assert.isInstanceOf(Promise.resolve(), Promise);
+        assert.isInstanceOf(new Promise(() => {}), Promise);
+    });
+
+    it("should fail for primitive string", () => {
+        try {
+            assert.isInstanceOf("hello", String);
+            assert.fail("Should have thrown");
+        } catch (e) {
+            expect(() => assert.isInstanceOf("hello", String)).to.throw(AssertionFailure);
+        }
+    });
+
+    it("should fail for primitive number", () => {
+        try {
+            assert.isInstanceOf(123, Number);
+            assert.fail("Should have thrown");
+        } catch (e) {
+            expect(() => assert.isInstanceOf(123, Number)).to.throw(AssertionFailure);
+        }
+    });
+
+    it("should fail for primitive boolean", () => {
+        try {
+            assert.isInstanceOf(true, Boolean);
+            assert.fail("Should have thrown");
+        } catch (e) {
+            expect(() => assert.isInstanceOf(true, Boolean)).to.throw(AssertionFailure);
+        }
+    });
+
+    it("should fail for wrong constructor", () => {
+        try {
+            assert.isInstanceOf([], Date);
+            assert.fail("Should have thrown");
+        } catch (e) {
+            expect(() => assert.isInstanceOf([], Date)).to.throw(AssertionFailure);
+        }
+    });
+
+    it("should fail for null", () => {
+        try {
+            assert.isInstanceOf(null, Object);
+            assert.fail("Should have thrown");
+        } catch (e) {
+            expect(() => assert.isInstanceOf(null, Object)).to.throw(AssertionFailure);
+        }
+    });
+
+    it("should fail for undefined", () => {
+        try {
+            assert.isInstanceOf(undefined, Object);
+            assert.fail("Should have thrown");
+        } catch (e) {
+            expect(() => assert.isInstanceOf(undefined, Object)).to.throw(AssertionFailure);
+        }
+    });
+
+    it("should support custom error message", () => {
+        try {
+            assert.isInstanceOf(123, Date, "Custom error message");
+            assert.fail("Should have thrown");
+        } catch (e: any) {
+            assert.equal(e.message.includes("Custom error message"), true);
+        }
+    });
+
+    it("should work with expect syntax", () => {
+        expect(new Date()).is.instanceOf(Date);
+        expect([]).is.instanceOf(Array);
+        expect(new Error()).is.instanceOf(Error);
+    });
+
+    it("should work with expect to.be syntax", () => {
+        expect(new Date()).to.be.instanceOf(Date);
+        expect([1, 2, 3]).to.be.an.instanceOf(Array);
+        expect({}).to.be.an.instanceOf(Object);
+    });
+
+    it("should work with expect chaining", () => {
+        expect(new Date()).is.a.instanceOf(Date);
+        expect([]).is.an.instanceOf(Array);
+    });
+});
+
+describe("assert.isNotInstanceOf", () => {
+    
+    it("should pass for primitive string not being String object", () => {
+        assert.isNotInstanceOf("hello", Number);
+        assert.isNotInstanceOf("hello", Date);
+    });
+
+    it("should pass for number not being other types", () => {
+        assert.isNotInstanceOf(123, String);
+        assert.isNotInstanceOf(123, Date);
+        assert.isNotInstanceOf(123, Array);
+    });
+
+    it("should pass for object not being Array", () => {
+        assert.isNotInstanceOf({}, Array);
+        assert.isNotInstanceOf({}, Date);
+        assert.isNotInstanceOf({}, RegExp);
+    });
+
+    it("should pass for array not being Date", () => {
+        assert.isNotInstanceOf([], Date);
+        assert.isNotInstanceOf([], RegExp);
+        assert.isNotInstanceOf([], Error);
+    });
+
+    it("should pass for null not being any type", () => {
+        assert.isNotInstanceOf(null, Object);
+        assert.isNotInstanceOf(null, Array);
+        assert.isNotInstanceOf(null, Date);
+    });
+
+    it("should pass for undefined not being any type", () => {
+        assert.isNotInstanceOf(undefined, Object);
+        assert.isNotInstanceOf(undefined, String);
+        assert.isNotInstanceOf(undefined, Number);
+    });
+
+    it("should pass for custom class not being another class", () => {
+        class MyClass {}
+        class OtherClass {}
+        
+        assert.isNotInstanceOf(new MyClass(), OtherClass);
+    });
+
+    it("should fail for Date instance being Date", () => {
+        try {
+            assert.isNotInstanceOf(new Date(), Date);
+            assert.fail("Should have thrown");
+        } catch (e) {
+            expect(() => assert.isNotInstanceOf(new Date(), Date)).to.throw(AssertionFailure);
+        }
+    });
+
+    it("should fail for Array instance being Array", () => {
+        try {
+            assert.isNotInstanceOf([], Array);
+            assert.fail("Should have thrown");
+        } catch (e) {
+            expect(() => assert.isNotInstanceOf([], Array)).to.throw(AssertionFailure);
+        }
+    });
+
+    it("should fail for Array being Object", () => {
+        try {
+            assert.isNotInstanceOf([], Object);
+            assert.fail("Should have thrown");
+        } catch (e) {
+            expect(() => assert.isNotInstanceOf([], Object)).to.throw(AssertionFailure);
+        }
+    });
+
+    it("should support custom error message", () => {
+        try {
+            assert.isNotInstanceOf(new Date(), Date, "Custom error message");
+            assert.fail("Should have thrown");
+        } catch (e: any) {
+            assert.equal(e.message.includes("Custom error message"), true);
+        }
+    });
+
+    it("should work with expect not syntax", () => {
+        expect(123).is.not.instanceOf(String);
+        expect("hello").is.not.instanceOf(Number);
+        expect({}).is.not.instanceOf(Array);
+    });
+
+    it("should work with expect to.not.be syntax", () => {
+        expect(123).to.not.be.instanceOf(Date);
+        expect("hello").to.not.be.an.instanceOf(Array);
+        expect({}).to.not.be.an.instanceOf(RegExp);
+    });
+});
+
+describe("expect chaining with instanceof", () => {
+    
+    it("should support is.instanceOf", () => {
+        expect(new Date()).is.instanceOf(Date);
+        expect([]).is.instanceOf(Array);
+    });
+
+    it("should support to.be.instanceof", () => {
+        expect(new Date()).to.be.instanceOf(Date);
+        expect([]).to.be.instanceOf(Array);
+    });
+
+    it("should support is.a.instanceof", () => {
+        expect(new Date()).is.a.instanceOf(Date);
+    });
+
+    it("should support is.an.instanceof", () => {
+        expect([]).is.an.instanceOf(Array);
+    });
+
+    it("should support not.instanceof", () => {
+        expect(123).is.not.instanceOf(String);
+        expect("hello").is.not.instanceOf(Number);
+    });
+
+    it("should throw for failed instanceof check", () => {
+        expect(() => {
+            expect(123).is.instanceOf(Date);
+        }).to.throw(AssertionFailure);
+    });
+
+    it("should throw for failed not.instanceof check", () => {
+        expect(() => {
+            expect(new Date()).is.not.instanceOf(Date);
+        }).to.throw(AssertionFailure);
+    });
+});
+
+describe("constructor parameter validation", () => {
+
+    it("should throw when constructor is a number", () => {
+        expect(() => {
+            assert.isInstanceOf(new Date(), 123 as any);
+        }).to.throw(AssertionFailure, /constructor to be a function, got number/);
+    });
+
+    it("should throw when constructor is a string", () => {
+        expect(() => {
+            assert.isInstanceOf(new Date(), "Date" as any);
+        }).to.throw(AssertionFailure, /constructor to be a function, got string/);
+    });
+
+    it("should throw when constructor is a boolean", () => {
+        expect(() => {
+            assert.isInstanceOf(new Date(), true as any);
+        }).to.throw(AssertionFailure, /constructor to be a function, got boolean/);
+    });
+
+    it("should throw when constructor is null", () => {
+        expect(() => {
+            assert.isInstanceOf(new Date(), null as any);
+        }).to.throw(AssertionFailure, /constructor to be a function, got object/);
+    });
+
+    it("should throw when constructor is undefined", () => {
+        expect(() => {
+            assert.isInstanceOf(new Date(), undefined as any);
+        }).to.throw(AssertionFailure, /constructor to be a function, got undefined/);
+    });
+
+    it("should throw when constructor is a plain object", () => {
+        expect(() => {
+            assert.isInstanceOf(new Date(), {} as any);
+        }).to.throw(AssertionFailure, /constructor to be a function, got object/);
+    });
+
+    it("should throw when constructor is a symbol", () => {
+        expect(() => {
+            assert.isInstanceOf(new Date(), Symbol() as any);
+        }).to.throw(AssertionFailure, /constructor to be a function, got symbol/);
+    });
+
+    it("should throw with custom message when constructor is invalid", () => {
+        expect(() => {
+            assert.isInstanceOf(new Date(), 123 as any, "Custom validation message");
+        }).to.throw(AssertionFailure, /Custom validation message/);
+    });
+});
+
+describe("instanceof edge cases", () => {
+
+    it("should handle inheritance correctly", () => {
+        class Parent {}
+        class Child extends Parent {}
+        
+        let child = new Child();
+        
+        assert.isInstanceOf(child, Child);
+        assert.isInstanceOf(child, Parent); // Child is also instance of Parent
+        assert.isInstanceOf(child, Object); // Everything is instance of Object
+    });
+
+    it("should handle Error subclasses", () => {
+        let typeError = new TypeError("test");
+        
+        assert.isInstanceOf(typeError, TypeError);
+        assert.isInstanceOf(typeError, Error); // TypeError extends Error
+        assert.isInstanceOf(typeError, Object);
+    });
+
+    it("should handle built-in types", () => {
+        assert.isInstanceOf(new String("test"), String);
+        assert.isInstanceOf(new Number(123), Number);
+        assert.isInstanceOf(new Boolean(true), Boolean);
+    });
+
+    it("should handle function constructors", () => {
+        function MyConstructor() {}
+        let instance = new (MyConstructor as any)();
+        
+        assert.isInstanceOf(instance, MyConstructor as any);
+    });
+
+    it("should handle anonymous constructors", () => {
+        let AnonymousClass = class {};
+        let instance = new AnonymousClass();
+        
+        assert.isInstanceOf(instance, AnonymousClass);
+    });
+});

--- a/core/test/src/assert/assert.isIterable.test.ts
+++ b/core/test/src/assert/assert.isIterable.test.ts
@@ -6,10 +6,9 @@
  * Licensed under the MIT license.
  */
 
-import { getKnownSymbol } from "@nevware21/ts-utils";
+import { getKnownSymbol, WellKnownSymbols } from "@nevware21/ts-utils";
 import { assert } from "../../../src/assert/assertClass";
 import { checkError } from "../support/checkError";
-import { WellKnownSymbols } from "@nevware21/ts-utils";
 
 describe("assert.isIterable", function () {
     it("examples", function () {

--- a/shim/chai/src/assert/chaiAssert.ts
+++ b/shim/chai/src/assert/chaiAssert.ts
@@ -101,8 +101,8 @@ function _createChaiAssert(): IChaiAssert {
         isNotBoolean: "is.not.boolean",
         typeOf: { scopeFn: createExprAdapter("is.typeOf"), nArgs: 2 },
         notTypeOf: { scopeFn: createExprAdapter("is.not.typeOf"), nArgs: 2 },
-        instanceOf: notImplemented, // TODO: Implement instanceOf in tripwire core
-        notInstanceOf: notImplemented, // TODO: Implement notInstanceOf in tripwire core
+        instanceOf: { scopeFn: createExprAdapter("is.instanceOf"), nArgs: 2 },
+        notInstanceOf: { scopeFn: createExprAdapter("is.not.instanceOf"), nArgs: 2 },
         include: { scopeFn: createExprAdapter("include"), nArgs: 2 },
         notInclude: { scopeFn: createExprAdapter("not.include"), nArgs: 2 },
         deepInclude: { scopeFn: createExprAdapter("deep.include"), nArgs: 2 },

--- a/shim/chai/src/assert/chaiExpect.ts
+++ b/shim/chai/src/assert/chaiExpect.ts
@@ -22,7 +22,7 @@ import { IChaiAssert } from "./interfaces/IChaiAssert";
  *
  * @param value The value to create the context object with.
  * @param initMsg The message to create the context object with.
- * @throws {AssertionError} Always throws indicating the feature is not implemented.
+ * @throws An {@link AssertionError} always throws indicating the feature is not implemented.
  * @see chaiAssert for the implemented assert-style API
  */
 export function chaiExpect<T>(value: T, initMsg?: string): IChaiAssert {

--- a/shim/chai/test/src/chaiAssert.test.ts
+++ b/shim/chai/test/src/chaiAssert.test.ts
@@ -196,123 +196,119 @@ describe("assert", function () {
         }, "blah: not expected [Function] to be of type function");
     });
 
-    // it("instanceOf", function() {
-    //     class Foo {}
-    //     assert.instanceOf(new Foo(), Foo);
+    it("instanceOf", function() {
+        class Foo {}
+        assert.instanceOf(new Foo(), Foo);
 
-    //     // Normally, `instanceof` requires that the constructor be a function or an
-    //     // object with a callable `@@hasInstance`. But in some older browsers such
-    //     // as IE11, `instanceof` also accepts DOM-related interfaces such as
-    //     // `HTMLElement`, despite being non-callable objects in those browsers.
-    //     // See: https://github.com/chaijs/chai/issues/1000.
-    //     if (typeof document !== "undefined" &&
-    //     typeof document.createElement !== "undefined" &&
-    //     typeof HTMLElement !== "undefined") {
-    //         assert.instanceOf(document.createElement("div"), HTMLElement);
-    //     }
+        // Normally, `instanceof` requires that the constructor be a function or an
+        // object with a callable `@@hasInstance`. But in some older browsers such
+        // as IE11, `instanceof` also accepts DOM-related interfaces such as
+        // `HTMLElement`, despite being non-callable objects in those browsers.
+        // See: https://github.com/chaijs/chai/issues/1000.
+        if (typeof document !== "undefined" &&
+        typeof document.createElement !== "undefined" &&
+        typeof HTMLElement !== "undefined") {
+            assert.instanceOf(document.createElement("div"), HTMLElement);
+        }
 
-    //     err(function(){
-    //         assert.instanceOf(new Foo(), 1, "blah");
-    //     }, "blah: The instanceof assertion needs a constructor but Number was given.");
+        err(function(){
+            assert.instanceOf(new Foo(), 1 as any, "blah");
+        }, /blah:.*constructor to be a function/);
 
-    //     err(function(){
-    //         assert.instanceOf(new Foo(), "batman");
-    //     }, "The instanceof assertion needs a constructor but String was given.");
+        err(function(){
+            assert.instanceOf(new Foo(), "batman" as any);
+        }, /constructor to be a function/);
 
-    //     err(function(){
-    //         assert.instanceOf(new Foo(), {});
-    //     }, "The instanceof assertion needs a constructor but Object was given.");
+        err(function(){
+            assert.instanceOf(new Foo(), {} as any);
+        }, /constructor to be a function/);
 
-    //     err(function(){
-    //         assert.instanceOf(new Foo(), true);
-    //     }, "The instanceof assertion needs a constructor but Boolean was given.");
+        err(function(){
+            assert.instanceOf(new Foo(), true as any);
+        }, /constructor to be a function/);
 
-    //     err(function(){
-    //         assert.instanceOf(new Foo(), null);
-    //     }, "The instanceof assertion needs a constructor but null was given.");
+        err(function(){
+            assert.instanceOf(new Foo(), null as any);
+        }, /constructor to be a function/);
 
-    //     err(function(){
-    //         assert.instanceOf(new Foo(), undefined);
-    //     }, "The instanceof assertion needs a constructor but undefined was given.");
+        err(function(){
+            assert.instanceOf(new Foo(), undefined as any);
+        }, /constructor to be a function/);
+        err(function(){
+            function Thing(){}
+            var t = new (Thing as any)();
+            (Thing as any).prototype = 1337;
+            assert.instanceOf(t, Thing as any);
+        }, /non-object prototype/, true);
 
-    //     err(function(){
-    //         function Thing(){}
-    //         var t = new Thing();
-    //         Thing.prototype = 1337;
-    //         assert.instanceOf(t, Thing);
-    //     }, "The instanceof assertion needs a constructor but Function was given.", true);
+        err(function(){
+            assert.instanceOf(new Foo(), Symbol() as any);
+        }, /constructor to be a function/);
 
-    //     err(function(){
-    //         assert.instanceOf(new Foo(), Symbol());
-    //     }, "The instanceof assertion needs a constructor but Symbol was given.");
+        err(function() {
+            var FakeConstructor: any = {};
+            var fakeInstanceB = 4;
+            FakeConstructor[Symbol.hasInstance] = function (val: any) {
+                return val === 3;
+            };
 
-    //     err(function() {
-    //         var FakeConstructor = {};
-    //         var fakeInstanceB = 4;
-    //         FakeConstructor[Symbol.hasInstance] = function (val) {
-    //             return val === 3;
-    //         };
+            assert.instanceOf(fakeInstanceB, FakeConstructor);
+        }, /constructor to be a function/);
 
-    //         assert.instanceOf(fakeInstanceB, FakeConstructor);
-    //     }, "expected 4 to be an instance of an unnamed constructor")
+        err(function () {
+            assert.instanceOf(5, Foo, "blah");
+        }, /blah:.*expected 5 to be an instance of/);
 
-    //     err(function () {
-    //         assert.instanceOf(5, Foo, "blah");
-    //     }, "blah: expected 5 to be an instance of Foo");
+        function CrashyObject() {}
+        CrashyObject.prototype.inspect = function () {
+            throw new Error("Arg's inspect() called even though the test passed");
+        };
+        assert.instanceOf(new (CrashyObject as any)(), CrashyObject as any);
+    });
 
-    //     function CrashyObject() {}
-    //     CrashyObject.prototype.inspect = function () {
-    //         throw new Error("Arg's inspect() called even though the test passed");
-    //     };
-    //     assert.instanceOf(new CrashyObject(), CrashyObject);
-    // });
+    it("notInstanceOf", function () {
+        function Foo(){}
+        assert.notInstanceOf(new (Foo as any)(), String);
 
-    // it("notInstanceOf", function () {
-    //     function Foo(){}
-    //     assert.notInstanceOf(new Foo(), String);
+        err(function(){
+            assert.notInstanceOf(new (Foo as any)(), 1 as any, "blah");
+        }, /blah:.*constructor to be a function/);
 
-    //     err(function(){
-    //         assert.notInstanceOf(new Foo(), 1, "blah");
-    //     }, "blah: The instanceof assertion needs a constructor but Number was given.");
+        err(function(){
+            assert.notInstanceOf(new (Foo as any)(), "batman" as any);
+        }, /constructor to be a function/);
+        err(function(){
+            assert.notInstanceOf(new (Foo as any)(), {} as any);
+        }, /constructor to be a function/);
 
-    //     err(function(){
-    //         assert.notInstanceOf(new Foo(), "batman");
-    //     }, "The instanceof assertion needs a constructor but String was given.");
+        err(function(){
+            assert.notInstanceOf(new (Foo as any)(), true as any);
+        }, /constructor to be a function/);
+        err(function(){
+            assert.notInstanceOf(new (Foo as any)(), null as any);
+        }, /constructor to be a function/);
 
-    //     err(function(){
-    //         assert.notInstanceOf(new Foo(), {});
-    //     }, "The instanceof assertion needs a constructor but Object was given.");
+        err(function(){
+            assert.notInstanceOf(new (Foo as any)(), undefined as any);
+        }, /constructor to be a function/);
+        err(function(){
+            assert.notInstanceOf(new (Foo as any)(), Symbol() as any);
+        }, /constructor to be a function/);
 
-    //     err(function(){
-    //         assert.notInstanceOf(new Foo(), true);
-    //     }, "The instanceof assertion needs a constructor but Boolean was given.");
+        err(function() {
+            var FakeConstructor: any = {};
+            var fakeInstanceB = 4;
+            FakeConstructor[Symbol.hasInstance] = function (val: any) {
+                return val === 4;
+            };
 
-    //     err(function(){
-    //         assert.notInstanceOf(new Foo(), null);
-    //     }, "The instanceof assertion needs a constructor but null was given.");
+            assert.notInstanceOf(fakeInstanceB, FakeConstructor);
+        }, /constructor to be a function/);
 
-    //     err(function(){
-    //         assert.notInstanceOf(new Foo(), undefined);
-    //     }, "The instanceof assertion needs a constructor but undefined was given.");
-
-    //     err(function(){
-    //         assert.notInstanceOf(new Foo(), Symbol());
-    //     }, "The instanceof assertion needs a constructor but Symbol was given.");
-
-    //     err(function() {
-    //         var FakeConstructor = {};
-    //         var fakeInstanceB = 4;
-    //         FakeConstructor[Symbol.hasInstance] = function (val) {
-    //             return val === 4;
-    //         };
-
-    //         assert.notInstanceOf(fakeInstanceB, FakeConstructor);
-    //     }, "expected 4 to not be an instance of an unnamed constructor");
-
-    //     err(function () {
-    //         assert.notInstanceOf(new Foo(), Foo, "blah");
-    //     }, "blah: expected Foo{} to not be an instance of Foo");
-    // });
+        err(function () {
+            assert.notInstanceOf(new (Foo as any)(), Foo as any, "blah");
+        }, /blah:.*not expected .* to be an instance of/);
+    });
 
     it("isObject", function () {
         class Foo{


### PR DESCRIPTION
Add support for instanceOf/notInstanceOf assertions to check if values are instances of specific constructors.

Changes:
- Add core instanceOfFunc implementation with JavaScript instanceof operator
- Add assert.isInstanceOf() and assert.isNotInstanceOf() methods
- Add expect().is.instanceOf() and expect().is.not.instanceOf() support
- Add ITypeOp.instanceOf interface definition and InstanceOfFn type
- Register instanceOf operation in isOp scope
- Enable instanceOf/notInstanceOf in Chai compatibility shim
- Export InstanceOfFn type from public API

The implementation validates that constructors are functions, uses the native instanceof operator for type checking, and supports inheritance chains. Works across node, browser, and worker environments.