### PR TITLE
feat: Add nested property operations with Chai compatibility

### DIFF
--- a/core/src/assert/assertClass.ts
+++ b/core/src/assert/assertClass.ts
@@ -20,6 +20,7 @@ import { IAssertClassDef } from "./interface/IAssertClassDef";
 import { matchFunc } from "./funcs/match";
 import { isErrorFunc, throwsFunc } from "./funcs/throws";
 import { hasPropertyFunc, hasOwnPropertyFunc, hasDeepPropertyFunc, hasDeepOwnPropertyFunc } from "./funcs/hasProperty";
+import { hasNestedPropertyFunc, hasDeepNestedPropertyFunc, nestedIncludeFunc, deepNestedIncludeFunc } from "./funcs/nested";
 import { AssertionError, AssertionFailure } from "./assertionError";
 import { createContext } from "./scopeContext";
 import { createAssertScope } from "./assertScope";
@@ -234,6 +235,16 @@ export function createAssert(): IAssertClass {
         notHasDeepProperty: { scopeFn: createExprAdapter("not", hasDeepPropertyFunc), nArgs: 3 },
         hasDeepOwnProperty: { scopeFn: hasDeepOwnPropertyFunc, nArgs: 3 },
         notHasDeepOwnProperty: { scopeFn: createExprAdapter("not", hasDeepOwnPropertyFunc), nArgs: 3 },
+
+        // Nested property operations
+        nestedProperty: { scopeFn: hasNestedPropertyFunc, nArgs: 3 },
+        notNestedProperty: { scopeFn: createExprAdapter("not", hasNestedPropertyFunc), nArgs: 3 },
+        deepNestedProperty: { scopeFn: hasDeepNestedPropertyFunc, nArgs: 3 },
+        notDeepNestedProperty: { scopeFn: createExprAdapter("not", hasDeepNestedPropertyFunc), nArgs: 3 },
+        nestedInclude: { scopeFn: nestedIncludeFunc, nArgs: 2 },
+        notNestedInclude: { scopeFn: createExprAdapter("not", nestedIncludeFunc), nArgs: 2 },
+        deepNestedInclude: { scopeFn: deepNestedIncludeFunc, nArgs: 2 },
+        notDeepNestedInclude: { scopeFn: createExprAdapter("not", deepNestedIncludeFunc), nArgs: 2 },
 
         // Numeric comparison operations
         isAbove: { scopeFn: aboveFunc, nArgs: 2 },

--- a/core/src/assert/config.ts
+++ b/core/src/assert/config.ts
@@ -36,7 +36,8 @@ const DEFAULT_CONFIG: IAssertConfig = (/* $__PURE__ */{
         finalizeFn: undefined,
         formatters: []
     },
-    circularMsg: () => cyan("[<Circular>]")
+    circularMsg: () => cyan("[<Circular>]"),
+    showDiff: true
 });
 
 function _mergeConfig(target: any, source: any) {

--- a/core/src/assert/funcs/hasProperty.ts
+++ b/core/src/assert/funcs/hasProperty.ts
@@ -150,7 +150,7 @@ export function hasPropertyFunc(this: IAssertScope, name: string | symbol | numb
         
         if (exists) {
             // Property exists - check the value using the negation-aware scope
-            scope.newScope(target[name]).exec(equalsFunc, [ value, evalMsg ]);
+            scope.newScope(target[name]).exec(equalsFunc, [ value, evalMsg || "expected {property} value {value} to equal {expected}" ]);
         } else {
             // Property doesn't exist - fail the assertion
             context.eval(false, evalMsg || "expected {value} to have a {property} property");
@@ -185,7 +185,7 @@ export function hasOwnPropertyFunc(this: IAssertScope, name: string | symbol | n
         
         if (exists) {
             // Own property exists - check the value using the negation-aware scope
-            scope.newScope(context.value[name]).exec(equalsFunc, [ value, evalMsg ]);
+            scope.newScope(context.value[name]).exec(equalsFunc, [ value, evalMsg || "expected {property} value {value} to equal {expected}" ]);
         } else {
             // Own property doesn't exist - fail the assertion
             context.eval(false, evalMsg || "expected {value} to have its own {property} property");
@@ -225,7 +225,7 @@ export function hasDeepPropertyFunc(this: IAssertScope, name: string | symbol | 
         
         if (exists) {
             // Property exists - check the value using deep equality with negation-aware scope
-            scope.newScope(target[name]).exec(deepEqualsFunc, [ value, evalMsg ]);
+            scope.newScope(target[name]).exec(deepEqualsFunc, [ value, evalMsg || "expected {property} value {value} to deeply equal {expected}" ]);
         } else {
             // Property doesn't exist - fail the assertion
             context.eval(false, evalMsg || "expected {value} to have a {property} property");
@@ -260,7 +260,7 @@ export function hasDeepOwnPropertyFunc(this: IAssertScope, name: string | symbol
         
         if (exists) {
             // Own property exists - check the value using deep equality with negation-aware scope
-            scope.newScope(context.value[name]).exec(deepEqualsFunc, [ value, evalMsg ]);
+            scope.newScope(context.value[name]).exec(deepEqualsFunc, [ value, evalMsg || "expected {property} value {value} to deeply equal {expected}" ]);
         } else {
             // Own property doesn't exist - fail the assertion
             context.eval(false, evalMsg || "expected {value} to have its own {property} property");

--- a/core/src/assert/funcs/nested.ts
+++ b/core/src/assert/funcs/nested.ts
@@ -1,0 +1,310 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { isArray, isObject, isString, isStrictNullOrUndefined, objKeys, objHasOwnProperty, asString } from "@nevware21/ts-utils";
+import { MsgSource } from "../interface/types";
+import { IAssertScope } from "../interface/IAssertScope";
+import { IPropertyResultOp } from "../interface/ops/IPropertyResultOp";
+import { propertyResultOp } from "../ops/propertyResultOp";
+
+export function _parseNestedPath(value: string): string[] {
+    let tokens: string[] = [];
+    let inEscape = false;
+    let lp = 0;
+
+    while (value && lp < value.length) {
+        let ch = value.charAt(lp++);
+        
+        if (!inEscape) {
+            if (ch === "\\") {
+                inEscape = true;
+            } else if (ch === ".") {
+                // Dot indicates a new token
+                tokens.push(value.substring(0, lp-1));
+                value = value.substring(lp);
+                lp = 0;
+            } else if (ch === "[") {
+                // Array indexer
+                let endIdx = value.indexOf("]", lp);
+                if (endIdx !== -1) {
+                    let indexer = value.substring(lp, endIdx);
+                    if (lp > 1) {
+                        tokens.push(value.substring(0, lp-1));
+                    }
+
+                    tokens.push(indexer);
+                    if (value.length > endIdx + 1 && value[endIdx + 1] === ".") {
+                        value = value.substring(endIdx + 2);
+                    } else {
+                        value = value.substring(endIdx + 1);
+                    }
+
+                    if (value.length === 0) {
+                        value = null;
+                    }
+
+                    lp = 0;
+                }
+            }
+        } else {
+            inEscape = false;
+            // remove the escape character
+            value = value.substring(0, lp-2) + ch + value.substring(lp);
+        }
+    }
+
+    if (value !== null) {
+        tokens.push(value);
+    }
+
+    return tokens;
+}
+
+/**
+ * Helper function to get a nested property value using dot notation
+ * @param target - The object to traverse
+ * @param path - The dot-separated path to the property
+ * @returns An object containing the value and a flag indicating if the property exists
+ */
+function _getNestedProperty(target: any, path: string): { value: any; exists: boolean } {
+    let result = false;
+    let current = target;
+
+    if (!isStrictNullOrUndefined(target)) {
+        let tokens = _parseNestedPath(asString(path));
+        let lp = 0;
+
+        result = true;
+        while (result && lp < tokens.length) {
+            let token = tokens[lp++];
+            
+            if (isStrictNullOrUndefined(current) || (!isObject(current) && !isArray(current)) || !(token in current)) {
+                result = false;
+            } else {
+                current = current[token];
+            }
+        }
+    }
+
+    return { value: result ? current : undefined, exists: result };
+}
+
+/**
+ * Simple deep equals helper for nested include
+ * @param a - First value
+ * @param b - Second value
+ * @returns True if values are deeply equal
+ */
+function _deepEquals(a: any, b: any): boolean {
+    if (a === b) {
+        return true;
+    }
+
+    if (isStrictNullOrUndefined(a) || isStrictNullOrUndefined(b)) {
+        return a === b;
+    }
+
+    if (typeof a !== typeof b) {
+        return false;
+    }
+
+    if (isArray(a) && isArray(b)) {
+        if (a.length !== b.length) {
+            return false;
+        }
+        for (let i = 0; i < a.length; i++) {
+            if (!_deepEquals(a[i], b[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    if (isObject(a) && isObject(b)) {
+        let keysA = objKeys(a);
+        let keysB = objKeys(b);
+        
+        if (keysA.length !== keysB.length) {
+            return false;
+        }
+
+        for (let key of keysA) {
+            if (!objHasOwnProperty(b, key)) {
+                return false;
+            }
+            if (!_deepEquals(a[key], b[key])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    return false;
+}
+
+/**
+ * Asserts that the current {@link IScopeContext} value has the specified nested property
+ * using dot notation (e.g., "a.b.c").
+ * @param this - The current {@link IAssertScope} assertion scope.
+ * @param path - The dot-separated path to the property.
+ * @param value - The expected value of the property (optional).
+ * @param evalMsg - The message to display if the assertion fails.
+ * @returns The new "instance" (object) to be used as the `this` for the chained operations.
+ * @throws An {@link AssertionFailure} if the nested property does not exist.
+ * @throws An {@link AssertionFailure} if the property value does not match the expected value (when provided).
+ * @since 0.1.5
+ */
+export function hasNestedPropertyFunc(this: IAssertScope, path: string, value?: any, evalMsg?: MsgSource): IPropertyResultOp {
+    let scope = this;
+    let context = scope.context;
+
+    context.set("property", path);
+
+    if (!isString(path)) {
+        context.fail(evalMsg || "expected {property} to be a string using nested syntax");
+    }
+
+    let valueResult = _getNestedProperty(context.value, path);
+
+    if (arguments.length > 1) {
+        context.set("expected", value);
+        if (valueResult.exists) {
+            context.set("nestedValue", valueResult.value);
+            context.eval(valueResult.value == value, evalMsg || "expected {value} to have a nested property {property} equal {expected}, but got {nestedValue}");
+        } else {
+            // Property doesn't exist - fail the assertion
+            context.eval(false, evalMsg || "expected {value} to have a nested property {property} equal {expected}");
+        }
+    } else {
+        // No value provided, just check property existence
+        context.eval(valueResult.exists, evalMsg || "expected {value} to have a nested property {property}");
+    }
+
+    return propertyResultOp(scope, valueResult.value);
+}
+
+/**
+ * Asserts that the current {@link IScopeContext} value has the specified nested property
+ * using dot notation and its value deeply equals the expected value.
+ * @param this - The current {@link IAssertScope} assertion scope.
+ * @param path - The dot-separated path to the property.
+ * @param value - The expected value of the property.
+ * @param evalMsg - The message to display if the assertion fails.
+ * @returns The new "instance" (object) to be used as the `this` for the chained operations.
+ * @throws An {@link AssertionFailure} if the nested property does not exist.
+ * @throws An {@link AssertionFailure} if the property value does not deeply equal the expected value.
+ * @since 0.1.5
+ */
+export function hasDeepNestedPropertyFunc(this: IAssertScope, path: string, value?: any, evalMsg?: MsgSource): IPropertyResultOp {
+    let scope = this;
+    let context = scope.context;
+
+    context.set("property", path);
+
+    if (!isString(path)) {
+        context.fail(evalMsg || "expected {property} to be a string using nested syntax");
+    }
+
+    let valueResult = _getNestedProperty(context.value, path);
+
+    if (arguments.length > 1) {
+        context.set("expected", value);
+        if (valueResult.exists) {
+            context.set("nestedValue", valueResult.value);
+            context.eval(valueResult.exists && _deepEquals(valueResult.value, value), evalMsg || "expected {value} to have a nested property {property} deeply equal {expected}, but got {nestedValue}");
+        } else {
+            // Property doesn't exist - fail the assertion
+            context.eval(false, evalMsg || "expected {value} to have a nested property {property} deeply equal {expected}");
+        }
+    } else {
+        // No value provided, just check property existence
+        context.eval(valueResult.exists, evalMsg || "expected {value} to have a nested property {property}");
+    }
+
+    return propertyResultOp(scope, valueResult.value);
+}
+
+/**
+ * Asserts that the value contains the expected using nested property matching.
+ * @param this - The current {@link IAssertScope} assertion scope.
+ * @param expected - The object with properties to match.
+ * @param evalMsg - The message to display if the assertion fails.
+ * @returns The assertion scope.
+ * @throws An {@link AssertionFailure} if the value does not contain the expected.
+ * @since 0.1.5
+ */
+export function nestedIncludeFunc(this: IAssertScope, expected: any, evalMsg?: MsgSource): any {
+    let scope = this;
+    let context = scope.context;
+    let value = context.value;
+
+    if (!isObject(expected)) {
+        context.set("expected", expected);
+        context.eval(false, evalMsg || "expected {expected} to be an object");
+        return scope.that;
+    }
+
+    // Check each property in expected against value
+    for (let key in expected) {
+        if (expected.hasOwnProperty(key)) {
+            let expectedValue = expected[key];
+            let valueResult = _getNestedProperty(value, key);
+
+            context.set("property", key);
+            context.set("expected", expectedValue);
+            if (valueResult.exists) {
+                context.set("nestedValue", valueResult.value);
+                context.eval(valueResult.exists && valueResult.value == expectedValue, evalMsg || "expected {value} to have a nested property {property} equal {expected}, but got {nestedValue}");
+            } else {
+                context.eval(false, evalMsg || "expected {value} to have a nested property {property} equal {expected}, but the property does not exist");
+            }
+        }
+    }
+
+    return scope.that;
+}
+
+/**
+ * Asserts that the value contains the expected using deep nested property matching.
+ * @param this - The current {@link IAssertScope} assertion scope.
+ * @param expected - The object with properties to match.
+ * @param evalMsg - The message to display if the assertion fails.
+ * @returns The assertion scope.
+ * @throws An {@link AssertionFailure} if the value does not contain the expected.
+ * @since 0.1.5
+ */
+export function deepNestedIncludeFunc(this: IAssertScope, expected: any, evalMsg?: MsgSource): any {
+    let scope = this;
+    let context = scope.context;
+    let value = context.value;
+
+    if (!isObject(expected)) {
+        context.set("expected", expected);
+        context.eval(false, evalMsg || "expected {expected} to be an object");
+        return scope.that;
+    }
+
+    // Check each property in expected against value
+    for (let key in expected) {
+        if (expected.hasOwnProperty(key)) {
+            let expectedValue = expected[key];
+            let valueResult = _getNestedProperty(value, key);
+
+            context.set("property", key);
+            context.set("expected", expectedValue);
+            if (valueResult.exists) {
+                context.set("nestedValue", valueResult.value);
+                context.eval(valueResult.exists && _deepEquals(valueResult.value, expectedValue), evalMsg || "expected {value} to have a nested property {property} deeply equal {expected}, but got {nestedValue}");
+            } else {
+                context.eval(false, evalMsg || "expected {value} to have a nested property {property} deeply equal {expected}, but the property does not exist");
+            }
+        }
+    }
+
+    return scope.that;
+}

--- a/core/src/assert/interface/IAssertClass.ts
+++ b/core/src/assert/interface/IAssertClass.ts
@@ -1545,6 +1545,157 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
     notHasDeepOwnProperty<T>(target: T, name: string, value: any, initMsg?: MsgSource): AssertInst;
 
     /**
+     * Asserts that the provided value has the specified nested property using dot notation
+     * (e.g., "a.b.c"). Optionally checks the property value using loose equality (==).
+     * If the value does not have the nested property or the value doesn't match,
+     * it throws an {@link AssertionFailure} with the given message.
+     *
+     * @param target - The value to evaluate.
+     * @param path - The dot-separated path to the property (e.g., "a.b.c").
+     * @param value - Optional. The expected value of the property (uses loose equality).
+     * @param initMsg - The message to display if the assertion fails.
+     * @asserts That the `value` has the specified nested property and throws {@link AssertionFailure} if it does not.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.nestedProperty({ a: { b: { c: 1 } } }, "a.b.c"); // Passes
+     * assert.nestedProperty({ a: { b: 2 } }, "a.b.c"); // Throws AssertionFailure
+     * assert.nestedProperty({ a: { b: { c: 1 } } }, "a.b.c", 1); // Passes
+     * assert.nestedProperty({ a: { b: { c: 1 } } }, "a.b.c", "1"); // Passes (loose equality)
+     * assert.nestedProperty({ a: { b: { c: 1 } } }, "a.b.c", 2); // Throws AssertionFailure
+     * ```
+     */
+    nestedProperty<T>(target: T, path: string, value?: any, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the provided value does NOT have the specified nested property using dot notation,
+     * or if a value is provided, that the nested property value does NOT match using loose equality (==).
+     *
+     * @param target - The value to evaluate.
+     * @param path - The dot-separated path to the property (e.g., "a.b.c").
+     * @param value - Optional. The value that should NOT match (uses loose equality).
+     * @param initMsg - The message to display if the assertion fails.
+     * @asserts That the `value` does not have the specified nested property (or value doesn't match) and throws {@link AssertionFailure} if it does.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.notNestedProperty({ a: { b: 2 } }, "a.b.c"); // Passes
+     * assert.notNestedProperty({ a: { b: { c: 1 } } }, "a.b.c"); // Throws AssertionFailure
+     * assert.notNestedProperty({ a: { b: { c: 1 } } }, "a.b.c", 2); // Passes
+     * assert.notNestedProperty({ a: { b: { c: 1 } } }, "a.b.c", 1); // Throws AssertionFailure
+     * ```
+     */
+    notNestedProperty<T>(target: T, path: string, value?: any, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the provided value has the specified nested property with a value that matches
+     * using deep equality.
+     *
+     * @param target - The value to evaluate.
+     * @param path - The dot-separated path to the property (e.g., "a.b.c").
+     * @param value - Optional. The expected value of the property (uses deep equality).
+     * @param initMsg - The message to display if the assertion fails.
+     * @asserts That the `value` has the specified nested property with matching deep value and throws {@link AssertionFailure} if it does not.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.deepNestedProperty({ a: { b: { c: { d: 1 } } } }, "a.b.c"); // Passes
+     * assert.deepNestedProperty({ a: { b: { c: { d: 1 } } } }, "a.b.c", { d: 1 }); // Passes
+     * assert.deepNestedProperty({ a: { b: { c: [1, 2, 3] } } }, "a.b.c", [1, 2, 3]); // Passes
+     * assert.deepNestedProperty({ a: { b: { c: { d: 1 } } } }, "a.b.c", { d: 2 }); // Throws AssertionFailure
+     * ```
+     */
+    deepNestedProperty<T>(target: T, path: string, value?: any, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the provided value does NOT have the specified nested property with a value that matches
+     * using deep equality.
+     *
+     * @param target - The value to evaluate.
+     * @param path - The dot-separated path to the property (e.g., "a.b.c").
+     * @param value - Optional. The value that should NOT match (uses deep equality).
+     * @param initMsg - The message to display if the assertion fails.
+     * @asserts That the `value` does not have the specified nested property with matching deep value and throws {@link AssertionFailure} if it does.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.notDeepNestedProperty({ a: { b: { c: { d: 1 } } } }, "a.b.d"); // Passes (property doesn't exist)
+     * assert.notDeepNestedProperty({ a: { b: { c: { d: 1 } } } }, "a.b.d", { d: 1 }); // Passes (property doesn't exist)
+     * assert.notDeepNestedProperty({ a: { b: { c: { d: 1 } } } }, "a.b.c", { d: 2 }); // Passes (value doesn't match)
+     * assert.notDeepNestedProperty({ a: { b: { c: { d: 1 } } } }, "a.b.c", { d: 1 }); // Throws AssertionFailure
+     * ```
+     */
+    notDeepNestedProperty<T>(target: T, path: string, value?: any, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the value contains the expected using nested property matching.
+     * Each property in the expected is matched against the value using dot notation.
+     *
+     * @param value - The object to search in.
+     * @param expected - The object with properties to match (can use dot notation for keys).
+     * @param initMsg - The message to display if the assertion fails.
+     * @asserts That the `value` contains the `expected` using nested property matching and throws {@link AssertionFailure} if it does not.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.nestedInclude({ a: { b: { c: 1 } } }, { 'a.b.c': 1 }); // Passes
+     * assert.nestedInclude({ a: { b: { c: 1 } }, d: 2 }, { 'a.b': { c: 1 } }); // Passes
+     * assert.nestedInclude({ a: { b: { c: 1 } } }, { 'a.b.c': 2 }); // Throws AssertionFailure
+     * ```
+     */
+    nestedInclude<T>(value: T, expected: any, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the value does NOT contain the expected using nested property matching.
+     *
+     * @param value - The object to search in.
+     * @param expected - The object with properties to match (can use dot notation for keys).
+     * @param initMsg - The message to display if the assertion fails.
+     * @asserts That the `value` does not contain the `expected` using nested property matching and throws {@link AssertionFailure} if it does.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.notNestedInclude({ a: { b: { c: 1 } } }, { 'a.b.c': 2 }); // Passes
+     * assert.notNestedInclude({ a: { b: { c: 1 } } }, { 'a.b.c': 1 }); // Throws AssertionFailure
+     * ```
+     */
+    notNestedInclude<T>(value: T, expected: any, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the value contains the expected using deep nested property matching.
+     * Each property in the expected is deeply compared against the value.
+     *
+     * @param value - The object to search in.
+     * @param expected - The object with properties to match (can use dot notation for keys).
+     * @param initMsg - The message to display if the assertion fails.
+     * @asserts That the `value` contains the `match` using deep nested property matching and throws {@link AssertionFailure} if it does not.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.deepNestedInclude({ a: { b: { c: { d: 1 } } } }, { 'a.b.c': { d: 1 } }); // Passes
+     * assert.deepNestedInclude({ a: { b: { c: [1, 2, 3] } } }, { 'a.b.c': [1, 2, 3] }); // Passes
+     * assert.deepNestedInclude({ a: { b: { c: { d: 1 } } } }, { 'a.b.c': { d: 2 } }); // Throws AssertionFailure
+     * ```
+     */
+    deepNestedInclude<T>(value: T, expected: any, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the value does NOT contain the expected using deep nested property matching.
+     *
+     * @param value - The object to search in.
+     * @param expected - The object with properties to match (can use dot notation for keys).
+     * @param initMsg - The message to display if the assertion fails.
+     * @asserts That the `value` does not contain the `expected` using deep nested property matching and throws {@link AssertionFailure} if it does.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.notDeepNestedInclude({ a: { b: { c: { d: 1 } } } }, { 'a.b.c': { d: 2 } }); // Passes
+     * assert.notDeepNestedInclude({ a: { b: { c: { d: 1 } } } }, { 'a.b.c': { d: 1 } }); // Throws AssertionFailure
+     * ```
+     */
+    notDeepNestedInclude<T>(value: T, expected: any, initMsg?: MsgSource): AssertInst;
+
+    /**
      * Asserts that the given value is greater than the expected value.
      *
      * This method checks if the provided value is numerically greater than the expected value.

--- a/core/src/assert/interface/IAssertConfig.ts
+++ b/core/src/assert/interface/IAssertConfig.ts
@@ -108,6 +108,14 @@ export interface IAssertConfig {
      * ```
      */
     circularMsg?: () => string;
+
+    /**
+     * Indicates whether to show the difference between expected and actual values
+     * in the error message.
+     * @default true
+     * @since 0.1.5
+     */
+    showDiff?: boolean;
 }
 
 export interface IAssertConfigDefaults extends IAssertConfig {

--- a/core/src/assert/interface/ops/IDeepOp.ts
+++ b/core/src/assert/interface/ops/IDeepOp.ts
@@ -12,6 +12,7 @@ import { IStrictlyOp } from "./IStrictlyOp";
 import { IEqualOp } from "./IEqualOp";
 import { IIncludeOp } from "./IIncludeOp";
 import { INotOp } from "./INotOp";
+import { INestedOp } from "./INestedOp";
 
 
 /**
@@ -64,4 +65,9 @@ export interface IDeepOp<R> extends INotOp<IDeepOp<R>>, IEqualOp<R> {
      * by the current assertion context value.
      */
     own: IOwnOp<R>;
+
+    /**
+     * Provides nested property operations using dot notation with deep equality.
+     */
+    nested: INestedOp<R>;
 }

--- a/core/src/assert/interface/ops/IHasOp.ts
+++ b/core/src/assert/interface/ops/IHasOp.ts
@@ -11,6 +11,7 @@ import { SymbolFn } from "../funcs/SymbolFn";
 import { IAllOp } from "./IAllOp";
 import { IAnyOp } from "./IAnyOp";
 import { IOwnOp } from "./IOwnOp";
+import { INestedOp } from "./INestedOp";
 
 /**
  * Provides the 'has' operation for the assert scope.
@@ -61,6 +62,16 @@ export interface IHasOp<R> {
      * ```
      */
     own: IOwnOp<R>;
+
+    /**
+     * Provides nested property operations using dot notation.
+     * @example
+     * ```typescript
+     * expect({ a: { b: { c: 1 } } }).has.nested.property('a.b.c');
+     * expect({ a: { b: { c: 1 } } }).to.have.nested.property('a.b.c', 1);
+     * ```
+     */
+    nested: INestedOp<R>;
 
     /**
      * Asserts that the object has the [Symbol.iterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/iterator)

--- a/core/src/assert/interface/ops/INestedOp.ts
+++ b/core/src/assert/interface/ops/INestedOp.ts
@@ -1,0 +1,77 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { MsgSource } from "../types";
+import { IPropertyResultOp } from "./IPropertyResultOp";
+
+/**
+ * Represents an interface that provides assertion operations for nested properties
+ * using dot notation (e.g., "a.b.c").
+ * @template R - The type of the result of the operation.
+ * @since 0.1.5
+ */
+export interface INestedOp<R> {
+    /**
+     * Asserts that the object has a nested property using dot notation.
+     * When a value is provided, also checks that the property value equals the expected value.
+     * @param path - The dot-separated path to the property (e.g., "a.b.c").
+     * @param value - The expected value of the property (optional).
+     * @param evalMsg - The message to display if the assertion fails.
+     * @returns The property result operation for chaining.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * expect({ a: { b: { c: 1 } } }).to.have.nested.property('a.b.c');
+     * expect({ a: { b: { c: 1 } } }).to.have.nested.property('a.b.c', 1);
+     * expect({ a: { b: 2 } }).to.not.have.nested.property('a.b.c');
+     * ```
+     */
+    property(path: string, value?: any, evalMsg?: MsgSource): IPropertyResultOp;
+
+    /**
+     * Asserts that the value contains the expected using nested property matching.
+     * Each property in the expected is matched against the value using dot notation.
+     * @param expected - The object with properties to match.
+     * @param evalMsg - The message to display if the assertion fails.
+     * @returns The assertion result.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * expect({ a: { b: { c: 1 } } }).to.nested.include({ 'a.b.c': 1 });
+     * expect({ a: { b: { c: 1 } }, d: 2 }).to.nested.include({ 'a.b': { c: 1 } });
+     * ```
+     */
+    include(expected: any, evalMsg?: MsgSource): R;
+
+    /**
+     * Alias for `include`.
+     * @param expected - The object with properties to match.
+     * @param evalMsg - The message to display if the assertion fails.
+     * @returns The assertion result.
+     * @since 0.1.5
+     */
+    includes(expected: any, evalMsg?: MsgSource): R;
+
+    /**
+     * Alias for `include`.
+     * @param expected - The object with properties to match.
+     * @param evalMsg - The message to display if the assertion fails.
+     * @returns The assertion result.
+     * @since 0.1.5
+     */
+    contain(expected: any, evalMsg?: MsgSource): R;
+
+    /**
+     * Alias for `include`.
+     * @param expected - The object with properties to match.
+     * @param evalMsg - The message to display if the assertion fails.
+     * @returns The assertion result.
+     * @since 0.1.5
+     */
+    contains(expected: any, evalMsg?: MsgSource): R;
+}

--- a/core/src/assert/ops/deepOp.ts
+++ b/core/src/assert/ops/deepOp.ts
@@ -16,6 +16,7 @@ import { deepStrictlyOp } from "./strictlyOp";
 import { hasDeepPropertyFunc, hasPropertyDescriptorFunc } from "../funcs/hasProperty";
 import { AssertScopeFuncDefs } from "../interface/IAssertInst";
 import { IAssertScope } from "../interface/IAssertScope";
+import { deepNestedOp } from "./nestedOp";
 
 export function deepOp<R>(scope: IAssertScope): IDeepOp<R> {
     scope.context.set(DEEP, true);
@@ -32,7 +33,8 @@ export function deepOp<R>(scope: IAssertScope): IDeepOp<R> {
         contains: { propFn: includeOp },
         property: { scopeFn: hasDeepPropertyFunc },
         propertyDescriptor: { scopeFn: hasPropertyDescriptorFunc },
-        own: { propFn: ownDeepOp }
+        own: { propFn: ownDeepOp },
+        nested: { propFn: deepNestedOp }
     };
 
     return scope.createOperation(props);

--- a/core/src/assert/ops/hasOp.ts
+++ b/core/src/assert/ops/hasOp.ts
@@ -13,6 +13,7 @@ import { allOp, allOwnOp, anyOp, anyOwnOp } from "./allOp";
 import { AssertScopeFuncDefs } from "../interface/IAssertInst";
 import { IAssertScope } from "../interface/IAssertScope";
 import { hasOwnSymbolFunc, hasSymbolFunc } from "../funcs/hasSymbol";
+import { nestedOp } from "./nestedOp";
 
 export function hasOp<R>(scope: IAssertScope): IHasOp<R> {
     let props: AssertScopeFuncDefs<IHasOp<R>> = {
@@ -21,6 +22,7 @@ export function hasOp<R>(scope: IAssertScope): IHasOp<R> {
         property: { scopeFn: hasPropertyFunc },
         propertyDescriptor: { scopeFn: hasPropertyDescriptorFunc},
         own: { propFn: ownOp },
+        nested: { propFn: nestedOp },
         iterator: { scopeFn: hasSymbolFunc(Symbol.iterator) }
     };
     
@@ -34,6 +36,7 @@ export function hasOwnOp<R>(scope: IAssertScope): IHasOp<R> {
         property: { scopeFn: hasOwnPropertyFunc },
         propertyDescriptor: { scopeFn: hasOwnPropertyDescriptorFunc},
         own: { propFn: ownOp },
+        nested: { propFn: nestedOp },
         iterator: { scopeFn: hasOwnSymbolFunc(Symbol.iterator) }
     };
     

--- a/core/src/assert/ops/includeOp.ts
+++ b/core/src/assert/ops/includeOp.ts
@@ -15,17 +15,17 @@ import { IAssertScope } from "../interface/IAssertScope";
 
 /**
  * Helper function to check if an array contains a deep equal item
- * @param haystack - The array to search in
- * @param needle - The item to search for
+ * @param items - The array to search in
+ * @param expected - The item to search for
  * @returns True if the item is found, false otherwise
  */
-function _deepIncludesArray(haystack: any[], needle: any[]): boolean {
-    for (let i = 0; i < haystack.length; i++) {
-        const item = haystack[i];
-        if (item.length === needle.length) {
+function _deepIncludesArray(items: any[], expected: any[]): boolean {
+    for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (item.length === expected.length) {
             let allEqual = true;
             for (let j = 0; j < item.length; j++) {
-                if (item[j] !== needle[j]) {
+                if (item[j] !== expected[j]) {
                     allEqual = false;
                     break;
                 }

--- a/core/src/assert/ops/nestedOp.ts
+++ b/core/src/assert/ops/nestedOp.ts
@@ -1,0 +1,51 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { INestedOp } from "../interface/ops/INestedOp";
+import { IAssertScope } from "../interface/IAssertScope";
+import { AssertScopeFuncDefs } from "../interface/IAssertInst";
+import { hasNestedPropertyFunc, nestedIncludeFunc, hasDeepNestedPropertyFunc, deepNestedIncludeFunc } from "../funcs/nested";
+
+/**
+ * Creates the nested assertion operation using the given scope.
+ * This provides operations for nested property checking using dot notation.
+ * @param scope - The current scope of the assert
+ * @returns - The {@link INestedOp} operation instance.
+ * @since 0.1.5
+ */
+export function nestedOp<R>(scope: IAssertScope): INestedOp<R> {
+    let props: AssertScopeFuncDefs<INestedOp<R>> = {
+        property: { scopeFn: hasNestedPropertyFunc },
+        include: { scopeFn: nestedIncludeFunc },
+        includes: { scopeFn: nestedIncludeFunc },
+        contain: { scopeFn: nestedIncludeFunc },
+        contains: { scopeFn: nestedIncludeFunc }
+    };
+    
+    return scope.createOperation(props);
+}
+
+/**
+ * Creates the deep nested assertion operation using the given scope.
+ * This provides operations for nested property checking with deep equality.
+ * @param scope - The current scope of the assert
+ * @returns - The {@link INestedOp} operation instance.
+ * @since 0.1.5
+ */
+export function deepNestedOp<R>(scope: IAssertScope): INestedOp<R> {
+    let props: AssertScopeFuncDefs<INestedOp<R>> = {
+        property: { scopeFn: hasDeepNestedPropertyFunc },
+        include: { scopeFn: deepNestedIncludeFunc },
+        includes: { scopeFn: deepNestedIncludeFunc },
+        contain: { scopeFn: deepNestedIncludeFunc },
+        contains: { scopeFn: deepNestedIncludeFunc }
+    };
+    
+    return scope.createOperation(props);
+}
+

--- a/core/src/assert/scopeContext.ts
+++ b/core/src/assert/scopeContext.ts
@@ -73,7 +73,7 @@ function _createStackTracker(parentstack?: Function[]): Function[] {
 
 /**
  * Returns the scope context for the given value, if it is an {@link IAssertInst}
- * instance it will return it's context, if it's a {@link IAssertScope} it will
+ * instance it will return its context, if it's a {@link IAssertScope} it will
  * return the context of the scope, if it's already a context it will return itself.
  * Otherwise it will create a new context with the value.
  * @param value - The value to get the context for.
@@ -185,7 +185,8 @@ export function createContext<T>(value?: T, initMsg?: MsgSource, stackStart?: Fu
         getDetails: function () {
             let _this = this;
             let details: any = {
-                actual: _this.value
+                actual: _this.value,
+                showDiff: theOptions.v.showDiff
             };
             arrForEach(_this.keys(), (key) => {
                 details[key] = _this.get(key);
@@ -221,7 +222,8 @@ export function createContext<T>(value?: T, initMsg?: MsgSource, stackStart?: Fu
 
             // Use the scope context during error throwing
             return useScope(_this, () => {
-                throw new AssertionFailure(_this.getMessage(msg), causedBy, details || _this.getDetails(), theStack);
+                let theDetails = details || _this.getDetails();
+                throw new AssertionFailure(_this.getMessage(msg), causedBy, theDetails, theStack);
             });
         },
         setOp: function (opName: string) {

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -33,6 +33,7 @@ import { IAnyOp } from "./assert/interface/ops/IAnyOp";
 import { IThrowOp } from "./assert/interface/ops/IThrowOp";
 import { IToOp } from "./assert/interface/ops/IToOp";
 import { ThrowFn } from "./assert/interface/funcs/ThrowFn";
+import { INestedOp } from "./assert/interface/ops/INestedOp";
 import { INotOp } from "./assert/interface/ops/INotOp";
 import { IHasOp } from "./assert/interface/ops/IHasOp";
 import { IIsTypeOp } from "./assert/interface/ops/ITypeOp";
@@ -75,9 +76,10 @@ export {
     IAllOp, IAnyOp, IAssertClass, IAssertClassDef, IAssertConfig, IAssertConfigDefaults,
     IAssertInst, IAssertInstCore, IAssertInstHandlers, IAssertScope, IAssertScopeFuncDef,
     IDeepOp, IEqualOp, IExtendedAssert, IExtendedAssertInst, IFormatCtx, IFormattedValue,
-    IFormatter, IFormatterOptions, IHasOp, IIncludeOp, IIsOp, IIsTypeOp, IKeysOp, INotOp,
-    INumericOp, IOwnOp, IPropertyResultOp, IRemovable, IScopeContext, IScopeContextOverrides,
-    IScopePropFn, IStrictlyOp, IThrowOp, IToOp, PropertyDescriptorFn, PropertyFn
+    IFormatter, IFormatterOptions, IHasOp, IIncludeOp, IIsOp, IIsTypeOp, IKeysOp, INestedOp,
+    INotOp, INumericOp, IOwnOp, IPropertyResultOp, IRemovable, IScopeContext,
+    IScopeContextOverrides, IScopePropFn, IStrictlyOp, IThrowOp, IToOp, PropertyDescriptorFn,
+    PropertyFn
 };
 
 /**

--- a/core/test/src/assert/assert.nested.test.ts
+++ b/core/test/src/assert/assert.nested.test.ts
@@ -1,0 +1,314 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2024-2026 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { assert } from "../../../src/assert/assertClass";
+import { expect } from "../../../src/assert/expect";
+import { checkError } from "../support/checkError";
+
+describe("Nested Property Operations", () => {
+
+    describe("nestedProperty", () => {
+        it("should pass when nested property exists", () => {
+            assert.nestedProperty({ a: { b: { c: 1 } } }, "a.b.c");
+            assert.nestedProperty({ x: { y: { z: "test" } } }, "x.y.z");
+        });
+
+        it("should fail when nested property does not exist", () => {
+            checkError(() => {
+                assert.nestedProperty({ a: { b: 2 } }, "a.b.c");
+            }, "to have a nested property");
+            checkError(() => {
+                assert.nestedProperty({ a: { b: { c: 1 } } }, "a.b.d");
+            }, "to have a nested property");
+        });
+
+        it("should pass when nested property exists and value matches (loose equality)", () => {
+            assert.nestedProperty({ a: { b: { c: 1 } } }, "a.b.c", 1);
+            assert.nestedProperty({ a: { b: { c: 1 } } }, "a.b.c", "1"); // loose equality
+            assert.nestedProperty({ a: { b: { c: "test" } } }, "a.b.c", "test");
+        });
+
+        it("should fail when nested property exists but value doesn't match", () => {
+            checkError(() => {
+                assert.nestedProperty({ a: { b: { c: 1 } } }, "a.b.c", 2);
+            }, "expected {a:{b:{c:1}}} to have a nested property \"a.b.c\" equal 2");
+            checkError(() => {
+                assert.nestedProperty({ a: { b: { c: "test" } } }, "a.b.c", "other");
+            }, "expected {a:{b:{c:\"test\"}}} to have a nested property \"a.b.c\" equal \"other\"");
+        });
+
+        it("should work with expect syntax", () => {
+            expect({ a: { b: { c: 1 } } }).has.nested.property("a.b.c");
+            expect({ a: { b: { c: 1 } } }).to.have.nested.property("a.b.c", 1);
+        });
+
+        it("should handle deep paths", () => {
+            let obj = { a: { b: { c: { d: { e: 42 } } } } };
+            assert.nestedProperty(obj, "a.b.c.d.e");
+            assert.nestedProperty(obj, "a.b.c.d.e", 42);
+        });
+
+        it("should handle arrays in path", () => {
+            let obj = { a: [{ b: 1 }, { b: 2 }] };
+            assert.nestedProperty(obj, "a.0.b");
+            assert.nestedProperty(obj, "a.1.b", 2);
+        });
+    });
+
+    describe("notHasNestedProperty", () => {
+        it("should pass when nested property does not exist", () => {
+            assert.notNestedProperty({ a: { b: 2 } }, "a.b.c");
+            assert.notNestedProperty({}, "x.y.z");
+        });
+
+        it("should fail when nested property exists", () => {
+            checkError(() => {
+                assert.notNestedProperty({ a: { b: { c: 1 } } }, "a.b.c");
+            }, "to have a nested property \"a.b.c\"");
+        });
+
+        it("should pass when nested property exists but value doesn't match", () => {
+            assert.notNestedProperty({ a: { b: { c: 1 } } }, "a.b.c", 2);
+            assert.notNestedProperty({ a: { b: { c: "test" } } }, "a.b.c", "other");
+        });
+
+        it("should fail when nested property exists and value matches", () => {
+            checkError(() => {
+                assert.notNestedProperty({ a: { b: { c: 1 } } }, "a.b.c", 1);
+            }, "not expected {a:{b:{c:1}}} to have a nested property \"a.b.c\" equal 1");
+        });
+
+        it("should work with expect syntax", () => {
+            expect({ a: { b: 2 } }).to.not.have.nested.property("a.b.c");
+            expect({ a: { b: { c: 1 } } }).to.not.have.nested.property("a.b.c", 2);
+        });
+    });
+
+    describe("nestedProperty", () => {
+        it("should pass when nested property value matches (loose equality)", () => {
+            assert.nestedProperty({ a: { b: { c: 1 } } }, "a.b.c", 1);
+            assert.nestedProperty({ a: { b: { c: 1 } } }, "a.b.c", "1"); // loose equality
+            assert.nestedProperty({ x: { y: "test" } }, "x.y", "test");
+        });
+
+        it("should fail when nested property does not exist", () => {
+            checkError(() => {
+                assert.nestedProperty({ a: { b: 2 } }, "a.b.c", 1);
+            }, "to have a nested property \"a.b.c\" equal 1");
+        });
+
+        it("should fail when nested property exists but value doesn't match", () => {
+            checkError(() => {
+                assert.nestedProperty({ a: { b: { c: 1 } } }, "a.b.c", 2);
+            }, "expected {a:{b:{c:1}}} to have a nested property \"a.b.c\" equal 2");
+        });
+
+        it("should work with expect syntax", () => {
+            expect({ a: { b: { c: 1 } } }).has.nested.property("a.b.c", 1);
+            expect({ a: { b: { c: "1" } } }).to.have.nested.property("a.b.c", 1); // loose equality
+        });
+    });
+
+    describe("notHasNestedProperty", () => {
+        it("should pass when nested property does not exist", () => {
+            assert.notNestedProperty({ a: { b: 2 } }, "a.b.c", 1);
+        });
+
+        it("should pass when nested property exists but value doesn't match", () => {
+            assert.notNestedProperty({ a: { b: { c: 1 } } }, "a.b.c", 2);
+            assert.notNestedProperty({ a: { b: { c: "test" } } }, "a.b.c", "other");
+        });
+
+        it("should fail when nested property value matches", () => {
+            checkError(() => {
+                assert.notNestedProperty({ a: { b: { c: 1 } } }, "a.b.c", 1);
+            }, "not expected {a:{b:{c:1}}} to have a nested property \"a.b.c\" equal 1");
+        });
+
+        it("should work with expect syntax", () => {
+            expect({ a: { b: { c: 1 } } }).to.not.have.nested.property("a.b.c", 2);
+        });
+    });
+
+    describe("deepnestedProperty", () => {
+        it("should pass when nested property deeply equals value", () => {
+            assert.deepNestedProperty({ a: { b: { c: { d: 1 } } } }, "a.b.c", { d: 1 });
+            assert.deepNestedProperty({ a: { b: { c: [1, 2, 3] } } }, "a.b.c", [1, 2, 3]);
+        });
+
+        it("should fail when nested property does not exist", () => {
+            checkError(() => {
+                assert.deepNestedProperty({ a: { b: 2 } }, "a.b.c", { d: 1 });
+            }, "to have a nested property \"a.b.c\" deeply equal {d:1}");
+        });
+
+        it("should fail when nested property exists but value doesn't deeply equal", () => {
+            checkError(() => {
+                assert.deepNestedProperty({ a: { b: { c: { d: 1 } } } }, "a.b.c", { d: 2 });
+            }, "to have a nested property \"a.b.c\" deeply equal {d:2}");
+            checkError(() => {
+                assert.deepNestedProperty({ a: { b: { c: [1, 2, 3] } } }, "a.b.c", [1, 2, 4]);
+            }, "to have a nested property \"a.b.c\" deeply equal [1,2,4]");
+        });
+
+        it("should work with deep expect syntax", () => {
+            expect({ a: { b: { c: { d: 1 } } } }).to.deep.nested.property("a.b.c", { d: 1 });
+            expect({ a: { b: { c: [1, 2] } } }).to.deep.nested.property("a.b.c", [1, 2]);
+        });
+    });
+
+    describe("notDeepnestedProperty", () => {
+        it("should pass when nested property does not exist", () => {
+            assert.notDeepNestedProperty({ a: { b: 2 } }, "a.b.c", { d: 1 });
+            assert.notDeepNestedProperty({ a: { b: { c: { d: 1 } } } }, "a.b.d", { d: 1 });
+        });
+
+        it("should pass when nested property exists but value doesn't deeply equal", () => {
+            assert.notDeepNestedProperty({ a: { b: { c: { d: 1 } } } }, "a.b.c", { d: 2 });
+            assert.notDeepNestedProperty({ a: { b: { c: [1, 2, 3] } } }, "a.b.c", [1, 2, 4]);
+        });
+
+        it("should fail when nested property deeply equals value", () => {
+            checkError(() => {
+                assert.notDeepNestedProperty({ a: { b: { c: { d: 1 } } } }, "a.b.c", { d: 1 });
+            }, "not expected {a:{b:{c:{d:1}}}} to have a nested property \"a.b.c\" deeply equal {d:1}");
+        });
+
+        it("should work with deep expect syntax", () => {
+            expect({ a: { b: { c: { d: 1 } } } }).to.not.deep.nested.property("a.b.c", { d: 2 });
+        });
+    });
+
+    describe("nestedInclude", () => {
+        it("should pass when all nested properties match", () => {
+            assert.nestedInclude({ a: { b: { c: 1 } } }, { "a.b.c": 1 });
+            assert.nestedInclude({ x: 1, y: 2 }, { "x": 1, "y": 2 });
+        });
+
+        it("should fail when nested properties don't match", () => {
+            checkError(() => {
+                assert.nestedInclude({ a: { b: { c: 1 } } }, { "a.b.c": 2 });
+            }, "to have a nested property \"a.b.c\" equal 2");
+            
+            checkError(() => {
+                assert.nestedInclude({ a: { b: 2 } }, { "a.b.c": 1 });
+            }, "to have a nested property \"a.b.c\" equal 1");
+        });
+
+        it("should work with expect syntax", () => {
+            expect({ a: { b: { c: 1 } } }).to.have.nested.includes({ "a.b.c": 1 });
+        });
+
+        it("should handle multiple nested properties", () => {
+            let obj = { a: { b: 1, c: 2 }, d: { e: 3 } };
+            assert.nestedInclude(obj, { "a.b": 1, "d.e": 3 });
+        });
+    });
+
+    describe("notNestedInclude", () => {
+        it("should pass when nested properties don't match", () => {
+            assert.notNestedInclude({ a: { b: { c: 1 } } }, { "a.b.c": 2 });
+            assert.notNestedInclude({ a: { b: 2 } }, { "a.b.c": 1 });
+        });
+
+        it("should fail when all nested properties match", () => {
+            checkError(() => {
+                assert.notNestedInclude({ a: { b: { c: 1 } } }, { "a.b.c": 1 });
+            }, "not expected {a:{b:{c:1}}} to have a nested property \"a.b.c\" equal 1");
+        });
+
+        it("should work with expect syntax", () => {
+            expect({ a: { b: { c: 1 } } }).to.not.have.nested.includes({ "a.b.c": 2 });
+        });
+    });
+
+    describe("deepNestedInclude", () => {
+        it("should pass when all nested properties deeply match", () => {
+            assert.deepNestedInclude({ a: { b: { c: { d: 1 } } } }, { "a.b.c": { d: 1 } });
+            assert.deepNestedInclude({ a: { b: [1, 2, 3] } }, { "a.b": [1, 2, 3] });
+        });
+
+        it("should fail when nested properties don't deeply match", () => {
+            checkError(() => {
+                assert.deepNestedInclude({ a: { b: { c: { d: 1 } } } }, { "a.b.c": { d: 2 } });
+            }, "to have a nested property \"a.b.c\" deeply equal {d:2}");
+            checkError(() => {
+                assert.deepNestedInclude({ a: { b: [1, 2, 3] } }, { "a.b": [1, 2, 4] });
+            }, "to have a nested property \"a.b\" deeply equal [1,2,4]");
+        });
+
+        it("should work with deep expect syntax", () => {
+            expect({ a: { b: { c: { d: 1 } } } }).to.deep.nested.includes({ "a.b.c": { d: 1 } });
+        });
+
+        it("should handle complex nested structures", () => {
+            let obj = {
+                user: {
+                    profile: {
+                        name: "John",
+                        settings: { theme: "dark", lang: "en" }
+                    }
+                }
+            };
+            assert.deepNestedInclude(obj, {
+                "user.profile.name": "John",
+                "user.profile.settings": { theme: "dark", lang: "en" }
+            });
+        });
+    });
+
+    describe("notDeepNestedInclude", () => {
+        it("should pass when nested properties don't deeply match", () => {
+            assert.notDeepNestedInclude({ a: { b: { c: { d: 1 } } } }, { "a.b.c": { d: 2 } });
+            assert.notDeepNestedInclude({ a: { b: [1, 2, 3] } }, { "a.b": [1, 2, 4] });
+        });
+
+        it("should fail when all nested properties deeply match", () => {
+            checkError(() => {
+                assert.notDeepNestedInclude({ a: { b: { c: { d: 1 } } } }, { "a.b.c": { d: 1 } });
+            }, "not expected {a:{b:{c:{d:1}}}} to have a nested property \"a.b.c\" deeply equal {d:1}");
+        });
+
+        it("should work with deep expect syntax", () => {
+            expect({ a: { b: { c: { d: 1 } } } }).to.not.deep.nested.includes({ "a.b.c": { d: 2 } });
+        });
+    });
+
+    describe("edge cases", () => {
+        it("should handle null and undefined in path", () => {
+            checkError(() => {
+                assert.nestedProperty({ a: null }, "a.b");
+            }, "to have a nested property");
+            checkError(() => {
+                assert.nestedProperty({ a: undefined }, "a.b");
+            }, "to have a nested property");
+        });
+
+        it("should handle empty paths", () => {
+            checkError(() => {
+                assert.nestedProperty({ a: 1 }, "");
+            }, "to have a nested property");
+        });
+
+        it("should handle single-level paths", () => {
+            assert.nestedProperty({ a: 1 }, "a");
+            assert.nestedProperty({ a: 1 }, "a", 1);
+        });
+
+        it("should handle objects with numeric keys", () => {
+            let obj = { "0": { "1": "value" } };
+            assert.nestedProperty(obj, "0.1");
+            assert.nestedProperty(obj, "0.1", "value");
+        });
+
+        it("should not treat dots in string values as path separators", () => {
+            let obj = { a: { b: "c.d.e" } };
+            assert.nestedProperty(obj, "a.b", "c.d.e");
+        });
+    });
+});

--- a/core/test/src/assert/assertionError.test.ts
+++ b/core/test/src/assert/assertionError.test.ts
@@ -196,6 +196,108 @@ describe("AssertionFailure", () => {
         assert.deepEqual(error.props.actual, [1, 2, 3]);
         assert.deepEqual(error.props.nested.array, [{ a: 1 }, { b: 2 }]);
     });
+
+    describe("readonly properties", () => {
+        it("should have readonly actual property", () => {
+            let error = new AssertionFailure("Test", { actual: 5, expected: 10 });
+            assert.equal(error.actual, 5);
+            // Verify it's accessible
+            assert.ok(error.actual !== undefined);
+        });
+
+        it("should have readonly expected property", () => {
+            let error = new AssertionFailure("Test", { actual: 5, expected: 10 });
+            assert.equal(error.expected, 10);
+            // Verify it's accessible
+            assert.ok(error.expected !== undefined);
+        });
+
+        it("should have readonly operator property", () => {
+            let error = new AssertionFailure("Test", { operator: "equal" });
+            assert.equal(error.operator, "equal");
+        });
+
+        it("should have readonly showDiff property", () => {
+            let error = new AssertionFailure("Test", { showDiff: true });
+            assert.equal(error.showDiff, true);
+        });
+
+        it("should handle undefined actual", () => {
+            let error = new AssertionFailure("Test", { expected: 10 });
+            assert.equal(error.actual, undefined);
+        });
+
+        it("should handle undefined expected", () => {
+            let error = new AssertionFailure("Test", { actual: 5 });
+            assert.equal(error.expected, undefined);
+        });
+
+        it("should handle undefined operator", () => {
+            let error = new AssertionFailure("Test", { actual: 5, expected: 10 });
+            assert.equal(error.operator, undefined);
+        });
+
+        it("should handle undefined showDiff", () => {
+            let error = new AssertionFailure("Test", { actual: 5, expected: 10 });
+            assert.equal(error.showDiff, undefined);
+        });
+
+        it("should preserve actual when null", () => {
+            let error = new AssertionFailure("Test", { actual: null, expected: "something" });
+            assert.equal(error.actual, null);
+        });
+
+        it("should preserve expected when null", () => {
+            let error = new AssertionFailure("Test", { actual: "something", expected: null });
+            assert.equal(error.expected, null);
+        });
+
+        it("should handle showDiff as false", () => {
+            let error = new AssertionFailure("Test", { showDiff: false });
+            assert.equal(error.showDiff, false);
+        });
+
+        it("should handle all properties together", () => {
+            let error = new AssertionFailure("Test", {
+                actual: { a: 1 },
+                expected: { a: 2 },
+                operator: "deepEqual",
+                showDiff: true
+            });
+            assert.deepEqual(error.actual, { a: 1 });
+            assert.deepEqual(error.expected, { a: 2 });
+            assert.equal(error.operator, "deepEqual");
+            assert.equal(error.showDiff, true);
+        });
+
+        it("should handle properties with primitive values", () => {
+            let error = new AssertionFailure("Test", {
+                actual: 42,
+                expected: "42",
+                operator: "strictEqual",
+                showDiff: true
+            });
+            assert.equal(error.actual, 42);
+            assert.equal(error.expected, "42");
+            assert.equal(error.operator, "strictEqual");
+            assert.equal(error.showDiff, true);
+        });
+
+        it("should handle properties with complex objects", () => {
+            let actualObj = { nested: { value: [1, 2, 3] } };
+            let expectedObj = { nested: { value: [1, 2, 4] } };
+            let error = new AssertionFailure("Test", {
+                actual: actualObj,
+                expected: expectedObj,
+                operator: "deepStrictEqual",
+                showDiff: true
+            });
+            assert.deepEqual(error.actual, actualObj);
+            assert.deepEqual(error.expected, expectedObj);
+            assert.equal(error.operator, "deepStrictEqual");
+            assert.equal(error.showDiff, true);
+        });
+    });
 });
 
 describe("AssertionFatal", () => {

--- a/core/test/src/assert/context.test.ts
+++ b/core/test/src/assert/context.test.ts
@@ -23,7 +23,7 @@ describe("context", () => {
         assert.equal(ctx.value, 1, "value should be 1");
         assert.equal(ctx.getMessage(), "first", "message should be first");
         assert.equal(ctx.getDetails().actual, 1, "actual should be 1");
-        assert.equal(objKeys(ctx.getDetails()).length, 1, "details should have 1 key - " + JSON.stringify(ctx.getDetails()));
+        assert.equal(objKeys(ctx.getDetails()).length, 2, "details should have 2 keys - " + JSON.stringify(ctx.getDetails()));
     });
 
     it("new child value", () => {
@@ -33,12 +33,12 @@ describe("context", () => {
         assert.equal(ctx.value, 1, "value should be 1");
         assert.equal(ctx.getMessage(), "first", "message should be first");
         assert.equal(ctx.getDetails().actual, 1, "actual should be 1");
-        assert.equal(objKeys(ctx.getDetails()).length, 1, "details should have 1 key");
+        assert.equal(objKeys(ctx.getDetails()).length, 2, "details should have 2 keys - " + JSON.stringify(ctx.getDetails()));
 
         assert.equal(ctx2.value, 2, "value should be 2");
         assert.equal(ctx2.getMessage(), "first", "message should be first");
         assert.equal(ctx2.getDetails().actual, 2, "actual should be 2");
-        assert.equal(objKeys(ctx2.getDetails()).length, 1, "details should have 1 key");
+        assert.equal(objKeys(ctx2.getDetails()).length, 2, "details should have 2 keys - " + JSON.stringify(ctx2.getDetails()));
     });
 
     it("getDetails", () => {
@@ -46,8 +46,8 @@ describe("context", () => {
         let details = ctx.getDetails();
         
         assert.equal(details.actual, 1, "actual should be 1");
-        assert.equal(objKeys(details).length, 1, "details should have 1 key");
-        assert.deepEqual(details, { actual: 1 }, "details should be { actual: 1 }");
+        assert.equal(objKeys(details).length, 2, "details should have 2 keys - " + JSON.stringify(details));
+        assert.deepEqual(details, { actual: 1, showDiff: true });
     });
 
     describe("eval", () => {
@@ -149,19 +149,17 @@ describe("context", () => {
                 let details = ctx.getDetails();
                 
                 assert.equal(details.actual, 1, "actual should be 1");
-                assert.equal(objKeys(details).length, 1, "details should have 1 key");
-                assert.deepEqual(details, { actual: 1 }, "details should be { actual: 1 }");
+                assert.equal(objKeys(details).length, 2, "details should have 2 keys");
+                assert.deepEqual(details, { actual: 1, showDiff: true });
     
                 let newDetails = newCtx.getDetails();
                 
                 assert.equal(newDetails.actual, 2, "actual should be 2");
-                assert.equal(objKeys(newDetails).length, 2, "details should have 2 keys");
+                assert.equal(objKeys(newDetails).length, 3, "details should have 3 keys");
                 checkError(() => {
                     assert.deepEqual(newDetails, { actual: 1, hello: "darkness" }, "details should be { actual: 1, hello: darkness }");
-                }, "details should be { actual: 1, hello: darkness }: expected {hello:\"darkness\",actual:2} to deeply equal {actual:1,hello:\"darkness\"}");
+                }, "details should be { actual: 1, hello: darkness }: expected {hello:\"darkness\",actual:2,showDiff:true} to deeply equal {actual:1,hello:\"darkness\"}");
             });
-        
-        
         });
     });
 });

--- a/core/test/src/assert/parseNestedPath.test.ts
+++ b/core/test/src/assert/parseNestedPath.test.ts
@@ -1,0 +1,173 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { _parseNestedPath } from "../../../src/assert/funcs/nested";
+import { assert } from "../../../src/assert/assertClass";
+
+describe("_parseNestedPath", () => {
+    describe("simple paths", () => {
+        it("should parse a single property", () => {
+            const result = _parseNestedPath("a");
+            assert.deepEqual(result, ["a"]);
+        });
+
+        it("should parse dot-separated properties", () => {
+            const result = _parseNestedPath("a.b.c");
+            assert.deepEqual(result, ["a", "b", "c"]);
+        });
+
+        it("should parse deeply nested dot notation", () => {
+            const result = _parseNestedPath("a.b.c.d.e.f");
+            assert.deepEqual(result, ["a", "b", "c", "d", "e", "f"]);
+        });
+    });
+
+    describe("bracket notation", () => {
+        it("should parse array index notation", () => {
+            const result = _parseNestedPath("a[0]");
+            assert.deepEqual(result, ["a", "0"]);
+        });
+
+        it("should parse multiple bracket indices", () => {
+            const result = _parseNestedPath("a[0][1]");
+            assert.deepEqual(result, ["a", "0", "1"]);
+        });
+
+        it("should parse bracket notation with property name", () => {
+            const result = _parseNestedPath("a[b]");
+            assert.deepEqual(result, ["a", "b"]);
+        });
+
+        it("should parse mixed dot and bracket notation", () => {
+            const result = _parseNestedPath("a.b[0].c");
+            assert.deepEqual(result, ["a", "b", "0", "c"]);
+        });
+
+        it("should parse complex mixed notation", () => {
+            const result = _parseNestedPath("a.b[0][1].c[2].d");
+            assert.deepEqual(result, ["a", "b", "0", "1", "c", "2", "d"]);
+        });
+
+        it("should parse bracket with numeric index", () => {
+            const result = _parseNestedPath("a.b[1]");
+            assert.deepEqual(result, ["a", "b", "1"]);
+        });
+    });
+
+    describe("escaped characters", () => {
+        it("should handle escaped dot", () => {
+            const result = _parseNestedPath("\\.a");
+            assert.deepEqual(result, [".a"]);
+        });
+
+        it("should handle escaped bracket", () => {
+            const result = _parseNestedPath("\\[b\\]");
+            assert.deepEqual(result, ["[b]"]);
+        });
+
+        it("should handle escaped dot in middle of path", () => {
+            const result = _parseNestedPath("a.\\.b.c");
+            assert.deepEqual(result, ["a", ".b", "c"]);
+        });
+
+        it("should handle multiple escaped characters", () => {
+            const result = _parseNestedPath("\\.a.\\[b\\]");
+            assert.deepEqual(result, [".a", "[b]"]);
+        });
+
+        it("should handle complex escaped path matching Chai test", () => {
+            const result = _parseNestedPath("\\.a.\\[b\\]");
+            assert.deepEqual(result, [".a", "[b]"]);
+        });
+
+        it("should handle escaped backslash", () => {
+            const result = _parseNestedPath("a.\\\\b.c");
+            assert.deepEqual(result, ["a", "\\b", "c"]);
+        });
+    });
+
+    describe("edge cases", () => {
+        it("should handle empty string", () => {
+            const result = _parseNestedPath("");
+            assert.deepEqual(result, [""]);
+        });
+
+        it("should handle path with empty bracket", () => {
+            const result = _parseNestedPath("a[]");
+            assert.deepEqual(result, ["a", ""]);
+        });
+
+        it("should handle path ending with dot", () => {
+            const result = _parseNestedPath("a.b.");
+            assert.deepEqual(result, ["a", "b", ""]);
+        });
+
+        it("should handle consecutive dots", () => {
+            const result = _parseNestedPath("a..b");
+            assert.deepEqual(result, ["a", "", "b"]);
+        });
+
+        it("should handle path starting with dot", () => {
+            const result = _parseNestedPath(".a.b");
+            assert.deepEqual(result, ["", "a", "b"]);
+        });
+    });
+
+    describe("real-world examples from Chai tests", () => {
+        it("should parse a.b[1] (array access)", () => {
+            const result = _parseNestedPath("a.b[1]");
+            assert.deepEqual(result, ["a", "b", "1"]);
+        });
+
+        it("should parse a.b[0] (first array element)", () => {
+            const result = _parseNestedPath("a.b[0]");
+            assert.deepEqual(result, ["a", "b", "0"]);
+        });
+
+        it("should parse a.b.c (nested properties)", () => {
+            const result = _parseNestedPath("a.b.c");
+            assert.deepEqual(result, ["a", "b", "c"]);
+        });
+
+        it("should parse escaped property names", () => {
+            const result = _parseNestedPath("\\.a.\\[b\\]");
+            assert.deepEqual(result, [".a", "[b]"]);
+        });
+    });
+
+    describe("unclosed brackets", () => {
+        it("should handle unclosed bracket at end", () => {
+            const result = _parseNestedPath("a[0");
+            // When bracket is not closed, it should be treated as regular characters
+            assert.deepEqual(result, ["a[0"]);
+        });
+
+        it("should handle unclosed bracket in middle", () => {
+            const result = _parseNestedPath("a[0.b");
+            // Unclosed bracket means it's treated as part of the path
+            assert.deepEqual(result, ["a[0", "b"]);
+        });
+    });
+
+    describe("closing bracket without opening bracket", () => {
+        it("should handle closing bracket without opening bracket at start", () => {
+            const result = _parseNestedPath("]a");
+            assert.deepEqual(result, ["]a"]);
+        });
+
+        it("should handle closing bracket without opening bracket in middle", () => {
+            const result = _parseNestedPath("a.b].c");
+            assert.deepEqual(result, ["a", "b]", "c"]);
+        });
+
+        it("should handle multiple unmatched closing brackets", () => {
+            const result = _parseNestedPath("a]b]c");
+            assert.deepEqual(result, ["a]b]c"]);
+        });
+    });
+});

--- a/core/test/src/support/checkError.ts
+++ b/core/test/src/support/checkError.ts
@@ -190,7 +190,7 @@ function _colorizeActual(actual: string, expected: string): string {
     return gray(result);
 }
 
-export function checkError(fn: () => void, match?: string | RegExp | Object, checkFrames?: boolean): void {
+export function checkError(fn: () => void, match: string | RegExp | Object, checkFrames?: boolean): void {
     let stackStart: Function | undefined = undefined;
     if (!assertConfig.fullStack) {
         stackStart = checkError;

--- a/shim/chai/src/assert/chaiAssert.ts
+++ b/shim/chai/src/assert/chaiAssert.ts
@@ -107,10 +107,10 @@ function _createChaiAssert(): IChaiAssert {
         notInclude: { scopeFn: createExprAdapter("not.include"), nArgs: 2 },
         deepInclude: { scopeFn: createExprAdapter("deep.include"), nArgs: 2 },
         notDeepInclude: { scopeFn: createExprAdapter("not.deep.include"), nArgs: 2 },
-        nestedInclude: notImplemented,
-        notNestedInclude: notImplemented,
-        deepNestedInclude: notImplemented,
-        notDeepNestedInclude: notImplemented,
+        nestedInclude: { scopeFn: createExprAdapter("has.nested.include"), nArgs: 2 },
+        notNestedInclude: { scopeFn: createExprAdapter("not.has.nested.include"), nArgs: 2 },
+        deepNestedInclude: { scopeFn: createExprAdapter("deep.nested.include"), nArgs: 2 },
+        notDeepNestedInclude: { scopeFn: createExprAdapter("not.deep.nested.include"), nArgs: 2 },
         ownInclude: notImplemented, //{ scopeFn: createExprAdapter("own.include"), nArgs: 2 },
         notOwnInclude: notImplemented, //{ scopeFn: createExprAdapter("not.own.include"), nArgs: 2 },
         deepOwnInclude: notImplemented, //{ scopeFn: createExprAdapter("deep.own.include"), nArgs: 2 },
@@ -214,12 +214,12 @@ function _createChaiAssert(): IChaiAssert {
         doesNotHaveAnyDeepKeys: notImplemented,
         doesNotHaveAllDeepKeys: notImplemented,
 
-        nestedProperty: notImplemented,
-        notNestedProperty: notImplemented,
-        nestedPropertyVal: notImplemented,
-        notNestedPropertyVal: notImplemented,
-        deepNestedPropertyVal: notImplemented,
-        notDeepNestedPropertyVal: notImplemented
+        nestedProperty: { scopeFn: createExprAdapter("has.nested.property"), nArgs: 2 },
+        notNestedProperty: { scopeFn: createExprAdapter("not.has.nested.property"), nArgs: 2 },
+        nestedPropertyVal: { scopeFn: createExprAdapter("has.nested.property"), nArgs: 3 },
+        notNestedPropertyVal: { scopeFn: createExprAdapter("not.has.nested.property"), nArgs: 3 },
+        deepNestedPropertyVal: { scopeFn: createExprAdapter("deep.nested.property"), nArgs: 3 },
+        notDeepNestedPropertyVal: { scopeFn: createExprAdapter("not.deep.nested.property"), nArgs: 3 }
     };
 
     function chaiResponseHandler(response: any) {

--- a/shim/chai/test/src/chaiAssert.test.ts
+++ b/shim/chai/test/src/chaiAssert.test.ts
@@ -921,57 +921,54 @@ describe("assert", function () {
     //     }, "blah: expected { foo: { a: 1 }, bar: { b: 2 } } to not have deep property \"foo\" of { a: 1 }");
     // });
 
-    // it("nestedInclude and notNestedInclude", function() {
-    //     assert.nestedInclude({a: {b: ["x", "y"]}}, {"a.b[1]": "y"});
-    //     assert.notNestedInclude({a: {b: ["x", "y"]}}, {"a.b[1]": "x"});
-    //     assert.notNestedInclude({a: {b: ["x", "y"]}}, {"a.c": "y"});
+    it("nestedInclude and notNestedInclude", function() {
+        assert.nestedInclude({a: {b: ["x", "y"]}}, {"a.b[1]": "y"});
+        assert.notNestedInclude({a: {b: ["x", "y"]}}, {"a.b[1]": "x"});
+        assert.notNestedInclude({a: {b: ["x", "y"]}}, {"a.c": "y"});
 
-    //     assert.notNestedInclude({a: {b: [{x: 1}]}}, {"a.b[0]": {x: 1}});
+        assert.notNestedInclude({a: {b: [{x: 1}]}}, {"a.b[0]": {x: 1}});
 
-    //     assert.nestedInclude({".a": {"[b]": "x"}}, {"\\.a.\\[b\\]": "x"});
-    //     assert.notNestedInclude({".a": {"[b]": "x"}}, {"\\.a.\\[b\\]": "y"});
+        assert.nestedInclude({".a": {"[b]": "x"}}, {"\\.a.\\[b\\]": "x"});
+        assert.notNestedInclude({".a": {"[b]": "x"}}, {"\\.a.\\[b\\]": "y"});
 
-    //     err(function () {
-    //         assert.nestedInclude({a: {b: ["x", "y"]}}, {"a.b[1]": "x"}, "blah");
-    //     }, "blah: expected {a:{b:[\"x\",\"y\"]}} to have nested property 'a.b[1]' of \"x\", but got \"y\"");
+        err(function () {
+            assert.nestedInclude({a: {b: ["x", "y"]}}, {"a.b[1]": "x"}, "blah");
+        }, "blah: expected {a:{b:[\"x\",\"y\"]}} to have a nested property \"a.b[1]\" equal \"x\", but got \"y\"");
 
-    //     err(function () {
-    //         assert.nestedInclude({a: {b: ["x", "y"]}}, {"a.b[1]": "x"}, "blah");
-    //     }, "blah: expected {a:{b:[\"x\",\"y\"]}} to have nested property 'a.b[1]' of \"x\", but got \"y\"");
+        err(function () {
+            assert.nestedInclude({a: {b: ["x", "y"]}}, {"a.b[1]": "x"}, "blah");
+        }, "blah: expected {a:{b:[\"x\",\"y\"]}} to have a nested property \"a.b[1]\" equal \"x\", but got \"y\"");
+        err(function () {
+            assert.nestedInclude({a: {b: ["x", "y"]}}, {"a.c": "y"});
+        }, "expected {a:{b:[\"x\",\"y\"]}} to have a nested property \"a.c\"");
+        err(function () {
+            assert.notNestedInclude({a: {b: ["x", "y"]}}, {"a.b[1]": "y"}, "blah");
+        }, "blah: not expected {a:{b:[\"x\",\"y\"]}} to have a nested property \"a.b[1]\" equal \"y\"");
+    });
 
-    //     err(function () {
-    //         assert.nestedInclude({a: {b: ["x", "y"]}}, {"a.c": "y"});
-    //     }, "expected {a:{b:[\"x\",\"y\"]}} to have nested property 'a.c'");
+    it("deepNestedInclude and notDeepNestedInclude", function() {
+        assert.deepNestedInclude({a: {b: [{x: 1}]}}, {"a.b[0]": {x: 1}});
+        assert.notDeepNestedInclude({a: {b: [{x: 1}]}}, {"a.b[0]": {y: 2}});
+        assert.notDeepNestedInclude({a: {b: [{x: 1}]}}, {"a.c": {x: 1}});
 
-    //     err(function () {
-    //         assert.notNestedInclude({a: {b: ["x", "y"]}}, {"a.b[1]": "y"}, "blah");
-    //     }, "blah: expected {a:{b:[\"x\",\"y\"]}} to not have nested property 'a.b[1]' of \"y\"");
-    // });
+        assert.deepNestedInclude({".a": {"[b]": {x: 1}}}, {"\\.a.\\[b\\]": {x: 1}});
+        assert.notDeepNestedInclude({".a": {"[b]": {x: 1}}}, {"\\.a.\\[b\\]": {y: 2}});
 
-    // it("deepNestedInclude and notDeepNestedInclude", function() {
-    //     assert.deepNestedInclude({a: {b: [{x: 1}]}}, {"a.b[0]": {x: 1}});
-    //     assert.notDeepNestedInclude({a: {b: [{x: 1}]}}, {"a.b[0]": {y: 2}});
-    //     assert.notDeepNestedInclude({a: {b: [{x: 1}]}}, {"a.c": {x: 1}});
+        err(function () {
+            assert.deepNestedInclude({a: {b: [{x: 1}]}}, {"a.b[0]": {y: 2}}, "blah");
+        }, "blah: expected {a:{b:[{x:1}]}} to have a nested property \"a.b[0]\" deeply equal {y:2}, but got {x:1}");
 
-    //     assert.deepNestedInclude({".a": {"[b]": {x: 1}}}, {"\\.a.\\[b\\]": {x: 1}});
-    //     assert.notDeepNestedInclude({".a": {"[b]": {x: 1}}}, {"\\.a.\\[b\\]": {y: 2}});
+        err(function () {
+            assert.deepNestedInclude({a: {b: [{x: 1}]}}, {"a.b[0]": {y: 2}}, "blah");
+        }, "blah: expected {a:{b:[{x:1}]}} to have a nested property \"a.b[0]\" deeply equal {y:2}, but got {x:1}");
+        err(function () {
+            assert.deepNestedInclude({a: {b: [{x: 1}]}}, {"a.c": {x: 1}});
+        }, "expected {a:{b:[{x:1}]}} to have a nested property \"a.c\" deeply equal {x:1}");
 
-    //     err(function () {
-    //         assert.deepNestedInclude({a: {b: [{x: 1}]}}, {"a.b[0]": {y: 2}}, "blah");
-    //     }, "blah: expected {a:{b:[{x:1}]}} to have deep nested property 'a.b[0]' of { y: 2 }, but got { x: 1 }");
-
-    //     err(function () {
-    //         assert.deepNestedInclude({a: {b: [{x: 1}]}}, {"a.b[0]": {y: 2}}, "blah");
-    //     }, "blah: expected {a:{b:[{x:1}]}} to have deep nested property 'a.b[0]' of { y: 2 }, but got { x: 1 }");
-
-    //     err(function () {
-    //         assert.deepNestedInclude({a: {b: [{x: 1}]}}, {"a.c": {x: 1}});
-    //     }, "expected {a:{b:[{x:1}]}} to have deep nested property 'a.c'");
-
-    //     err(function () {
-    //         assert.notDeepNestedInclude({a: {b: [{x: 1}]}}, {"a.b[0]": {x: 1}}, "blah");
-    //     }, "blah: expected {a:{b:[{x:1}]}} to not have deep nested property 'a.b[0]' of { x: 1 }");
-    // });
+        err(function () {
+            assert.notDeepNestedInclude({a: {b: [{x: 1}]}}, {"a.b[0]": {x: 1}}, "blah");
+        }, "blah: not expected {a:{b:[{x:1}]}} to have a nested property \"a.b[0]\" deeply equal {x:1}");
+    });
 
     // it("ownInclude and notOwnInclude", function() {
     //     assert.ownInclude({a: 1}, {a: 1});
@@ -1479,32 +1476,32 @@ describe("assert", function () {
         assert.propertyVal(obj, "toString", Object.prototype.toString);
         assert.property(undefinedKeyObj, "foo");
         assert.propertyVal(undefinedKeyObj, "foo", undefined);
-        // assert.nestedProperty(obj, "foo.bar");
+        assert.nestedProperty(obj, "foo.bar");
         assert.notProperty(obj, "baz");
         assert.notProperty(obj, "foo.bar");
         assert.notPropertyVal(simpleObj, "foo", "flow");
         assert.notPropertyVal(simpleObj, "flow", "bar");
         assert.notPropertyVal(obj, "foo", {bar: "baz"});
-        // assert.notNestedProperty(obj, "foo.baz");
-        // assert.nestedPropertyVal(obj, "foo.bar", "baz");
-        // assert.notNestedPropertyVal(obj, "foo.bar", "flow");
-        // assert.notNestedPropertyVal(obj, "foo.flow", "baz");
+        assert.notNestedProperty(obj, "foo.baz");
+        assert.nestedPropertyVal(obj, "foo.bar", "baz");
+        assert.notNestedPropertyVal(obj, "foo.bar", "flow");
+        assert.notNestedPropertyVal(obj, "foo.flow", "baz");
 
         err(function () {
             assert.property(obj, "baz", "blah");
         }, "blah: expected {foo:{bar:\"baz\"}} to have a \"baz\" property");
 
-        // err(function () {
-        //     assert.nestedProperty(obj, "foo.baz", "blah");
-        // }, "blah: expected { foo: { bar: \"baz\" } } to have nested property 'foo.baz'");
+        err(function () {
+            assert.nestedProperty(obj, "foo.baz", "blah");
+        }, "blah: expected {foo:{bar:\"baz\"}} to have a nested property \"foo.baz\"");
 
         err(function () {
             assert.notProperty(obj, "foo", "blah");
         }, "blah: not expected {foo:{bar:\"baz\"}} to have a \"foo\" property");
 
-        // err(function () {
-        //     assert.notNestedProperty(obj, "foo.bar", "blah");
-        // }, "blah: expected { foo: { bar: \"baz\" } } to not have nested property 'foo.bar'");
+        err(function () {
+            assert.notNestedProperty(obj, "foo.bar", "blah");
+        }, "blah: not expected {foo:{bar:\"baz\"}} to have a nested property \"foo.bar\"");
 
         err(function () {
             assert.propertyVal(simpleObj, "foo", "ball", "blah");
@@ -1514,17 +1511,17 @@ describe("assert", function () {
             assert.propertyVal(simpleObj, "foo", undefined);
         }, /expected/);
 
-        // err(function () {
-        //     assert.nestedPropertyVal(obj, "foo.bar", "ball", "blah");
-        // }, "blah: expected { foo: { bar: \"baz\" } } to have nested property 'foo.bar' of \"ball\", but got \"baz\"");
+        err(function () {
+            assert.nestedPropertyVal(obj, "foo.bar", "ball", "blah");
+        }, "blah: expected {foo:{bar:\"baz\"}} to have a nested property \"foo.bar\" equal \"ball\", but got \"baz\"");
 
         err(function () {
             assert.notPropertyVal(simpleObj, "foo", "bar", "blah");
         }, /blah/);
 
-        // err(function () {
-        //     assert.notNestedPropertyVal(obj, "foo.bar", "baz", "blah");
-        // }, "blah: expected { foo: { bar: \"baz\" } } to not have nested property 'foo.bar' of \"baz\"");
+        err(function () {
+            assert.notNestedPropertyVal(obj, "foo.bar", "baz", "blah");
+        }, "blah: not expected {foo:{bar:\"baz\"}} to have a nested property \"foo.bar\" equal \"baz\"");
 
         err(function () {
             assert.property(null, "a", "blah");
@@ -1542,9 +1539,9 @@ describe("assert", function () {
             assert.propertyVal(dummyObj, "a", "2", "blah");
         }, /blah/);
 
-        // err(function () {
-        //     assert.nestedProperty({a:1}, {"a":"1"} as any, "blah");
-        // }, "blah: the argument to property must be a string when using nested syntax");
+        err(function () {
+            assert.nestedProperty({a:1}, {"a":"1"} as any, "blah");
+        }, "blah: expected {a:\"1\"} to be a string using nested syntax");
     });
 
     it("deepPropertyVal", function () {
@@ -1633,25 +1630,24 @@ describe("assert", function () {
         }, /blah/);
     });
 
-    // it("deepNestedPropertyVal", function () {
-    //     var obj = {a: {b: {c: 1}}};
-    //     assert.deepNestedPropertyVal(obj, "a.b", {c: 1});
-    //     assert.notDeepNestedPropertyVal(obj, "a.b", {c: 7});
-    //     assert.notDeepNestedPropertyVal(obj, "a.b", {z: 1});
-    //     assert.notDeepNestedPropertyVal(obj, "a.z", {c: 1});
+    it("deepNestedPropertyVal", function () {
+        var obj = {a: {b: {c: 1}}};
+        assert.deepNestedPropertyVal(obj, "a.b", {c: 1});
+        assert.notDeepNestedPropertyVal(obj, "a.b", {c: 7});
+        assert.notDeepNestedPropertyVal(obj, "a.b", {z: 1});
+        assert.notDeepNestedPropertyVal(obj, "a.z", {c: 1});
 
-    //     err(function () {
-    //         assert.deepNestedPropertyVal(obj, "a.b", {c: 7}, "blah");
-    //     }, "blah: expected { a: { b: { c: 1 } } } to have deep nested property 'a.b' of { c: 7 }, but got { c: 1 }");
+        err(function () {
+            assert.deepNestedPropertyVal(obj, "a.b", {c: 7}, "blah");
+        }, "blah: expected {a:{b:{c:1}}} to have a nested property \"a.b\" deeply equal {c:7}, but got {c:1}");
 
-    //     err(function () {
-    //         assert.deepNestedPropertyVal(obj, "a.z", {c: 1}, "blah");
-    //     }, "blah: expected { a: { b: { c: 1 } } } to have deep nested property 'a.z'");
-
-    //     err(function () {
-    //         assert.notDeepNestedPropertyVal(obj, "a.b", {c: 1}, "blah");
-    //     }, "blah: expected {a:{b:{c:1}}} to not have deep nested property \"a.b\" of {c:1}");
-    // });
+        err(function () {
+            assert.deepNestedPropertyVal(obj, "a.z", {c: 1}, "blah");
+        }, "blah: expected {a:{b:{c:1}}} to have a nested property \"a.z\"");
+        err(function () {
+            assert.notDeepNestedPropertyVal(obj, "a.b", {c: 1}, "blah");
+        }, "blah: not expected {a:{b:{c:1}}} to have a nested property \"a.b\" deeply equal {c:1}");
+    });
 
     it("throws / throw / Throw", function() {
         ["throws", "throw", "Throw"].forEach(function (throws) {


### PR DESCRIPTION
Implement comprehensive support for nested property assertions using dot notation (e.g., a.b.c) and bracket notation (e.g., a[0]).

New Assertions:
- nestedProperty / notNestedProperty - Check nested properties with loose equality
- deepNestedProperty / notDeepNestedProperty - Check nested properties with deep equality
- nestedInclude / notNestedInclude - Match nested properties against expected object
- deepNestedInclude / notDeepNestedInclude - Deep match nested properties

Features:
- Dot notation: a.b.c
- Bracket notation: a[0], a[b]
- Mixed paths: a.b[0].c
- Escape sequences: \.a, \[b\] for literal dots/brackets

API Extensions:
- Added INestedOp<R> interface with property, include, includes, contain, contains methods
- Integrated with IHasOp and IDeepOp operation chains
- Supports both assert and expect syntax

Error Enhancements:
- Added operator and showDiff readonly properties to AssertionError
- Added showDiff configuration option (default: true)
- Improved error messages with better context for nested property failures

Chai Shim:
- Implemented nestedProperty, notNestedProperty, nestedPropertyVal, notNestedPropertyVal
- Implemented deepNestedPropertyVal, notDeepNestedPropertyVal
- Implemented nestedInclude, notNestedInclude, deepNestedInclude, notDeepNestedInclude