### PR TITLE
feat: Add operator comparison function with typeof support

### DIFF
--- a/core/src/assert/assertClass.ts
+++ b/core/src/assert/assertClass.ts
@@ -37,6 +37,7 @@ import { typeOfFunc } from "./funcs/typeOf";
 import { instanceOfFunc } from "./funcs/instanceOf";
 import { lengthFunc } from "./funcs/length";
 import { closeToFunc } from "./funcs/closeTo";
+import { operatorFunc } from "./funcs/operator";
 
 /**
  * @internal
@@ -270,7 +271,10 @@ export function createAssert(): IAssertClass {
         closeTo: { scopeFn: closeToFunc, nArgs: 3 },
         notCloseTo: { scopeFn: createExprAdapter("not", closeToFunc), nArgs: 3 },
         approximately: { alias: "closeTo" },
-        notApproximately: { alias: "notCloseTo" }
+        notApproximately: { alias: "notCloseTo" },
+
+        // Operator comparison
+        operator: { scopeFn: operatorFunc, nArgs: 3 }
     };
 
     addAssertFuncs(assert, assertFuncs);

--- a/core/src/assert/const.ts
+++ b/core/src/assert/const.ts
@@ -16,4 +16,3 @@
  * change over time).
  */
 export const CHECK_INTERNAL_STACK_FRAME_REGEX = /at [a-zA-Z]*\.?(_fn|_processFn|_assertFunc|_exec|_exprFn|_runOp|_runExpr)/;
-

--- a/core/src/assert/funcs/closeTo.ts
+++ b/core/src/assert/funcs/closeTo.ts
@@ -18,7 +18,7 @@ import { MsgSource } from "../interface/types";
  * @param delta - The maximum allowed difference between actual and expected. Note: A negative delta will never result in a passing assertion since the absolute difference is always non-negative.
  * @param evalMsg - The message to display if the assertion fails.
  * @returns - The assert scope.
