### PR TITLE
feat: implement exists/notExists assertions

### DIFF
--- a/core/src/assert/assertClass.ts
+++ b/core/src/assert/assertClass.ts
@@ -216,13 +216,10 @@ export function createAssert(): IAssertClass {
         isFinite: createExprAdapter("is.finite"),
         isNotFinite: createExprAdapter("not.is.finite"),
 
-        /**
-         * @since 0.1.5
-         */
+        exists: createExprAdapter("to.exist"),
+        notExists: createExprAdapter("not.to.exist"),
+
         isInstanceOf: { scopeFn: instanceOfFunc, nArgs: 2 },
-        /**
-         * @since 0.1.5
-         */
         isNotInstanceOf: { scopeFn: createExprAdapter("not", instanceOfFunc), nArgs: 2 },
             
         throws: { scopeFn: throwsFunc, nArgs: 3 },

--- a/core/src/assert/funcs/exists.ts
+++ b/core/src/assert/funcs/exists.ts
@@ -1,0 +1,40 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { isNullOrUndefined } from "@nevware21/ts-utils";
+import { IAssertScope } from "../interface/IAssertScope";
+import { MsgSource } from "../interface/types";
+
+/**
+ * Asserts that the target is not null and not undefined.
+ * @since 0.1.5
+ * @param this - The assert scope.
+ * @param evalMsg - The message to display if the assertion fails.
+ * @returns - The assert scope.
+ * @example
+ * ```typescript
+ * import { assert } from "@nevware21/tripwire";
+ *
+ * assert(0).to.exist();          // Passes - 0 is not null or undefined
+ * assert("").to.exist();         // Passes - empty string exists
+ * assert(false).to.exist();      // Passes - false exists
+ * assert(null).to.not.exist();   // Passes - null does not exist
+ * assert(undefined).to.not.exist(); // Passes - undefined does not exist
+ * ```
+ */
+export function existsFunc<R>(this: IAssertScope, evalMsg?: MsgSource): R {
+    let context = this.context;
+    let value = context.value;
+
+    context.eval(
+        !isNullOrUndefined(value),
+        evalMsg || "expected {value} to exist (not null or undefined)"
+    );
+
+    return this.that;
+}

--- a/core/src/assert/interface/IAssertClass.ts
+++ b/core/src/assert/interface/IAssertClass.ts
@@ -1134,6 +1134,44 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
     isNotFinite(value: any, initMsg?: MsgSource): AssertInst;
 
     /**
+     * Asserts that the given value exists (is not null and not undefined).
+     *
+     * @since 0.1.5
+     * @param value - The value to check.
+     * @param initMsg - The message to display if the assertion fails.
+     * @asserts That the `value` is not null and not undefined and throws {@link AssertionFailure} if it is.
+     * @example
+     * ```typescript
+     * assert.exists(0); // Passes - 0 is not null or undefined
+     * assert.exists(""); // Passes - empty string exists
+     * assert.exists(false); // Passes - false exists
+     * assert.exists([]); // Passes - arrays exist
+     * assert.exists({}); // Passes - objects exist
+     * assert.exists(null); // Throws AssertionFailure
+     * assert.exists(undefined); // Throws AssertionFailure
+     * ```
+     */
+    exists(value: any, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the given value does not exist (is null or undefined).
+     *
+     * @since 0.1.5
+     * @param value - The value to check.
+     * @param initMsg - The message to display if the assertion fails.
+     * @asserts That the `value` is null or undefined and throws {@link AssertionFailure} if it is not.
+     * @example
+     * ```typescript
+     * assert.notExists(null); // Passes
+     * assert.notExists(undefined); // Passes
+     * assert.notExists(0); // Throws AssertionFailure
+     * assert.notExists(""); // Throws AssertionFailure
+     * assert.notExists(false); // Throws AssertionFailure
+     * ```
+     */
+    notExists(value: any, initMsg?: MsgSource): AssertInst;
+
+    /**
      * Asserts that the given value's type matches the expected type string.
      * Uses the JavaScript `typeof` operator for type comparison.
      *

--- a/core/src/assert/interface/ops/IToOp.ts
+++ b/core/src/assert/interface/ops/IToOp.ts
@@ -14,6 +14,7 @@ import { IIncludeOp } from "./IIncludeOp";
 import { IIsOp } from "./IIsOp";
 import { INotOp } from "./INotOp";
 import { IStrictlyOp } from "./IStrictlyOp";
+import { AssertFn } from "../funcs/AssertFn";
 
 /**
  * Represents an interface for operations that can be performed on an assertion scope.
@@ -22,6 +23,21 @@ import { IStrictlyOp } from "./IStrictlyOp";
  * @template R - The type of the result of the operation.
  */
 export interface IToOp<R> extends INotOp<IToOp<R>> {
+
+    /**
+     * Asserts that the target exists (is not null and not undefined).
+     *
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * expect(0).to.exist();          // Passes - 0 is not null or undefined
+     * expect("").to.exist();         // Passes - empty string exists
+     * expect(false).to.exist();      // Passes - false exists
+     * expect(null).to.not.exist();   // Passes - null does not exist
+     * expect(undefined).to.not.exist(); // Passes - undefined does not exist
+     * ```
+     */
+    exist: AssertFn<R>;
 
     /**
      * Provides access to operations that can be performed on the assertion scope,

--- a/core/src/assert/ops/toOp.ts
+++ b/core/src/assert/ops/toOp.ts
@@ -17,6 +17,7 @@ import { matchFunc } from "../funcs/match";
 import { includeOp } from "./includeOp";
 import { strictlyOp } from "./strictlyOp";
 import { deepOp } from "./deepOp";
+import { existsFunc } from "../funcs/exists";
 
 export function toOp<R>(scope: IAssertScope): IToOp<R> {
 
@@ -31,7 +32,8 @@ export function toOp<R>(scope: IAssertScope): IToOp<R> {
         contains: { propFn: includeOp },
         strictly: { propFn: strictlyOp },
         match: { scopeFn: matchFunc },
-        throw: { scopeFn: throwsFunc }
+        throw: { scopeFn: throwsFunc },
+        exist: { scopeFn: existsFunc }
     };
     
     return scope.createOperation(props);

--- a/core/test/src/assert/assert.exists.test.ts
+++ b/core/test/src/assert/assert.exists.test.ts
@@ -1,0 +1,171 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { assert } from "../../../src/assert/assertClass";
+import { expect } from "../../../src/assert/expect";
+import { checkError } from "../support/checkError";
+
+describe("assert.exists", () => {
+    describe("basic functionality", () => {
+        it("should pass for non-null and non-undefined values", () => {
+            assert.exists(0);
+            assert.exists("");
+            assert.exists(false);
+            assert.exists([]);
+            assert.exists({});
+            assert.exists("hello");
+            assert.exists(123);
+            assert.exists(true);
+        });
+
+        it("should fail for null", () => {
+            checkError(() => assert.exists(null), "expected null to exist (not null or undefined)");
+        });
+
+        it("should fail for undefined", () => {
+            checkError(() => assert.exists(undefined), "expected undefined to exist (not null or undefined)");
+        });
+
+        it("should work with custom message", () => {
+            checkError(() => assert.exists(null, "Value should exist"), "Value should exist");
+        });
+    });
+
+    describe("expect syntax", () => {
+        it("should work with expect syntax", () => {
+            expect(0).to.exist();
+            expect("").to.exist();
+            expect(false).to.exist();
+            expect([]).to.exist();
+            expect({}).to.exist();
+        });
+
+        it("should fail with null/undefined", () => {
+            checkError(() => expect(null).to.exist(), "expected null to exist (not null or undefined)");
+            checkError(() => expect(undefined).to.exist(), "expected undefined to exist (not null or undefined)");
+        });
+
+        it("should work with negation", () => {
+            expect(null).to.not.exist();
+            expect(undefined).to.not.exist();
+        });
+
+        it("negation should fail for existing values", () => {
+            checkError(() => expect(0).to.not.exist(), "not expected 0 to exist (not null or undefined)");
+            checkError(() => expect("").to.not.exist(), "not expected \"\" to exist (not null or undefined)");
+            checkError(() => expect(false).to.not.exist(), "not expected false to exist (not null or undefined)");
+        });
+    });
+
+    describe("edge cases", () => {
+        it("should pass for empty collections", () => {
+            assert.exists([]);
+            assert.exists({});
+            assert.exists(new Map());
+            assert.exists(new Set());
+        });
+
+        it("should pass for zero and empty string", () => {
+            assert.exists(0);
+            assert.exists("");
+            assert.exists(false);
+        });
+
+        it("should pass for NaN", () => {
+            assert.exists(NaN);
+        });
+
+        it("should pass for Infinity", () => {
+            assert.exists(Infinity);
+            assert.exists(-Infinity);
+        });
+
+        it("should pass for functions", () => {
+            assert.exists(() => {});
+            assert.exists(function() {});
+            assert.exists(async () => {});
+        });
+
+        it("should pass for symbols", () => {
+            assert.exists(Symbol("test"));
+            assert.exists(Symbol.iterator);
+        });
+    });
+});
+
+describe("assert.notExists", () => {
+    describe("basic functionality", () => {
+        it("should pass for null and undefined", () => {
+            assert.notExists(null);
+            assert.notExists(undefined);
+        });
+
+        it("should fail for non-null and non-undefined values", () => {
+            checkError(() => assert.notExists(0), "not expected 0 to exist (not null or undefined)");
+            checkError(() => assert.notExists(""), "not expected \"\" to exist (not null or undefined)");
+            checkError(() => assert.notExists(false), "not expected false to exist (not null or undefined)");
+            checkError(() => assert.notExists([]), "not expected [] to exist (not null or undefined)");
+            checkError(() => assert.notExists({}), "not expected {} to exist (not null or undefined)");
+        });
+
+        it("should work with custom message", () => {
+            checkError(() => assert.notExists(0, "Value should not exist"), "Value should not exist");
+        });
+    });
+
+    describe("expect syntax", () => {
+        it("should work with expect syntax", () => {
+            expect(null).to.not.exist();
+            expect(undefined).to.not.exist();
+        });
+
+        it("should fail for existing values", () => {
+            checkError(() => expect(0).to.not.exist(), "not expected 0 to exist (not null or undefined)");
+            checkError(() => expect("").to.not.exist(), "not expected \"\" to exist (not null or undefined)");
+            checkError(() => expect(false).to.not.exist(), "not expected false to exist (not null or undefined)");
+        });
+    });
+});
+
+describe("exists combinations", () => {
+    it("should work with other assertions", () => {
+        expect(123).to.exist();
+        expect(123).is.number();
+        
+        expect("test").to.exist();
+        expect("test").is.string();
+        
+        expect([1, 2, 3]).to.exist();
+        expect([1, 2, 3]).is.array();
+    });
+
+    it("should work in conditional checks", () => {
+        let value: any = "hello";
+
+        expect(value).to.exist();
+        
+        value = null;
+        expect(value).to.not.exist();
+    });
+
+    it("should differentiate from empty checks", () => {
+        // exists passes for empty values
+        expect("").to.exist();
+        expect("").is.empty();
+        
+        expect([]).to.exist();
+        expect([]).is.empty();
+        
+        expect({}).to.exist();
+        expect({}).is.empty();
+        
+        // null/undefined fail exists but are considered empty in some contexts
+        expect(null).to.not.exist();
+        expect(undefined).to.not.exist();
+    });
+});

--- a/shim/chai/src/assert/chaiAssert.ts
+++ b/shim/chai/src/assert/chaiAssert.ts
@@ -80,8 +80,8 @@ function _createChaiAssert(): IChaiAssert {
         isNaN: "is.nan",
         isNotNaN: "is.not.nan",
 
-        exists: notImplemented, // TODO: Implement exists in tripwire core
-        notExists: notImplemented, // TODO: Implement notExists in tripwire core
+        exists: "to.exist",
+        notExists: "to.not.exist",
         isUndefined: "is.undefined",
         isDefined: "is.not.undefined",
         isFunction: "is.function",

--- a/shim/chai/test/src/chaiAssert.test.ts
+++ b/shim/chai/test/src/chaiAssert.test.ts
@@ -508,30 +508,30 @@ describe("assert", function () {
         }, "blah: not expected NaN to be NaN");
     });
 
-    // it("exists", function() {
-    //     var meeber = "awesome";
-    //     var iDoNotExist: any;
+    it("exists", function() {
+        var meeber = "awesome";
+        var iDoNotExist: any;
 
-    //     assert.exists(meeber);
-    //     assert.exists(0);
-    //     assert.exists(false);
-    //     assert.exists("");
+        assert.exists(meeber);
+        assert.exists(0);
+        assert.exists(false);
+        assert.exists("");
 
-    //     err(function (){
-    //         assert.exists(iDoNotExist, "blah");
-    //     }, "blah: expected undefined to exist");
-    // });
+        err(function (){
+            assert.exists(iDoNotExist, "blah");
+        }, "blah: expected undefined to exist");
+    });
 
-    // it("notExists", function() {
-    //     var meeber = "awesome";
-    //     var iDoNotExist: any;
+    it("notExists", function() {
+        var meeber = "awesome";
+        var iDoNotExist: any;
 
-    //     assert.notExists(iDoNotExist);
+        assert.notExists(iDoNotExist);
 
-    //     err(function (){
-    //         assert.notExists(meeber, "blah");
-    //     }, "blah: expected \"awesome\" to not exist");
-    // });
+        err(function (){
+            assert.notExists(meeber, "blah");
+        }, "blah: not expected \"awesome\" to exist");
+    });
 
     it("isUndefined", function() {
         assert.isUndefined(undefined);


### PR DESCRIPTION
Add existence checking functionality to the tripwire assertion library with support for both assert methods and expect chain syntax.

Changes:
- Created existsFunc to check if values are not null/undefined
- Added exist property to IToOp interface for expect().to.exist() syntax
- Added exists() and notExists() methods to IAssertClass
- Registered exist in toOp with existsFunc implementation
- Implemented exists/notExists in Chai compatibility shim