### PR TITLE
docs(copyright): update copyright headers for 2025 changes

### DIFF
--- a/core/src/assert/adapters/evalAdapter.ts
+++ b/core/src/assert/adapters/evalAdapter.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/adapters/exprAdapter.ts
+++ b/core/src/assert/adapters/exprAdapter.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/assertScope.ts
+++ b/core/src/assert/assertScope.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/funcs/equal.ts
+++ b/core/src/assert/funcs/equal.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/funcs/hasProperty.ts
+++ b/core/src/assert/funcs/hasProperty.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/funcs/isEmpty.ts
+++ b/core/src/assert/funcs/isEmpty.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/funcs/isExtensible.ts
+++ b/core/src/assert/funcs/isExtensible.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/funcs/isFrozen.ts
+++ b/core/src/assert/funcs/isFrozen.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/funcs/isSealed.ts
+++ b/core/src/assert/funcs/isSealed.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/funcs/keysFunc.ts
+++ b/core/src/assert/funcs/keysFunc.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/funcs/throws.ts
+++ b/core/src/assert/funcs/throws.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/funcs/valuesFunc.ts
+++ b/core/src/assert/funcs/valuesFunc.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/interface/IAssertConfig.ts
+++ b/core/src/assert/interface/IAssertConfig.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/interface/IFormatter.ts
+++ b/core/src/assert/interface/IFormatter.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/interface/IRemovable.ts
+++ b/core/src/assert/interface/IRemovable.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/interface/funcs/IncludeFn.ts
+++ b/core/src/assert/interface/funcs/IncludeFn.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/interface/ops/IAllOp.ts
+++ b/core/src/assert/interface/ops/IAllOp.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/interface/ops/IAnyOp.ts
+++ b/core/src/assert/interface/ops/IAnyOp.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/internal/_formatValue.ts
+++ b/core/src/assert/internal/_formatValue.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/internal/_handleResult.ts
+++ b/core/src/assert/internal/_handleResult.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/ops/allOp.ts
+++ b/core/src/assert/ops/allOp.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/ops/includeOp.ts
+++ b/core/src/assert/ops/includeOp.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/ops/propertyResultOp.ts
+++ b/core/src/assert/ops/propertyResultOp.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/scopeContext.ts
+++ b/core/src/assert/scopeContext.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/assert/useScope.ts
+++ b/core/src/assert/useScope.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/src/internal/captureStack.ts
+++ b/core/src/internal/captureStack.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/test/src/assert/assert.empty.test.ts
+++ b/core/test/src/assert/assert.empty.test.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/test/src/assert/assert.equals.test.ts
+++ b/core/test/src/assert/assert.equals.test.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/test/src/assert/assert.format.test.ts
+++ b/core/test/src/assert/assert.format.test.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/test/src/assert/assert.function.test.ts
+++ b/core/test/src/assert/assert.function.test.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/test/src/assert/assert.includes.test.ts
+++ b/core/test/src/assert/assert.includes.test.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/test/src/assert/context.test.ts
+++ b/core/test/src/assert/context.test.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/test/src/assert/funcs/allValuesFunc.test.ts
+++ b/core/test/src/assert/funcs/allValuesFunc.test.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/test/src/assert/funcs/anyValuesFunc.test.ts
+++ b/core/test/src/assert/funcs/anyValuesFunc.test.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/test/src/operations/keysOp.test.ts
+++ b/core/test/src/operations/keysOp.test.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/test/src/support/checkError.ts
+++ b/core/test/src/support/checkError.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/core/test/src/support/validate.symbol.test.ts
+++ b/core/test/src/support/validate.symbol.test.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 

--- a/shim/chai/src/index.ts
+++ b/shim/chai/src/index.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2025 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 


### PR DESCRIPTION
Update copyright headers for all files modified or created in 2025 that have the wrong year:

New files from 2025 (Copyright (c) 2025):
- IFormatter.ts
- IRemovable.ts
- useScope.ts
- assert.format.test.ts
- valuesFunc.ts
- ValuesFn.ts
- allValuesFunc.test.ts
- anyValuesFunc.test.ts

Files modified in 2025 (Copyright (c) 2024-2025):

- evalAdapter.ts
- exprAdapter.ts
- assertScope.ts
- equal.ts
- hasProperty.ts
- isEmpty.ts
- isExtensible.ts
- isFrozen.ts
- isSealed.ts
- keysFunc.ts
- throws.ts
- IAssertConfig.ts
- IncludeFn.ts
- IAllOp.ts
- IAnyOp.ts
- _formatValue.ts
- _handleResult.ts
- allOp.ts
- includeOp.ts
- propertyResultOp.ts
- scopeContext.ts
- captureStack.ts
- assert.empty.test.ts
- assert.equals.test.ts
- assert.function.test.ts
- assert.includes.test.ts
- context.test.ts
- keysOp.test.ts
- checkError.ts
- validate.symbol.test.ts
- index.ts

All copyright headers now reflect accurate creation and modification dates for 2025.