- * @since 0.1.7
+ * @since 0.1.5
  * @example
  * ```typescript
  * import { assert } from "@nevware21/tripwire";

--- a/core/src/assert/funcs/operator.ts
+++ b/core/src/assert/funcs/operator.ts
@@ -1,0 +1,99 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2026 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { IAssertScope } from "../interface/IAssertScope";
+import { MsgSource } from "../interface/types";
+
+/**
+ * Asserts that a boolean comparison operation between value and expected using the given operator is true.
+ * Supports comparison operators: ==, ===, <, >, <=, >=, !=, !==, typeof
+ * The support for typeof is in the form of `typeof XXX` === `"expected"`, where expected is the type name string.
+ * @param this - The assert scope.
+ * @param operator - The boolean comparison operator to use (or "typeof" for type checking).
+ * @param expected - The expected value to compare against (or expected type string for typeof).
+ * @param evalMsg - The message to display if the assertion fails.
+ * @returns - The assert scope.
+ * @since 0.1.5
+ * @example
+ * ```typescript
+ * import { assert } from "@nevware21/tripwire";
+ *
+ * // Comparison operators
+ * assert.operator(1, "<", 2);      // Passes
+ * assert.operator(2, ">", 1);      // Passes
+ * assert.operator(1, "==", 1);     // Passes
+ * assert.operator(1, "===", 1);    // Passes
+ * assert.operator(1, "<=", 1);     // Passes
+ * assert.operator(1, ">=", 1);     // Passes
+ * assert.operator(1, "!=", 2);     // Passes
+ * assert.operator(1, "!==", 2);    // Passes
+ * assert.operator(1, "!==", "1");  // Passes - type difference
+ *
+ * // Typeof operator
+ * assert.operator("hello", "typeof", "string");  // Passes - simplistic type check
+ * assert.operator(123, "typeof", "number");      // Passes
+ * assert.operator(true, "typeof", "boolean");    // Passes
+ *
+ * // Failures
+ * assert.operator(2, "<", 1);      // Fails
+ * assert.operator(123, "typeof", "string");  // Fails
+ * ```
+ */
+export function operatorFunc<R>(this: IAssertScope, operator: string, expected: any, evalMsg?: MsgSource): R {
+    let context = this.context;
+
+    // val1 comes from context.value (the first argument passed to assert.operator)
+    let value = context.value;
+    let result: boolean;
+    
+    switch (operator) {
+        case "==":
+            // eslint-disable-next-line eqeqeq
+            result = value == expected;
+            break;
+        case "===":
+            result = value === expected;
+            break;
+        case "<":
+            result = value < expected;
+            break;
+        case ">":
+            result = value > expected;
+            break;
+        case "<=":
+            result = value <= expected;
+            break;
+        case ">=":
+            result = value >= expected;
+            break;
+        case "!=":
+            // eslint-disable-next-line eqeqeq
+            result = value != expected;
+            break;
+        case "!==":
+            result = value !== expected;
+            break;
+        case "typeof":
+            result = typeof value === expected;
+            break;
+        default:
+            context.set("operator", operator);
+            context.fail(evalMsg || "Invalid operator {operator}");
+            return this.that;
+    }
+
+    context.set("operator", operator);
+    context.set("expected", expected);
+
+    context.eval(
+        result,
+        evalMsg || ("expected {value} to be " + operator + " {expected}")
+    );
+
+    return this.that;
+}

--- a/core/src/assert/funcs/valuesFunc.ts
+++ b/core/src/assert/funcs/valuesFunc.ts
@@ -117,7 +117,7 @@ export function anyValuesFunc<R>(_scope: IAssertScope): ValuesFn<R> {
             }
         });
 
-        context.eval(found, `expected any value: [${_formatValues(expectedValues)}], found: [${_formatValues(checkValue)}] (${checkLength} value${checkLength > 1 ? "s" : ""})`);
+        context.eval(found, `expected any value: [${_formatValues(expectedValues)}], found: [${_formatValues(checkValue)}] (${checkLength} value${checkLength > 1 ? "s" : EMPTY_STRING})`);
 
         return scope.that;
     }
@@ -161,7 +161,7 @@ export function allValuesFunc<R>(_scope: IAssertScope): ValuesFn<R> {
             }
         });
 
-        context.eval(missingValues.length === 0, `expected all values: [${_formatValues(expectedValues)}], missing: [${_formatValues(missingValues)}], found: [${_formatValues(checkValue)}] (${checkLength} value${checkLength > 1 ? "s" : ""})`);
+        context.eval(missingValues.length === 0, `expected all values: [${_formatValues(expectedValues)}], missing: [${_formatValues(missingValues)}], found: [${_formatValues(checkValue)}] (${checkLength} value${checkLength > 1 ? "s" : EMPTY_STRING})`);
 
         return scope.that;
     }

--- a/core/src/assert/interface/IAssertClass.ts
+++ b/core/src/assert/interface/IAssertClass.ts
@@ -2008,7 +2008,7 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * @param delta - The maximum allowed difference between actual and expected. Must be a number. Note: A negative delta will never result in a passing assertion since the absolute difference is always non-negative.
      * @param initMsg - The message to display if the assertion fails.
      * @returns - An assert instance for further chaining.
-     * @since 0.1.7
+     * @since 0.1.5
      * @example
      * ```typescript
      * assert.closeTo(1.5, 1.0, 0.5);  // Passes - difference is 0.5
@@ -2028,7 +2028,7 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * @param delta - The maximum allowed difference. Must be a number. Note: A negative delta will always result in a passing assertion since the absolute difference is always non-negative.
      * @param initMsg - The message to display if the assertion fails.
      * @returns - An assert instance for further chaining.
-     * @since 0.1.7
+     * @since 0.1.5
      * @example
      * ```typescript
      * assert.notCloseTo(2, 1.0, 0.5);   // Passes - difference is 1.0 which is > 0.5
@@ -2046,7 +2046,7 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * @param delta - The maximum allowed difference between actual and expected. Must be a number. Note: A negative delta will never result in a passing assertion since the absolute difference is always non-negative.
      * @param initMsg - The message to display if the assertion fails.
      * @returns - An assert instance for further chaining.
-     * @since 0.1.7
+     * @since 0.1.5
      * @example
      * ```typescript
      * assert.approximately(1.5, 1.0, 0.5);  // Passes - difference is 0.5
@@ -2064,7 +2064,7 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * @param delta - The maximum allowed difference. Must be a number. Note: A negative delta will always result in a passing assertion since the absolute difference is always non-negative.
      * @param initMsg - The message to display if the assertion fails.
      * @returns - An assert instance for further chaining.
