### PR TITLE
feat: Add endsWith and subsequence member comparison functions

### DIFF
--- a/core/src/assert/assertClass.ts
+++ b/core/src/assert/assertClass.ts
@@ -38,7 +38,11 @@ import { instanceOfFunc } from "./funcs/instanceOf";
 import { lengthFunc } from "./funcs/length";
 import { closeToFunc } from "./funcs/closeTo";
 import { operatorFunc } from "./funcs/operator";
-import { includeMembersFunc, includeDeepMembersFunc, includeOrderedMembersFunc, includeDeepOrderedMembersFunc, sameMembersFunc, sameDeepMembersFunc, sameOrderedMembersFunc, sameDeepOrderedMembersFunc, startsWithMembersFunc, startsWithDeepMembersFunc } from "./funcs/members";
+import { 
+    includeMembersFunc, includeDeepMembersFunc, includeOrderedMembersFunc, includeDeepOrderedMembersFunc,
+    sameMembersFunc, sameDeepMembersFunc, sameOrderedMembersFunc, sameDeepOrderedMembersFunc, startsWithMembersFunc,
+    startsWithDeepMembersFunc, endsWithMembersFunc, endsWithDeepMembersFunc, subsequenceFunc, deepSubsequenceFunc
+} from "./funcs/members";
 
 /**
  * @internal
@@ -297,7 +301,15 @@ export function createAssert(): IAssertClass {
         startsWithMembers: { scopeFn: startsWithMembersFunc, nArgs: 2 },
         notStartsWithMembers: { scopeFn: createExprAdapter("not", startsWithMembersFunc), nArgs: 2 },
         startsWithDeepMembers: { scopeFn: startsWithDeepMembersFunc, nArgs: 2 },
-        notStartsWithDeepMembers: { scopeFn: createExprAdapter("not", startsWithDeepMembersFunc), nArgs: 2 }
+        notStartsWithDeepMembers: { scopeFn: createExprAdapter("not", startsWithDeepMembersFunc), nArgs: 2 },
+        endsWithMembers: { scopeFn: endsWithMembersFunc, nArgs: 2 },
+        notEndsWithMembers: { scopeFn: createExprAdapter("not", endsWithMembersFunc), nArgs: 2 },
+        endsWithDeepMembers: { scopeFn: endsWithDeepMembersFunc, nArgs: 2 },
+        notEndsWithDeepMembers: { scopeFn: createExprAdapter("not", endsWithDeepMembersFunc), nArgs: 2 },
+        subsequence: { scopeFn: subsequenceFunc, nArgs: 2 },
+        notSubsequence: { scopeFn: createExprAdapter("not", subsequenceFunc), nArgs: 2 },
+        deepSubsequence: { scopeFn: deepSubsequenceFunc, nArgs: 2 },
+        notDeepSubsequence: { scopeFn: createExprAdapter("not", deepSubsequenceFunc), nArgs: 2 }
     };
 
     addAssertFuncs(assert, assertFuncs);

--- a/core/src/assert/interface/IAssertClass.ts
+++ b/core/src/assert/interface/IAssertClass.ts
@@ -2484,6 +2484,146 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * ```
      */
     notStartsWithDeepMembers<T>(actual: ArrayLikeOrSizedIterable<T>, expected: ArrayLikeOrSizedIterable<T>, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the target collection ends with the expected members in consecutive order at the end.
+     * Uses strict equality (===) for comparison.
+     * Both arguments must conform to {@link ArrayLikeOrSizedIterable} but can be different concrete types.
+     * @param actual - The collection that should end with the expected sequence (must be an {@link ArrayLikeOrSizedIterable}).
+     * @param expected - The expected ending sequence (must be an {@link ArrayLikeOrSizedIterable}).
+     * @param initMsg - The message to display if the assertion fails.
+     * @returns - An assert instance for further chaining.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.endsWithMembers([1, 2, 3, 4], [3, 4]);     // Passes - ends with [3, 4]
+     * assert.endsWithMembers([1, 2, 3, 4], [4]);        // Passes - ends with [4]
+     * assert.endsWithMembers([1, 2, 3, 4], [2, 3]);     // Throws AssertionFailure - doesn't end with [2, 3]
+     * ```
+     */
+    endsWithMembers<T>(actual: ArrayLikeOrSizedIterable<T>, expected: ArrayLikeOrSizedIterable<T>, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the target collection does not end with the expected members in consecutive order at the end.
+     * This is the inverse of {@link endsWithMembers}.
+     * Both arguments must conform to {@link ArrayLikeOrSizedIterable} but can be different concrete types.
+     * @param actual - The collection that should not end with the expected sequence (must be an {@link ArrayLikeOrSizedIterable}).
+     * @param expected - The sequence to check against (must be an {@link ArrayLikeOrSizedIterable}).
+     * @param initMsg - The message to display if the assertion fails.
+     * @returns - An assert instance for further chaining.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.notEndsWithMembers([1, 2, 3, 4], [2, 3]);  // Passes - doesn't end with [2, 3]
+     * assert.notEndsWithMembers([1, 2, 3, 4], [3, 4]);  // Throws AssertionFailure - does end with [3, 4]
+     * ```
+     */
+    notEndsWithMembers<T>(actual: ArrayLikeOrSizedIterable<T>, expected: ArrayLikeOrSizedIterable<T>, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the target collection ends with the expected members in consecutive order at the end.
+     * Uses deep equality for comparison.
+     * Both arguments must conform to {@link ArrayLikeOrSizedIterable} but can be different concrete types.
+     * @param actual - The collection that should end with the expected sequence (must be an {@link ArrayLikeOrSizedIterable}).
+     * @param expected - The expected ending sequence (must be an {@link ArrayLikeOrSizedIterable}).
+     * @param initMsg - The message to display if the assertion fails.
+     * @returns - An assert instance for further chaining.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.endsWithDeepMembers([{a: 1}, {b: 2}, {c: 3}], [{b: 2}, {c: 3}]);  // Passes
+     * assert.endsWithDeepMembers([{a: 1}, {b: 2}, {c: 3}], [{a: 1}]);          // Throws AssertionFailure
+     * ```
+     */
+    endsWithDeepMembers<T>(actual: ArrayLikeOrSizedIterable<T>, expected: ArrayLikeOrSizedIterable<T>, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the target collection does not end with the expected members in consecutive order at the end.
+     * This is the inverse of {@link endsWithDeepMembers}.
+     * Both arguments must conform to {@link ArrayLikeOrSizedIterable} but can be different concrete types.
+     * @param actual - The collection that should not end with the expected sequence (must be an {@link ArrayLikeOrSizedIterable}).
+     * @param expected - The sequence to check against (must be an {@link ArrayLikeOrSizedIterable}).
+     * @param initMsg - The message to display if the assertion fails.
+     * @returns - An assert instance for further chaining.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.notEndsWithDeepMembers([{a: 1}, {b: 2}], [{a: 1}]);  // Passes
+     * assert.notEndsWithDeepMembers([{a: 1}, {b: 2}], [{b: 2}]);  // Throws AssertionFailure
+     * ```
+     */
+    notEndsWithDeepMembers<T>(actual: ArrayLikeOrSizedIterable<T>, expected: ArrayLikeOrSizedIterable<T>, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the target collection contains a subsequence matching the expected members.
+     * The members must appear in the specified order but don't need to be consecutive -
+     * other elements can appear between them. Uses strict equality (===) for comparison.
+     * Both arguments must conform to {@link ArrayLikeOrSizedIterable} but can be different concrete types.
+     * @param actual - The collection that should contain the ordered subsequence (must be an {@link ArrayLikeOrSizedIterable}).
+     * @param expected - The expected ordered subsequence (must be an {@link ArrayLikeOrSizedIterable}).
+     * @param initMsg - The message to display if the assertion fails.
+     * @returns - An assert instance for further chaining.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.subsequence([1, 2, 3, 4, 5], [2, 4, 5]);     // Passes - in order with gaps
+     * assert.subsequence([1, 2, 3, 4, 5], [1, 3, 5]);     // Passes
+     * assert.subsequence([1, 2, 3, 4, 5], [5, 3, 1]);     // Throws AssertionFailure - wrong order
+     * ```
+     */
+    subsequence<T>(actual: ArrayLikeOrSizedIterable<T>, expected: ArrayLikeOrSizedIterable<T>, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the target collection does not contain a subsequence matching the expected members.
+     * This is the inverse of {@link subsequence}.
+     * Both arguments must conform to {@link ArrayLikeOrSizedIterable} but can be different concrete types.
+     * @param actual - The collection to check (must be an {@link ArrayLikeOrSizedIterable}).
+     * @param expected - The sequence to check against (must be an {@link ArrayLikeOrSizedIterable}).
+     * @param initMsg - The message to display if the assertion fails.
+     * @returns - An assert instance for further chaining.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.notSubsequence([1, 2, 3, 4, 5], [5, 3, 1]);  // Passes - wrong order
+     * assert.notSubsequence([1, 2, 3, 4, 5], [1, 3, 5]);  // Throws AssertionFailure
+     * ```
+     */
+    notSubsequence<T>(actual: ArrayLikeOrSizedIterable<T>, expected: ArrayLikeOrSizedIterable<T>, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the target collection contains a subsequence matching the expected members using deep equality.
+     * The members must appear in the specified order but don't need to be consecutive -
+     * other elements can appear between them.
+     * Both arguments must conform to {@link ArrayLikeOrSizedIterable} but can be different concrete types.
+     * @param actual - The collection that should contain the ordered subsequence (must be an {@link ArrayLikeOrSizedIterable}).
+     * @param expected - The expected ordered subsequence (must be an {@link ArrayLikeOrSizedIterable}).
+     * @param initMsg - The message to display if the assertion fails.
+     * @returns - An assert instance for further chaining.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.deepSubsequence([{a: 1}, {b: 2}, {c: 3}], [{a: 1}, {c: 3}]);  // Passes
+     * assert.deepSubsequence([{a: 1}, {b: 2}, {c: 3}], [{c: 3}, {a: 1}]);  // Throws AssertionFailure
+     * ```
+     */
+    deepSubsequence<T>(actual: ArrayLikeOrSizedIterable<T>, expected: ArrayLikeOrSizedIterable<T>, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the target collection does not contain a subsequence matching the expected members using deep equality.
+     * This is the inverse of {@link deepSubsequence}.
+     * Both arguments must conform to {@link ArrayLikeOrSizedIterable} but can be different concrete types.
+     * @param actual - The collection to check (must be an {@link ArrayLikeOrSizedIterable}).
+     * @param expected - The sequence to check against (must be an {@link ArrayLikeOrSizedIterable}).
+     * @param initMsg - The message to display if the assertion fails.
+     * @returns - An assert instance for further chaining.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.notDeepSubsequence([{a: 1}, {b: 2}], [{b: 2}, {a: 1}]);  // Passes - wrong order
+     * assert.notDeepSubsequence([{a: 1}, {b: 2}], [{a: 1}]);          // Throws AssertionFailure
+     * ```
+     */
+    notDeepSubsequence<T>(actual: ArrayLikeOrSizedIterable<T>, expected: ArrayLikeOrSizedIterable<T>, initMsg?: MsgSource): AssertInst;
 }
 
 export type IExtendedAssert<T = any> = IAssertClass<IAssertInst & T> & T;

--- a/core/src/assert/interface/ops/IIncludeOp.ts
+++ b/core/src/assert/interface/ops/IIncludeOp.ts
@@ -107,4 +107,37 @@ export interface IIncludeOp<R> extends IncludeFn<R> {
      * ```
      */
     startsWithMembers(expected: ArrayLikeOrSizedIterable, evalMsg?: MsgSource): R;
+
+    /**
+     * Asserts that the target collection ends with the expected members in consecutive order at the end.
+     * Uses deep equality when in deep context, strict equality otherwise.
+     * Both target and expected must conform to {@link ArrayLikeOrSizedIterable} but can be different concrete types.
+     * @since 0.1.5
+     * @param expected - The expected ending sequence (must be an {@link ArrayLikeOrSizedIterable}).
+     * @param evalMsg - Optional error message.
+     * @example
+     * ```typescript
+     * expect([1, 2, 3, 4]).includes.endsWithMembers([3, 4]);  // Passes
+     * expect([1, 2, 3, 4]).includes.endsWithMembers([2, 3]);  // Fails - doesn't end with [2, 3]
+     * ```
+     */
+    endsWithMembers(expected: ArrayLikeOrSizedIterable, evalMsg?: MsgSource): R;
+
+    /**
+     * Asserts that the target collection contains a subsequence matching the expected members.
+     * The members must appear in the specified order but don't need to be consecutive -
+     * other elements can appear between them.
+     * Uses deep equality when in deep context, strict equality otherwise.
+     * Both target and expected must conform to {@link ArrayLikeOrSizedIterable} but can be different concrete types.
+     * @since 0.1.5
+     * @param expected - The expected ordered subsequence (must be an {@link ArrayLikeOrSizedIterable}).
+     * @param evalMsg - Optional error message.
+     * @example
+     * ```typescript
+     * expect([1, 2, 3, 4, 5]).includes.subsequence([2, 4, 5]);  // Passes - in order with gaps
+     * expect([1, 2, 3, 4, 5]).includes.subsequence([5, 3, 1]);  // Fails - wrong order
+     * expect([{a: 1}, {b: 2}, {c: 3}]).deep.includes.subsequence([{a: 1}, {c: 3}]);  // Passes with deep equality
+     * ```
+     */
+    subsequence(expected: ArrayLikeOrSizedIterable, evalMsg?: MsgSource): R;
 }

--- a/core/src/assert/ops/includeOp.ts
+++ b/core/src/assert/ops/includeOp.ts
@@ -12,7 +12,7 @@ import { allOp, anyOp } from "./allOp";
 import { IAssertInst, AssertScopeFuncDefs } from "../interface/IAssertInst";
 import { IIncludeOp } from "../interface/ops/IIncludeOp";
 import { IAssertScope } from "../interface/IAssertScope";
-import { includeDeepMembersFunc, includeDeepOrderedMembersFunc, includeMembersFunc, includeOrderedMembersFunc, sameDeepMembersFunc, sameDeepOrderedMembersFunc, sameMembersFunc, sameOrderedMembersFunc, startsWithMembersFunc, startsWithDeepMembersFunc } from "../funcs/members";
+import { includeDeepMembersFunc, includeDeepOrderedMembersFunc, includeMembersFunc, includeOrderedMembersFunc, sameDeepMembersFunc, sameDeepOrderedMembersFunc, sameMembersFunc, sameOrderedMembersFunc, startsWithMembersFunc, startsWithDeepMembersFunc, endsWithMembersFunc, endsWithDeepMembersFunc, subsequenceFunc, deepSubsequenceFunc } from "../funcs/members";
 import { _deepEqual } from "../funcs/equal";
 
 /**
@@ -53,7 +53,9 @@ export function includeOp<R>(scope: IAssertScope): IIncludeOp<R> {
         orderedMembers: { scopeFn: includeOrderedMembersFunc },
         sameMembers: { scopeFn: sameMembersFunc },
         sameOrderedMembers: { scopeFn: sameOrderedMembersFunc },
-        startsWithMembers: { scopeFn: startsWithMembersFunc }
+        startsWithMembers: { scopeFn: startsWithMembersFunc },
+        endsWithMembers: { scopeFn: endsWithMembersFunc },
+        subsequence: { scopeFn: subsequenceFunc }
     };
 
     return scope.createOperation(props, _includes);
@@ -107,7 +109,9 @@ export function deepIncludeOp<R>(scope: IAssertScope): IIncludeOp<R> {
         orderedMembers: { scopeFn: includeDeepOrderedMembersFunc },
         sameMembers: { scopeFn: sameDeepMembersFunc },
         sameOrderedMembers: { scopeFn: sameDeepOrderedMembersFunc },
-        startsWithMembers: { scopeFn: startsWithDeepMembersFunc }
+        startsWithMembers: { scopeFn: startsWithDeepMembersFunc },
+        endsWithMembers: { scopeFn: endsWithDeepMembersFunc },
+        subsequence: { scopeFn: deepSubsequenceFunc }
     };
 
     return scope.createOperation(props, _deepIncludes);

--- a/core/test/src/assert/members.test.ts
+++ b/core/test/src/assert/members.test.ts
@@ -971,7 +971,7 @@ describe("Member Comparison Tests", () => {
                 // 2. Circular reference error (if >10 visits detected)
                 // NOT acceptable: null pointer exception from context.fail()
                 assert.isTrue(
-                    e.message.includes("AssertionFailure") || 
+                    e.message.includes("AssertionFailure") ||
                     e.message.includes("Circular reference") ||
                     e.message.includes("expected") ||
                     e.name === "AssertionFailure" ||
@@ -979,6 +979,359 @@ describe("Member Comparison Tests", () => {
                     "Should not throw null pointer exception, got: " + e.message
                 );
             }
+        });
+    });
+
+    describe("endsWithMembers", () => {
+        it("should pass when array ends with the expected sequence", () => {
+            assert.endsWithMembers([1, 2, 3, 4, 5], [4, 5]);
+        });
+
+        it("should pass when arrays are equal", () => {
+            assert.endsWithMembers([1, 2, 3], [1, 2, 3]);
+        });
+
+        it("should pass when expected is empty", () => {
+            assert.endsWithMembers([1, 2, 3], []);
+        });
+
+        it("should fail when array doesn't end with the expected sequence", () => {
+            expect(() => {
+                assert.endsWithMembers([1, 2, 3, 4, 5], [3, 4]);
+            }).to.throw();
+        });
+
+        it("should fail when expected is longer than actual", () => {
+            expect(() => {
+                assert.endsWithMembers([1, 2], [1, 2, 3]);
+            }).to.throw();
+        });
+
+        it("should fail when sequence appears in middle but not at end", () => {
+            expect(() => {
+                assert.endsWithMembers([1, 2, 3, 4, 5], [2, 3]);
+            }).to.throw();
+        });
+
+        it("should work with expect syntax", () => {
+            expect([1, 2, 3, 4]).includes.endsWithMembers([3, 4]);
+            expect([1, 2, 3, 4]).to.include.endsWithMembers([3, 4]);
+        });
+
+        it("should work with not operator", () => {
+            expect([1, 2, 3, 4]).to.not.include.endsWithMembers([1, 2]);
+        });
+
+        it("should fail with correct error message for invalid types", () => {
+            expect(() => {
+                assert.endsWithMembers("not an array" as any, [1, 2]);
+            }).to.throw(/array-like or sized iterable/);
+        });
+
+        describe("with Sets", () => {
+            it("should check if Array ends with Set members", () => {
+                assert.endsWithMembers([1, 2, 3, 4], new Set([3, 4]));
+            });
+
+            it("should check if Set ends with Array members", () => {
+                assert.endsWithMembers(new Set([1, 2, 3, 4]), [3, 4]);
+            });
+
+            it("should check if Set ends with Set members", () => {
+                assert.endsWithMembers(new Set([1, 2, 3]), new Set([2, 3]));
+            });
+
+            it("should fail when Set doesn't end with the sequence", () => {
+                expect(() => {
+                    assert.endsWithMembers(new Set([1, 2, 3]), [1, 2]);
+                }).to.throw();
+            });
+        });
+    });
+
+    describe("endsWithDeepMembers", () => {
+        it("should pass when array ends with the expected deep sequence", () => {
+            assert.endsWithDeepMembers([{a: 1}, {b: 2}, {c: 3}], [{b: 2}, {c: 3}]);
+        });
+
+        it("should fail when array doesn't end with the expected deep sequence", () => {
+            expect(() => {
+                assert.endsWithDeepMembers([{a: 1}, {b: 2}, {c: 3}], [{a: 1}, {b: 2}]);
+            }).to.throw();
+        });
+
+        it("should fail when expected is longer than actual", () => {
+            expect(() => {
+                assert.endsWithDeepMembers([{a: 1}], [{a: 1}, {b: 2}]);
+            }).to.throw();
+        });
+
+        it("should work with expect syntax", () => {
+            expect([{a: 1}, {b: 2}]).deep.includes.endsWithMembers([{b: 2}]);
+            expect([{a: 1}, {b: 2}]).to.deep.include.endsWithMembers([{b: 2}]);
+        });
+
+        it("should work with not operator", () => {
+            expect([{a: 1}, {b: 2}, {c: 3}]).to.not.deep.include.endsWithMembers([{a: 1}]);
+        });
+
+        it("should handle nested arrays", () => {
+            assert.endsWithDeepMembers([[1, 2], [3, 4], [5, 6]], [[3, 4], [5, 6]]);
+        });
+
+        it("should fail with correct error message for invalid types", () => {
+            expect(() => {
+                assert.endsWithDeepMembers("not an array" as any, [{a: 1}]);
+            }).to.throw(/array-like or sized iterable/);
+        });
+
+        describe("with Sets", () => {
+            it("should check if Array ends with Set deep members", () => {
+                assert.endsWithDeepMembers([{a: 1}, {b: 2}, {c: 3}], new Set([{b: 2}, {c: 3}]));
+            });
+
+            it("should check if Set ends with Array deep members", () => {
+                assert.endsWithDeepMembers(new Set([{a: 1}, {b: 2}]), [{b: 2}]);
+            });
+
+            it("should check if Set ends with Set deep members", () => {
+                assert.endsWithDeepMembers(new Set([{a: 1}, {b: 2}]), new Set([{b: 2}]));
+            });
+
+            it("should fail when Set doesn't end with the deep sequence", () => {
+                expect(() => {
+                    assert.endsWithDeepMembers(new Set([{a: 1}, {b: 2}]), [{a: 1}]);
+                }).to.throw();
+            });
+        });
+    });
+
+    describe("subsequence", () => {
+        it("should pass when members appear in order with gaps", () => {
+            assert.subsequence([1, 2, 3, 4, 5], [2, 4, 5]);
+        });
+
+        it("should pass when members appear in order without gaps", () => {
+            assert.subsequence([1, 2, 3, 4, 5], [1, 2, 3]);
+        });
+
+        it("should pass when arrays are equal", () => {
+            assert.subsequence([1, 2, 3], [1, 2, 3]);
+        });
+
+        it("should pass when expected is empty", () => {
+            assert.subsequence([1, 2, 3], []);
+        });
+
+        it("should pass when expected is a single element", () => {
+            assert.subsequence([1, 2, 3, 4, 5], [3]);
+        });
+
+        it("should fail when members appear in wrong order", () => {
+            expect(() => {
+                assert.subsequence([1, 2, 3, 4, 5], [5, 3, 1]);
+            }).to.throw();
+        });
+
+        it("should fail when not all members are present", () => {
+            expect(() => {
+                assert.subsequence([1, 2, 3, 4, 5], [2, 6]);
+            }).to.throw();
+        });
+
+        it("should handle duplicates correctly", () => {
+            assert.subsequence([1, 2, 2, 3, 3, 3], [2, 2, 3]);
+        });
+
+        it("should fail when not enough duplicates", () => {
+            expect(() => {
+                assert.subsequence([1, 2, 3], [2, 2]);
+            }).to.throw();
+        });
+
+        it("should throw with correct message when members appear in wrong order", () => {
+            expect(() => {
+                assert.subsequence([1, 2, 3, 4, 5], [5, 3, 1]);
+            }).to.throw(/expected \[1,2,3,4,5\] to include subsequence \[5,3,1\]/);
+        });
+
+        it("should throw with correct message when not all members are present", () => {
+            expect(() => {
+                assert.subsequence([1, 2, 3, 4, 5], [2, 6]);
+            }).to.throw(/expected \[1,2,3,4,5\] to include subsequence \[2,6\]/);
+        });
+
+        it("should throw with correct message when not enough duplicates", () => {
+            expect(() => {
+                assert.subsequence([1, 2, 3], [2, 2]);
+            }).to.throw(/expected \[1,2,3\] to include subsequence \[2,2\]/);
+        });
+
+        it("should work with expect syntax", () => {
+            expect([1, 2, 3, 4, 5]).includes.subsequence([1, 3, 5]);
+            expect([1, 2, 3, 4, 5]).to.include.subsequence([1, 3, 5]);
+        });
+
+        it("should work with not operator", () => {
+            expect([1, 2, 3, 4, 5]).to.not.include.subsequence([5, 1]);
+        });
+
+        it("should fail with correct error message for invalid types", () => {
+            expect(() => {
+                assert.subsequence("not an array" as any, [1, 2]);
+            }).to.throw(/array-like or sized iterable/);
+        });
+
+        describe("with Sets", () => {
+            it("should check if Array contains Set members in order", () => {
+                assert.subsequence([1, 2, 3, 4, 5], new Set([2, 4]));
+            });
+
+            it("should check if Set contains Array members in order", () => {
+                assert.subsequence(new Set([1, 2, 3, 4]), [1, 3]);
+            });
+
+            it("should check if Set contains Set members in order", () => {
+                assert.subsequence(new Set([1, 2, 3]), new Set([1, 3]));
+            });
+
+            it("should fail when Set doesn't contain members in order", () => {
+                expect(() => {
+                    assert.subsequence(new Set([1, 2, 3]), [3, 1]);
+                }).to.throw();
+            });
+        });
+
+        describe("real-world use cases", () => {
+            it("should validate event sequence with interspersed events", () => {
+                const events = ["start", "init", "loading", "progress", "loaded", "ready"];
+                assert.subsequence(events, ["init", "loaded", "ready"]);
+            });
+
+            it("should validate filtered array maintains order", () => {
+                const numbers = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+                const evens = [2, 4, 6, 8, 10];
+                assert.subsequence(numbers, evens);
+            });
+
+            it("should validate workflow steps occurred in order", () => {
+                const log = ["user_login", "view_page", "click_button", "submit_form", "api_call", "success"];
+                assert.subsequence(log, ["user_login", "submit_form", "success"]);
+            });
+        });
+    });
+
+    describe("deepSubsequence", () => {
+        it("should pass when deep members appear in order with gaps", () => {
+            assert.deepSubsequence([{a: 1}, {b: 2}, {c: 3}, {d: 4}], [{a: 1}, {c: 3}]);
+        });
+
+        it("should pass when deep members appear in order without gaps", () => {
+            assert.deepSubsequence([{a: 1}, {b: 2}, {c: 3}], [{a: 1}, {b: 2}]);
+        });
+
+        it("should pass when arrays are equal", () => {
+            assert.deepSubsequence([{a: 1}, {b: 2}], [{a: 1}, {b: 2}]);
+        });
+
+        it("should pass when expected is empty", () => {
+            assert.deepSubsequence([{a: 1}, {b: 2}], []);
+        });
+
+        it("should fail when members appear in wrong order", () => {
+            expect(() => {
+                assert.deepSubsequence([{a: 1}, {b: 2}, {c: 3}], [{c: 3}, {a: 1}]);
+            }).to.throw();
+        });
+
+        it("should fail when not all members are present", () => {
+            expect(() => {
+                assert.deepSubsequence([{a: 1}, {b: 2}], [{a: 1}, {c: 3}] as any);
+            }).to.throw();
+        });
+
+        it("should throw with correct message when members appear in wrong order", () => {
+            expect(() => {
+                assert.deepSubsequence([{a: 1}, {b: 2}, {c: 3}], [{c: 3}, {a: 1}]);
+            }).to.throw(/expected .* to include deep subsequence .*/);
+        });
+
+        it("should throw with correct message when not all members are present", () => {
+            expect(() => {
+                assert.deepSubsequence([{a: 1}, {b: 2}], [{a: 1}, {c: 3}] as any);
+            }).to.throw(/expected .* to include deep subsequence .*/);
+        });
+
+        it("should handle nested objects", () => {
+            assert.deepSubsequence([{a: {x: 1}}, {b: {y: 2}}, {c: {z: 3}}], [{a: {x: 1}}, {c: {z: 3}}]);
+        });
+
+        it("should handle nested arrays", () => {
+            assert.deepSubsequence([[1, 2], [3, 4], [5, 6], [7, 8]], [[1, 2], [5, 6]]);
+        });
+
+        it("should work with expect syntax", () => {
+            expect([{a: 1}, {b: 2}, {c: 3}]).deep.includes.subsequence([{a: 1}, {c: 3}]);
+            expect([{a: 1}, {b: 2}, {c: 3}]).to.deep.include.subsequence([{a: 1}, {c: 3}]);
+        });
+
+        it("should work with not operator", () => {
+            expect([{a: 1}, {b: 2}, {c: 3}]).to.not.deep.include.subsequence([{c: 3}, {a: 1}]);
+        });
+
+        it("should fail with correct error message for invalid types", () => {
+            expect(() => {
+                assert.deepSubsequence("not an array" as any, [{a: 1}]);
+            }).to.throw(/array-like or sized iterable/);
+        });
+
+        describe("with Sets", () => {
+            it("should check if Array contains Set deep members in order", () => {
+                assert.deepSubsequence([{a: 1}, {b: 2}, {c: 3}], new Set([{a: 1}, {c: 3}]));
+            });
+
+            it("should check if Set contains Array deep members in order", () => {
+                assert.deepSubsequence(new Set([{a: 1}, {b: 2}, {c: 3}]), [{a: 1}, {c: 3}]);
+            });
+
+            it("should check if Set contains Set deep members in order", () => {
+                assert.deepSubsequence(new Set([{a: 1}, {b: 2}]), new Set([{a: 1}]));
+            });
+
+            it("should fail when Set doesn't contain deep members in order", () => {
+                expect(() => {
+                    assert.deepSubsequence(new Set([{a: 1}, {b: 2}]), [{b: 2}, {a: 1}]);
+                }).to.throw();
+            });
+        });
+
+        describe("real-world use cases", () => {
+            it("should validate object event sequence", () => {
+                const events = [
+                    {type: "init", data: {id: 1}},
+                    {type: "loading", data: {id: 1}},
+                    {type: "progress", data: {id: 1, pct: 50}},
+                    {type: "loaded", data: {id: 1}},
+                    {type: "ready", data: {id: 1}}
+                ];
+                assert.deepSubsequence(events, [
+                    {type: "init", data: {id: 1}},
+                    {type: "loaded", data: {id: 1}}
+                ]);
+            });
+
+            it("should validate API response sequence", () => {
+                const responses = [
+                    {status: 200, body: {step: 1}},
+                    {status: 200, body: {step: 2}},
+                    {status: 200, body: {step: 3}},
+                    {status: 201, body: {complete: true}}
+                ];
+                assert.deepSubsequence(responses, [
+                    {status: 200, body: {step: 1}},
+                    {status: 201, body: {complete: true}}
+                ]);
+            });
         });
     });
 });


### PR DESCRIPTION
Add four new member comparison assertion functions with strict and deep equality variants:

- `endsWithMembers` / `endsWithDeepMembers`: Verify arrays end with a specific consecutive sequence
- `subsequence` / `deepSubsequence`: Check for ordered subsequences with gaps allowed