-     * @since 0.1.7
+     * @since 0.1.5
      * @example
      * ```typescript
      * assert.notApproximately(2, 1.0, 0.5);   // Passes - difference is 1.0 which is > 0.5
@@ -2072,6 +2072,39 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * ```
      */
     notApproximately(actual: number, expected: number, delta: number, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that value is compared to expected using the given operator and the result is true.
+     * Supports comparison operators: ==, ===, <, >, <=, >=, !=, !==, typeof
+     * The support for typeof is in the form of `typeof XXX` === `"expected"`, where expected is the type name string.
+     * @param value - The first value to compare.
+     * @param operator - The comparison operator to use.
+     * @param expected - The second value to compare.
+     * @param initMsg - The message to display if the assertion fails.
+     * @returns - An assert instance for further chaining.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.operator(1, "<", 2);      // Passes
+     * assert.operator(2, ">", 1);      // Passes
+     * assert.operator(1, "==", 1);     // Passes
+     * assert.operator(1, "===", 1);    // Passes
+     * assert.operator(1, "<=", 1);     // Passes
+     * assert.operator(1, ">=", 1);     // Passes
+     * assert.operator(1, "!=", 2);     // Passes
+     * assert.operator(1, "!==", 2);    // Passes
+     * assert.operator(1, "!==", "1");  // Passes - type difference
+     * assert.operator(2, "<", 1);      // Throws AssertionFailure
+     * assert.operator(1, "=", 2);      // Throws AssertionFailure - invalid operator
+     *
+     * // Typeof operator
+     * assert.operator("hello", "typeof", "string");  // Passes - simplistic type check
+     * assert.operator(123, "typeof", "number");      // Passes
+     * assert.operator(true, "typeof", "boolean");    // Passes
+     * assert.operator(123, "typeof", "string");  // Throws AssertionFailure
+     * ```
+     */
+    operator(value: any, operator: string, expected: any, initMsg?: MsgSource): AssertInst;
 }
 
 export type IExtendedAssert<T = any> = IAssertClass<IAssertInst & T> & T;

--- a/core/src/assert/interface/funcs/CloseToFn.ts
+++ b/core/src/assert/interface/funcs/CloseToFn.ts
@@ -12,7 +12,7 @@ import { MsgSource } from "../types";
  * This interface provides methods for checking if the current `actual` value is
  * close to an expected value within a specified delta (tolerance).
  * @template R - The type of the result of the operation.
- * @since 0.1.7
+ * @since 0.1.5
  */
 export interface CloseToFn<R> {
 

--- a/core/src/assert/interface/funcs/OperatorFn.ts
+++ b/core/src/assert/interface/funcs/OperatorFn.ts
@@ -1,0 +1,30 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2026 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { MsgSource } from "../types";
+
+/**
+ * This interface provides methods for comparing two values using a comparison operator.
+ * Supports operators: ==, ===, <, >, <=, >=, !=, !==
+ * @template R - The type of the result of the operation.
+ * @since 0.1.5
+ */
+export interface OperatorFn<R> {
+
+    /**
+     * Asserts that the relationship between value and expected using the given operator is true.
+     * Note: val1 is obtained from the scoped value (context.value) - the first parameter passed to assert.operator()
+     * @param operator - The comparison operator (==, ===, <, >, <=, >=, !=, !==)
+     * @param expected - The second value to compare
+     * @param evalMsg - The message to evaluate if the assertion fails
+     * @returns The result of the operation, which will generally be the existing
+     * {@link IAssertScope.that} object.
+     * @throws An {@link AssertionFailure} if the assertion fails or if an invalid operator is provided
+     */
+    (operator: string, expected: any, evalMsg?: MsgSource): R;
+}

--- a/core/src/assert/interface/ops/IIsOp.ts
+++ b/core/src/assert/interface/ops/IIsOp.ts
@@ -59,7 +59,7 @@ export interface IIsOp<R> extends INotOp<IIsOp<R>>, IEqualOp<R>, IIsTypeOp<R>, I
      * @param delta - The maximum allowed difference between actual and expected. Note: A negative delta will never result in a passing assertion since the absolute difference is always non-negative.
      * @param evalMsg - The message to evaluate if the assertion fails.
      * @returns The result of the operation.
-     * @since 0.1.7
+     * @since 0.1.5
      * @example
      * ```typescript
      * import { assert } from "@nevware21/tripwire";
@@ -79,7 +79,7 @@ export interface IIsOp<R> extends INotOp<IIsOp<R>>, IEqualOp<R>, IIsTypeOp<R>, I
      * @param delta - The maximum allowed difference between actual and expected. Note: A negative delta will never result in a passing assertion since the absolute difference is always non-negative.
      * @param evalMsg - The message to evaluate if the assertion fails.
      * @returns The result of the operation.
-     * @since 0.1.7
+     * @since 0.1.5
      * @example
      * ```typescript
      * import { assert } from "@nevware21/tripwire";

--- a/core/src/assert/internal/_baseFunctions.ts
+++ b/core/src/assert/internal/_baseFunctions.ts
@@ -9,6 +9,7 @@
 import { equalsFunc } from "../funcs/equal";
 import { hasOwnPropertyFunc, hasPropertyFunc } from "../funcs/hasProperty";
 import { matchFunc } from "../funcs/match";
+import { operatorFunc } from "../funcs/operator";
 import { throwsFunc } from "../funcs/throws";
 import { truthyFunc } from "../funcs/truthy";
 import { IAssertInst, IAssertScopeFuncDef } from "../interface/IAssertInst";
@@ -96,6 +97,7 @@ export const coreFunctions: _AssertInstScopeFuncs = {
     equal: _asFunc(equalsFunc),
     equals: _asFunc(equalsFunc),
     eq: _asFunc(equalsFunc),
+    operator: _asFunc(operatorFunc),
 
     throws: _asFunc(throwsFunc),
     toThrow: _asFunc(throwsFunc),

--- a/core/src/assert/internal/_formatValue.ts
+++ b/core/src/assert/internal/_formatValue.ts
@@ -216,7 +216,7 @@ const _defaultConstructorFormatter: IFormatter = {
             if (value && ("constructor" in value && value.constructor && value.constructor.name)) {
                 result = {
                     res: eFormatResult.Ok,
-                    val: "[" + value.constructor.name + ":" + (JSON.stringify(value) || "").replace(/"(\w+)"\s*:\s{0,1}/g, "$1:") + "]"
+                    val: "[" + value.constructor.name + ":" + (JSON.stringify(value) || EMPTY_STRING).replace(/"(\w+)"\s*:\s{0,1}/g, "$1:") + "]"
                 };
             }
         } catch (e) {
@@ -228,7 +228,7 @@ const _defaultConstructorFormatter: IFormatter = {
                 if (value && ("name" in value && value.constructor && value.constructor.name)) {
                     result = {
                         res: eFormatResult.Ok,
-                        val: "[" + value.name + ":" + (JSON.stringify(value) || "").replace(/"(\w+)"\s*:\s{0,1}/g, "$1:") + "]"
+                        val: "[" + value.name + ":" + (JSON.stringify(value) || EMPTY_STRING).replace(/"(\w+)"\s*:\s{0,1}/g, "$1:") + "]"
                     };
                 }
             } catch (e) {

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -41,6 +41,7 @@ import { INumericOp } from "./assert/interface/ops/INumericOp";
 import { NumberFn } from "./assert/interface/funcs/NumericFn";
 import { WithinFn } from "./assert/interface/funcs/WithinFn";
 import { CloseToFn } from "./assert/interface/funcs/CloseToFn";
+import { OperatorFn } from "./assert/interface/funcs/OperatorFn";
 import { KeysFn } from "./assert/interface/funcs/KeysFn";
 import { IncludeFn } from "./assert/interface/funcs/IncludeFn";
 import { ValuesFn } from "./assert/interface/funcs/ValuesFn";
@@ -89,7 +90,7 @@ export {
 export {
     AssertClassDef, AssertFn, AssertInstHandlers, AssertScopeFuncDefs, CloseToFn, EqualFn,
     ErrorLikeFn, EvalFn, IncludeFn, InstanceOfFn, IScopeFn, KeysFn, MsgSource, NumberFn,
-    SymbolFn, ThrowFn, ValuesFn, WithinFn
+    OperatorFn, SymbolFn, ThrowFn, ValuesFn, WithinFn
 };
 
 /**

--- a/core/test/src/assert/assert.operator.test.ts
+++ b/core/test/src/assert/assert.operator.test.ts
@@ -1,0 +1,375 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2026 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { assert } from "../../../src/assert/assertClass";
+import { checkError } from "../support/checkError";
+
+describe("assert.operator", () => {
+    describe("== (loose equality)", () => {
+        it("should pass when values are loosely equal", () => {
+            assert.operator(1, "==", 1);
+            assert.operator("1", "==", 1);
+            assert.operator(true, "==", 1);
+            assert.operator(false, "==", 0);
+            assert.operator(null, "==", undefined);
+            assert.operator(undefined, "==", null);
+            assert.operator([], "==", false);
+        });
+
+        it("should fail when values are not loosely equal", () => {
+            checkError(
+                () => assert.operator(1, "==", 2),
+                "expected 1 to be == 2"
+            );
+        });
+
+        it("should work with custom message", () => {
+            checkError(
+                () => assert.operator(1, "==", 2, "custom message"),
+                "custom message"
+            );
+        });
+    });
+
+    describe("=== (strict equality)", () => {
+        it("should pass when values are strictly equal", () => {
+            assert.operator(1, "===", 1);
+            assert.operator("test", "===", "test");
+            assert.operator(true, "===", true);
+            assert.operator(null, "===", null);
+            assert.operator(undefined, "===", undefined);
+        });
+
+        it("should fail when values are not strictly equal", () => {
+            checkError(
+                () => assert.operator(1, "===", "1"),
+                "expected 1 to be === \"1\""
+            );
+        });
+
+        it("should fail on type coercion cases", () => {
+            checkError(
+                () => assert.operator(null, "===", undefined),
+                "expected null to be === undefined"
+            );
+        });
+    });
+
+    describe("< (less than)", () => {
+        it("should pass when first value is less than second", () => {
+            assert.operator(1, "<", 2);
+            assert.operator(-10, "<", 0);
+            assert.operator(0, "<", 1);
+            assert.operator("a", "<", "b");
+        });
+
+        it("should fail when first value is not less than second", () => {
+            checkError(
+                () => assert.operator(2, "<", 1),
+                "expected 2 to be < 1"
+            );
+        });
+
+        it("should fail when values are equal", () => {
+            checkError(
+                () => assert.operator(1, "<", 1),
+                "expected 1 to be < 1"
+            );
+        });
+
+        it("should work with custom message", () => {
+            checkError(
+                () => assert.operator(2, "<", 1, "blah"),
+                "blah"
+            );
+        });
+    });
+
+    describe("> (greater than)", () => {
+        it("should pass when first value is greater than second", () => {
+            assert.operator(2, ">", 1);
+            assert.operator(0, ">", -10);
+            assert.operator(100, ">", 99);
+            assert.operator("b", ">", "a");
+        });
+
+        it("should fail when first value is not greater than second", () => {
+            checkError(
+                () => assert.operator(1, ">", 2),
+                "expected 1 to be > 2"
+            );
+        });
+
+        it("should fail when values are equal", () => {
+            checkError(
+                () => assert.operator(1, ">", 1),
+                "expected 1 to be > 1"
+            );
+        });
+    });
+
+    describe("<= (less than or equal)", () => {
+        it("should pass when first value is less than second", () => {
+            assert.operator(1, "<=", 2);
+            assert.operator(-10, "<=", 0);
+        });
+
+        it("should pass when values are equal", () => {
+            assert.operator(1, "<=", 1);
+            assert.operator(0, "<=", 0);
+            assert.operator(-5, "<=", -5);
+        });
+
+        it("should fail when first value is greater than second", () => {
+            checkError(
+                () => assert.operator(2, "<=", 1),
+                "expected 2 to be <= 1"
+            );
+        });
+    });
+
+    describe(">= (greater than or equal)", () => {
+        it("should pass when first value is greater than second", () => {
+            assert.operator(2, ">=", 1);
+            assert.operator(0, ">=", -10);
+        });
+
+        it("should pass when values are equal", () => {
+            assert.operator(1, ">=", 1);
+            assert.operator(0, ">=", 0);
+            assert.operator(-5, ">=", -5);
+        });
+
+        it("should fail when first value is less than second", () => {
+            checkError(
+                () => assert.operator(1, ">=", 2),
+                "expected 1 to be >= 2"
+            );
+        });
+    });
+
+    describe("!= (loose inequality)", () => {
+        it("should pass when values are not loosely equal", () => {
+            assert.operator(1, "!=", 2);
+            assert.operator("a", "!=", "b");
+            assert.operator(true, "!=", false);
+        });
+
+        it("should fail when values are loosely equal", () => {
+            checkError(
+                () => assert.operator(1, "!=", 1),
+                "expected 1 to be != 1"
+            );
+        });
+
+        it("should fail on type coercion cases", () => {
+            checkError(
+                () => assert.operator(1, "!=", "1"),
+                "expected 1 to be != \"1\""
+            );
+        });
+    });
+
+    describe("!== (strict inequality)", () => {
+        it("should pass when values are not strictly equal", () => {
+            assert.operator(1, "!==", 2);
+            assert.operator(1, "!==", "1");
+            assert.operator(null, "!==", undefined);
+            assert.operator(true, "!==", 1);
+        });
+
+        it("should fail when values are strictly equal", () => {
+            checkError(
+                () => assert.operator(1, "!==", 1),
+                "expected 1 to be !== 1"
+            );
+        });
+    });
+
+    describe("typeof (type checking)", () => {
+        it("should pass when typeof matches expected type", () => {
+            assert.operator("hello", "typeof", "string");
+            assert.operator(123, "typeof", "number");
+            assert.operator(true, "typeof", "boolean");
+            assert.operator({}, "typeof", "object");
+            assert.operator([], "typeof", "object");
+            assert.operator(() => {}, "typeof", "function");
+            assert.operator(undefined, "typeof", "undefined");
+            assert.operator(Symbol(), "typeof", "symbol");
+            assert.operator(BigInt(123), "typeof", "bigint");
+        });
+
+        it("should fail when typeof does not match expected type", () => {
+            checkError(() => {
+                assert.operator("hello", "typeof", "number");
+            }, "expected \"hello\" to be typeof \"number\"");
+        });
+
+        it("should fail with correct type names", () => {
+            checkError(() => {
+                assert.operator(123, "typeof", "string");
+            }, "expected 123 to be typeof \"string\"");
+
+            checkError(() => {
+                assert.operator(true, "typeof", "number");
+            }, "expected true to be typeof \"number\"");
+        });
+
+        it("should work with custom message", () => {
+            assert.operator("test", "typeof", "string", "Should be a string");
+            
+            checkError(() => {
+                assert.operator(123, "typeof", "string", "Value must be a string");
+            }, "Value must be a string");
+        });
+    });
+
+    describe("invalid operator", () => {
+        it("should fail with invalid operator", () => {
+            checkError(
+                () => assert.operator(1, "=", 2),
+                /Invalid operator/
+            );
+        });
+
+        it("should work with custom message on invalid operator", () => {
+            checkError(
+                () => assert.operator(1, "=", 2, "blah"),
+                "blah"
+            );
+        });
+
+        it("should fail with other invalid operators", () => {
+            checkError(
+                () => assert.operator(1, ">>", 2),
+                /Invalid operator/
+            );
+
+            checkError(
+                () => assert.operator(1, "&&", 2),
+                /Invalid operator/
+            );
+
+            checkError(
+                () => assert.operator(1, "||", 2),
+                /Invalid operator/
+            );
+        });
+    });
+
+    describe("edge cases", () => {
+        it("should handle null and undefined", () => {
+            let w: any;
+            assert.operator(w, "==", undefined);
+            assert.operator(w, "===", undefined);
+            assert.operator(w, "==", null);
+            assert.operator(null, "==", null);
+            assert.operator(undefined, "==", undefined);
+        });
+
+        it("should handle NaN (always not equal to itself)", () => {
+            checkError(
+                () => assert.operator(NaN, "==", NaN),
+                "expected NaN to be == NaN"
+            );
+
+            checkError(
+                () => assert.operator(NaN, "===", NaN),
+                "expected NaN to be === NaN"
+            );
+
+            assert.operator(NaN, "!=", NaN);
+            assert.operator(NaN, "!==", NaN);
+        });
+
+        it("should handle zero values", () => {
+            assert.operator(0, "==", 0);
+            assert.operator(0, "===", 0);
+            assert.operator(-0, "===", 0);
+            assert.operator(+0, "===", 0);
+        });
+
+        it("should handle boolean comparisons", () => {
+            assert.operator(true, "==", true);
+            assert.operator(false, "==", false);
+            assert.operator(true, "!=", false);
+            assert.operator(true, "!==", false);
+        });
+
+        it("should handle string comparisons", () => {
+            assert.operator("abc", "<", "abd");
+            assert.operator("xyz", ">", "abc");
+            assert.operator("test", "==", "test");
+            assert.operator("test", "===", "test");
+        });
+
+        it("should handle type coercion with ==", () => {
+            assert.operator(1, "==", "1");
+            assert.operator(0, "==", false);
+            assert.operator(1, "==", true);
+            assert.operator("", "==", false);
+        });
+
+        it("should not coerce with ===", () => {
+            assert.operator(1, "!==", "1");
+            assert.operator(0, "!==", false);
+            assert.operator(1, "!==", true);
+            assert.operator("", "!==", false);
+        });
+
+        it("should handle objects (by reference)", () => {
+            const obj1 = { a: 1 };
+            const obj2 = { a: 1 };
+            const obj3 = obj1;
+
+            assert.operator(obj1, "===", obj1);
+            assert.operator(obj1, "===", obj3);
+            assert.operator(obj1, "!==", obj2);
+            assert.operator(obj2, "!==", obj3);
+        });
+
+        it("should handle arrays (by reference)", () => {
+            const arr1 = [1, 2, 3];
+            const arr2 = [1, 2, 3];
+            const arr3 = arr1;
+
+            assert.operator(arr1, "===", arr1);
+            assert.operator(arr1, "===", arr3);
+            assert.operator(arr1, "!==", arr2);
+        });
+    });
+
+    describe("real-world scenarios", () => {
+        it("should work with numeric ranges", () => {
+            const age = 25;
+            assert.operator(age, ">=", 18);
+            assert.operator(age, "<", 65);
+        });
+
+        it("should work with version comparison", () => {
+            const version = "1.2.3";
+            assert.operator(version, "!==", "1.2.2");
+            assert.operator(version, "===", "1.2.3");
+        });
+
+        it("should work with status codes", () => {
+            const statusCode = 200;
+            assert.operator(statusCode, ">=", 200);
+            assert.operator(statusCode, "<", 300);
+        });
+
+        it("should work with boundary checks", () => {
+            const value = 50;
+            const min = 0;
+            const max = 100;
+
+            assert.operator(value, ">=", min);
+            assert.operator(value, "<=", max);
+        });
+    });
+});

--- a/shim/chai/src/assert/chaiAssert.ts
+++ b/shim/chai/src/assert/chaiAssert.ts
@@ -138,7 +138,7 @@ function _createChaiAssert(): IChaiAssert {
         throws: { scopeFn: createExprAdapter("throws"), nArgs: 3 },
         Throw: { scopeFn: createExprAdapter("throws"), nArgs: 3 },
         doesNotThrow: { scopeFn: createExprAdapter("not.throws"), nArgs: 3 },
-        operator: notImplemented,
+        operator: { scopeFn: createExprAdapter("operator"), nArgs: 3 },
         closeTo: { scopeFn: createExprAdapter("is.closeTo"), nArgs: 3 },
         approximately: { scopeFn: createExprAdapter("is.approximately"), nArgs: 3 },
 

--- a/shim/chai/test/src/chaiAssert.test.ts
+++ b/shim/chai/test/src/chaiAssert.test.ts
@@ -1872,62 +1872,62 @@ describe("assert", function () {
     //     }, "This is an error message");
     // });
 
-    // it("operator", function() {
-    // // For testing undefined and null with == and ===
-    //     var w: any;
+    it("operator", function() {
+    // For testing undefined and null with == and ===
+        var w: any;
 
-    //     assert.operator(1, "<", 2);
-    //     assert.operator(2, ">", 1);
-    //     assert.operator(1, "==", 1);
-    //     assert.operator(1, "<=", 1);
-    //     assert.operator(1, ">=", 1);
-    //     assert.operator(1, "!=", 2);
-    //     assert.operator(1, "!==", 2);
-    //     assert.operator(1, "!==", "1");
-    //     assert.operator(w, "==", undefined);
-    //     assert.operator(w, "===", undefined);
-    //     assert.operator(w, "==", null);
+        assert.operator(1, "<", 2);
+        assert.operator(2, ">", 1);
+        assert.operator(1, "==", 1);
+        assert.operator(1, "<=", 1);
+        assert.operator(1, ">=", 1);
+        assert.operator(1, "!=", 2);
+        assert.operator(1, "!==", 2);
+        assert.operator(1, "!==", "1");
+        assert.operator(w, "==", undefined);
+        assert.operator(w, "===", undefined);
+        assert.operator(w, "==", null);
 
-    //     err(function () {
-    //         assert.operator(1, "=", 2, "blah");
-    //     }, "blah: Invalid operator \"=\"");
+        err(function () {
+            assert.operator(1, "=", 2, "blah");
+        }, "blah: Invalid operator \"=\"");
 
-    //     err(function () {
-    //         assert.operator(2, "<", 1, "blah");
-    //     }, "blah: expected 2 to be < 1");
+        err(function () {
+            assert.operator(2, "<", 1, "blah");
+        }, "blah: expected 2 to be < 1");
 
-    //     err(function () {
-    //         assert.operator(1, ">", 2);
-    //     }, "expected 1 to be > 2");
+        err(function () {
+            assert.operator(1, ">", 2);
+        }, "expected 1 to be > 2");
 
-    //     err(function () {
-    //         assert.operator(1, "==", 2);
-    //     }, "expected 1 to be == 2");
+        err(function () {
+            assert.operator(1, "==", 2);
+        }, "expected 1 to be == 2");
 
-    //     err(function () {
-    //         assert.operator(1, "===", "1");
-    //     }, "expected 1 to be === \"1\"");
+        err(function () {
+            assert.operator(1, "===", "1");
+        }, "expected 1 to be === \"1\"");
 
-    //     err(function () {
-    //         assert.operator(2, "<=", 1);
-    //     }, "expected 2 to be <= 1");
+        err(function () {
+            assert.operator(2, "<=", 1);
+        }, "expected 2 to be <= 1");
 
-    //     err(function () {
-    //         assert.operator(1, ">=", 2);
-    //     }, "expected 1 to be >= 2");
+        err(function () {
+            assert.operator(1, ">=", 2);
+        }, "expected 1 to be >= 2");
 
-    //     err(function () {
-    //         assert.operator(1, "!=", 1);
-    //     }, "expected 1 to be != 1");
+        err(function () {
+            assert.operator(1, "!=", 1);
+        }, "expected 1 to be != 1");
 
-    //     err(function () {
-    //         assert.operator(1, "!==", 1);
-    //     }, "expected 1 to be !== 1");
+        err(function () {
+            assert.operator(1, "!==", 1);
+        }, "expected 1 to be !== 1");
 
-    //     err(function () {
-    //         assert.operator(w, "===", null);
-    //     }, "expected undefined to be === null");
-    // });
+        err(function () {
+            assert.operator(w, "===", null);
+        }, "expected undefined to be === null");
+    });
 
     it("closeTo", function(){
         assert.closeTo(1.5, 1.0, 0.5);


### PR DESCRIPTION
Implements operator() function for boolean comparison operations supporting 9 operators: ==, ===, <, >, <=, >=, !=, !==, and typeof.

Changes:
- Add operator.ts with operatorFunc supporting all comparison operators
- Add typeof operator for simplistic type checking (typeof value === expected)
- Add OperatorFn interface and export in index.ts
- Add operator to assertClass with nArgs: 3 parameter handling
- Add operator to AssertInst prototype via _baseFunctions.ts (required for Chai shim)
- Add assert.operator() method to IAssertClass interface
- Enable operator in Chai shim via createExprAdapter("operator")
- Enable operator tests in chaiAssert.test.ts

Technical details:
- First parameter extracted from context.value, remaining params passed to function
- Error message format: "expected {value} to be <operator> {expected}"
- Typeof implementation: typeof value === expected
- Invalid operators fail with clear error message

Also includes:
- Fix @since version tags for closeTo/approximately (0.1.7 → 0.1.5)
- Code cleanup (EMPTY_STRING usage, trailing whitespace removal)