### PR TITLE
feat: Add isNumber and isBoolean assertion methods with comprehensive…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,16 @@ As part of the Mono-Repo it also provides some shim implementations which are de
 ## Key Features
 
 ### Comprehensive Assertion Library
-- Type checking (object, array, string, number, boolean, null, undefined, etc.)
-- Equality assertions (equal, strictEqual, deepEqual)
-- Property checking (has, hasOwn, hasDeep)
-- Collection operations (include, keys, members)
-- **Numeric comparisons** (above, below, within, etc.)
-- Error/exception testing
-- Custom error messages
-- Full `not` operator support
+- **Type checking** - object, array, string, number, boolean, null, undefined, NaN, finite, typeof, instanceof
+- **Equality assertions** - equal, strictEqual, deepEqual, closeTo (approximate equality)
+- **Property checking** - property, ownProperty, deepProperty, nestedProperty with value validation
+- **Collection operations** - include, keys, members with deep equality and ordered comparison support
+- **Numeric comparisons** - above, below, within, atLeast, atMost with full range validation
+- **Value changes** - track changes, increases, decreases over function execution with delta validation
+- **Array operations** - member comparison with subsequence, endsWith, and oneOf matching
+- **Error/exception testing** - comprehensive throw/catch with error type and message validation
+- **Custom error messages** - all assertions support optional custom messages
+- **Full negation support** - consistent `not` operator across all assertion types
 
 ## API Documentation
 
@@ -69,10 +71,10 @@ As of the initial version not all functions are yet implemented
 
 ## Quick Start
 
-Install the npm packare: `npm install @nevware21/tripwire --save-dev`
+Install the npm package: `npm install @nevware21/tripwire --save-dev`
 
-> It is suggested / recommended that you use the following definition in your `package.json` so that you are compatible with any future releases as they become available
-> we do not intend to make ANY known breaking changes moving forward until v2.x 
+> Recommended: Use the following definition in your `package.json` to stay compatible with future releases.
+> We do not intend to make runtime / environment breaking changes until at least v2.x
 > ```json
 > "@nevware21/tripwire": ">= 0.1.4 < 2.x"
 > ```

--- a/core/README.md
+++ b/core/README.md
@@ -1,4 +1,4 @@
-# Core Module
+# @nevware21/tripwire
 
 ![GitHub Workflow Status (main)](https://img.shields.io/github/actions/workflow/status/nevware21/tripwire/ci.yml?branch=main)
 [![codecov](https://codecov.io/gh/nevware21/tripwire/graph/badge.svg?token=I9mMGSvfkk)](https://codecov.io/gh/nevware21/tripwire)
@@ -6,67 +6,93 @@
 [![downloads](https://img.shields.io/npm/dt/%40nevware21/tripwire.svg)](https://www.npmjs.com/package/%40nevware21/tripwire)
 [![downloads](https://img.shields.io/npm/dm/%40nevware21/tripwire.svg)](https://www.npmjs.com/package/%40nevware21/tripwire)
 
-This is the core module of the `tripwire` project which is designed to be used for testing your Javascript or TypeScript packages.
+Modern assertion library for testing JavaScript and TypeScript packages across Node.js, Browser, and Web Worker environments.
 
-It is designed to work in and is tested with the following environments.
+## Why Tripwire?
 
-- `node`
-- `browser`
-- `worker` (browser)
+**Cross-Environment Testing**
+- Works seamlessly in Node.js, browsers, and Web Workers
+- Comprehensive support from ES5+ for broad compatibility
+- Tested across all three environments
 
-It currently provides `assertion` functions to make testing simplier and easier by providing common assertion checks that you can run against your code.
+**Dual API Design**
+- Use familiar `assert.*` functions for quick checks
+- Use fluent `expect().to.be.*` syntax for readable tests
+- Mix both styles in the same test suite
 
-It provides both `assert` and `expect` support, where the `assert` functions are a set of fixed operations, which the `expect` is a more descriptive language API.
+**Reliable & Lightweight**
+- Minimal dependencies to prevent build breakages
+- Built with TypeScript for full type safety
+- No dependency on unstable or unmaintained packages
 
-The `assert` functions are built on-top of the underlying `expect` support, and if no assertions are thrown the result of the internal "chained" descriptive language API is returned. Which means you can mix the `expect` objects with the responses from the `assert` functions.
+## Installation
 
-To avoid dependency issues, this project will use the mininal set of external dependencies so that it can ensure and maintain compatibility with current (and future) runtimes.
+```bash
+npm install @nevware21/tripwire --save-dev
+```
 
-## API Documentation
-
-The API documentation is generated from the source code via typedoc and is located [here](https://nevware21.github.io/tripwire/index.html)
+**Recommended version range:**
+```json
+{
+  "devDependencies": {
+    "@nevware21/tripwire": ">= 0.1.4 < 2.x"
+  }
+}
+```
 
 ## Quick Start
-
-Install the npm packare: `npm install @nevware21/tripwire --save-dev`
-
-> It is suggested / recommended that you use the following definition in your `package.json` so that you are compatible with any future releases as they become available
-> we do not intend to make ANY known breaking changes moving forward until v2.x 
-> ```json
-> "@nevware21/tripwire": ">= 0.1.4 < 2.x"
-> ```
-
-## Usage
-
-To use the core functionalities, import the necessary modules and functions:
 
 ```ts
 import { assert, expect } from '@nevware21/tripwire';
 
-assert.isObject([]); // throws
+// Assert style
+assert.equal(1 + 1, 2);
+assert.isString("hello");
+assert.deepEqual({ a: 1 }, { a: 1 });
 
-expect(() => { dosomething(); }).to.not.throw();
-expect(() => { throw new Error("failed")}).to.throw();
+// Expect style
+expect(1 + 1).to.equal(2);
+expect("hello").to.be.a.string;
+expect({ a: 1 }).to.deep.equal({ a: 1 });
 ```
 
-For detailed documentation on specific assertion types, see:
-- [Change/Increase/Decrease Assertions](https://nevware21.github.io/tripwire/change-assertions) - Testing value changes over function execution
+## Key Features
 
-## API Documentation
+- **Type Checking** - `isObject`, `isArray`, `isString`, `isNumber`, `isBoolean`, `isFunction`, `isNull`, `isUndefined`, `isNaN`, `isFinite`, `typeOf`, `instanceOf`, `exists`
+- **Equality** - `equal`, `strictEqual`, `deepEqual`, `closeTo` (approximate equality)
+- **Comparisons** - `above`, `below`, `within`, `atLeast`, `atMost`
+- **Properties** - `property`, `ownProperty`, `deepProperty`, `nestedProperty` with value validation
+- **Collections** - `include`, `keys`, `members` with deep equality and ordered comparison
+- **Size/Length** - `lengthOf`, `sizeOf` for arrays, strings, maps, sets
+- **Array Operations** - `subsequence`, `endsWith`, `oneOf` matching
+- **Change Tracking** - Monitor value `changes`, `increases`, `decreases` with delta validation
+- **Error Testing** - `throw`, `throws`, `doesNotThrow` with type and message validation
+- **Object State** - `isExtensible`, `isSealed`, `isFrozen`, `isEmpty`
 
-The API documentation is generated from the source code via typedoc and is located [here](https://nevware21.github.io/tripwire/index.html)
+## Documentation
+
+**Quick Start & Examples**: [Documentation Guide](https://nevware21.github.io/tripwire)
+
+**API Reference**: [TypeDoc Documentation](https://nevware21.github.io/tripwire/typedoc/core/index.html)
+
+**Guides**:
+- [Change/Increase/Decrease Assertions](https://nevware21.github.io/tripwire/change-assertions)
+
+**Repository**: [github.com/nevware21/tripwire](https://github.com/nevware21/tripwire)
 
 ## Browser Support
 
-General support is currently set to ES5 supported runtimes and higher.
+- Comprehensive support from ES5+ for broad browser compatibility, from IE9+
+- Tested in Node.js, Chrome, Firefox, Safari, Edge
+- Full Web Worker support
 
-This module uses [@nevware21/ts-utils](https://github.com/nevware21/ts-utils) to provide some of it core functionality which includes internal polyfills to provide support on older browsers.
+## Related Packages
 
-While every effort will be made to maintain as much technical compatibility as possible, some assertions and functionality will require later browsers to function correctly.
+**[@nevware21/tripwire-chai](https://www.npmjs.com/package/@nevware21/tripwire-chai)** - Chai.js compatibility shim
 
 ## Contributing
 
-Read our primary [contributing guide](https://github.com/nevware21/tripwire/blob/main/CONTRIBUTING.md) to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes.
+See [Contributing Guide](https://github.com/nevware21/tripwire/blob/main/CONTRIBUTING.md)
 
 ## License
 

--- a/core/src/assert/assertClass.ts
+++ b/core/src/assert/assertClass.ts
@@ -14,7 +14,7 @@ import { IPromise } from "@nevware21/ts-async";
 import { IAssertClass } from "./interface/IAssertClass";
 import { IAssertInst } from "./interface/IAssertInst";
 import { MsgSource } from "./type/MsgSource";
-import { isFunctionFunc, isNullFunc, isObjectFunc, isPlainObjectFunc, isStrictFalseFunc, isStrictTrueFunc, isUndefinedFunc } from "./funcs/is";
+import { isBooleanFunc, isFunctionFunc, isNumberFunc, isNullFunc, isObjectFunc, isPlainObjectFunc, isStrictFalseFunc, isStrictTrueFunc, isUndefinedFunc } from "./funcs/is";
 import { isEmptyFunc } from "./funcs/isEmpty";
 import { IAssertClassDef } from "./interface/IAssertClassDef";
 import { matchFunc } from "./funcs/match";
@@ -211,6 +211,12 @@ export function createAssert(): IAssertClass {
 
         isArray: createExprAdapter("is.array"),
         isNotArray: createExprAdapter("not.is.array"),
+
+        isNumber: isNumberFunc,
+        isNotNumber: createExprAdapter("not.is.number"),
+
+        isBoolean: isBooleanFunc,
+        isNotBoolean: createExprAdapter("not.is.boolean"),
 
         isExtensible: isExtensibleFunc,
         isNotExtensible: createExprAdapter("not", isExtensibleFunc),

--- a/core/src/assert/interface/IAssertClass.ts
+++ b/core/src/assert/interface/IAssertClass.ts
@@ -973,9 +973,79 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
     isNotArray(value: any, initMsg?: MsgSource): AssertInst;
 
     /**
+     * Asserts that the value is a number.
+     * @param value - The value to check.
+     * @param initMsg - The custom message to display if the assertion fails.
+     * @throws An {@link AssertionFailure} if the value is not a number.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.isNumber(123); // Passes
+     * assert.isNumber(3.14); // Passes
+     * assert.isNumber(0); // Passes
+     * assert.isNumber("123"); // Throws AssertionFailure
+     * assert.isNumber(null); // Throws AssertionFailure
+     * assert.isNumber(undefined); // Throws AssertionFailure
+     * ```
+     */
+    isNumber(value: any, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the value is not a number.
+     * @param value - The value to check.
+     * @param initMsg - The custom message to display if the assertion fails.
+     * @throws An {@link AssertionFailure} if the value is a number.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.isNotNumber("hello"); // Passes
+     * assert.isNotNumber({}); // Passes
+     * assert.isNotNumber(null); // Passes
+     * assert.isNotNumber(123); // Throws AssertionFailure
+     * assert.isNotNumber(3.14); // Throws AssertionFailure
+     * ```
+     */
+    isNotNumber(value: any, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the value is a boolean.
+     * @param value - The value to check.
+     * @param initMsg - The custom message to display if the assertion fails.
+     * @throws An {@link AssertionFailure} if the value is not a boolean.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.isBoolean(true); // Passes
+     * assert.isBoolean(false); // Passes
+     * assert.isBoolean(1); // Throws AssertionFailure
+     * assert.isBoolean("true"); // Throws AssertionFailure
+     * assert.isBoolean(null); // Throws AssertionFailure
+     * assert.isBoolean(undefined); // Throws AssertionFailure
+     * ```
+     */
+    isBoolean(value: any, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the value is not a boolean.
+     * @param value - The value to check.
+     * @param initMsg - The custom message to display if the assertion fails.
+     * @throws An {@link AssertionFailure} if the value is a boolean.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * assert.isNotBoolean(123); // Passes
+     * assert.isNotBoolean("hello"); // Passes
+     * assert.isNotBoolean(null); // Passes
+     * assert.isNotBoolean(true); // Throws AssertionFailure
+     * assert.isNotBoolean(false); // Throws AssertionFailure
+     * ```
+     */
+    isNotBoolean(value: any, initMsg?: MsgSource): AssertInst;
+
+    /**
      * Asserts whether the value is extensible indicating whether
      * new properties can be added to it.
-     * Primive values are not extensible.
+     * Primitive values are not extensible.
      * @param value - The value to check.
      * @param initMsg - The custom message to display if the assertion fails.
      * @throws An {@link AssertionFailure} if the value is not extensible.
@@ -993,7 +1063,7 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
     /**
      * Asserts whether the value is not extensible indicating whether
      * new properties can be added to it.
-     * Primive values are not extensible.
+     * Primitive values are not extensible.
      * @param value - The value to check.
      * @param initMsg - The custom message to display if the assertion fails
      * @throws An {@link AssertionFailure} if the value is extensible.

--- a/core/test/src/assert/assert.isBoolean.test.ts
+++ b/core/test/src/assert/assert.isBoolean.test.ts
@@ -1,0 +1,158 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2026 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { assert } from "../../../src/assert/assertClass";
+import { expect } from "../../../src/assert/expect";
+import { checkError } from "../support/checkError";
+
+describe("isBoolean", () => {
+    it("should pass when the value is true", () => {
+        assert.isBoolean(true);
+        expect(() => assert.isBoolean(true)).to.not.throw();
+    });
+
+    it("should pass when the value is false", () => {
+        assert.isBoolean(false);
+        expect(() => assert.isBoolean(false)).to.not.throw();
+    });
+
+    it("should throw an error when the value is not a boolean", () => {
+        checkError(() => {
+            assert.isBoolean(1);
+        }, "expected 1 to be a boolean");
+
+        expect(() => assert.isBoolean(1)).to.throw();
+    });
+
+    it("should throw an error with a custom message when the value is not a boolean", () => {
+        checkError(() => {
+            assert.isBoolean(1, "Custom error message");
+        }, "Custom error message");
+
+        expect(() => assert.isBoolean(1, "Custom error message")).to.throw();
+    });
+
+    it("should throw an error when the value is a string", () => {
+        checkError(() => {
+            assert.isBoolean("true");
+        }, "expected \"true\" to be a boolean");
+
+        expect(() => assert.isBoolean("true")).to.throw();
+    });
+
+    it("should throw an error when the value is an object", () => {
+        checkError(() => {
+            assert.isBoolean({});
+        }, "expected {} to be a boolean");
+
+        expect(() => assert.isBoolean({})).to.throw();
+    });
+
+    it("should throw an error when the value is an array", () => {
+        checkError(() => {
+            assert.isBoolean([]);
+        }, "expected [] to be a boolean");
+
+        expect(() => assert.isBoolean([])).to.throw();
+    });
+
+    it("should throw an error when the value is null", () => {
+        checkError(() => {
+            assert.isBoolean(null);
+        }, "expected null to be a boolean");
+
+        expect(() => assert.isBoolean(null)).to.throw();
+    });
+
+    it("should throw an error when the value is undefined", () => {
+        checkError(() => {
+            assert.isBoolean(undefined);
+        }, "expected undefined to be a boolean");
+
+        expect(() => assert.isBoolean(undefined)).to.throw();
+    });
+
+    it("should throw an error when the value is a number", () => {
+        checkError(() => {
+            assert.isBoolean(0);
+        }, "expected 0 to be a boolean");
+
+        expect(() => assert.isBoolean(0)).to.throw();
+    });
+});
+
+describe("isNotBoolean", () => {
+    it("should pass when the value is a number", () => {
+        assert.isNotBoolean(123);
+        expect(() => assert.isNotBoolean(123)).to.not.throw();
+    });
+
+    it("should pass when the value is a string", () => {
+        assert.isNotBoolean("hello");
+        expect(() => assert.isNotBoolean("hello")).to.not.throw();
+    });
+
+    it("should pass when the value is an object", () => {
+        assert.isNotBoolean({});
+        expect(() => assert.isNotBoolean({})).to.not.throw();
+    });
+
+    it("should throw an error when the value is true", () => {
+        checkError(() => {
+            assert.isNotBoolean(true);
+        }, "not expected true to be a boolean");
+
+        expect(() => assert.isNotBoolean(true)).to.throw();
+    });
+
+    it("should throw an error when the value is false", () => {
+        checkError(() => {
+            assert.isNotBoolean(false);
+        }, "not expected false to be a boolean");
+
+        expect(() => assert.isNotBoolean(false)).to.throw();
+    });
+
+    it("should pass when the value is null", () => {
+        assert.isNotBoolean(null);
+        expect(() => assert.isNotBoolean(null)).to.not.throw();
+    });
+
+    it("should pass when the value is undefined", () => {
+        assert.isNotBoolean(undefined);
+        expect(() => assert.isNotBoolean(undefined)).to.not.throw();
+    });
+
+    it("should throw an error with a custom message when the value is a boolean", () => {
+        checkError(() => {
+            assert.isNotBoolean(true, "Custom error message");
+        }, "Custom error message");
+
+        expect(() => assert.isNotBoolean(true, "Custom error message")).to.throw();
+    });
+
+    it("should pass when the value is an array", () => {
+        assert.isNotBoolean([]);
+        expect(() => assert.isNotBoolean([])).to.not.throw();
+    });
+
+    it("should pass when the value is a function", () => {
+        assert.isNotBoolean(() => {});
+        expect(() => assert.isNotBoolean(() => {})).to.not.throw();
+    });
+
+    it("should pass when the value is zero", () => {
+        assert.isNotBoolean(0);
+        expect(() => assert.isNotBoolean(0)).to.not.throw();
+    });
+
+    it("should pass when the value is one", () => {
+        assert.isNotBoolean(1);
+        expect(() => assert.isNotBoolean(1)).to.not.throw();
+    });
+});

--- a/core/test/src/assert/assert.isNumber.test.ts
+++ b/core/test/src/assert/assert.isNumber.test.ts
@@ -1,0 +1,150 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2026 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { assert } from "../../../src/assert/assertClass";
+import { expect } from "../../../src/assert/expect";
+import { checkError } from "../support/checkError";
+
+describe("isNumber", () => {
+    it("should pass when the value is a number", () => {
+        assert.isNumber(123);
+        expect(() => assert.isNumber(123)).to.not.throw();
+    });
+
+    it("should pass when the value is zero", () => {
+        assert.isNumber(0);
+        expect(() => assert.isNumber(0)).to.not.throw();
+    });
+
+    it("should pass when the value is a decimal", () => {
+        assert.isNumber(3.14);
+        expect(() => assert.isNumber(3.14)).to.not.throw();
+    });
+
+    it("should pass when the value is a negative number", () => {
+        assert.isNumber(-42);
+        expect(() => assert.isNumber(-42)).to.not.throw();
+    });
+
+    it("should throw an error when the value is not a number", () => {
+        checkError(() => {
+            assert.isNumber("123");
+        }, "expected \"123\" to be a number");
+
+        expect(() => assert.isNumber("123")).to.throw();
+    });
+
+    it("should throw an error with a custom message when the value is not a number", () => {
+        checkError(() => {
+            assert.isNumber("123", "Custom error message");
+        }, "Custom error message");
+
+        expect(() => assert.isNumber("123", "Custom error message")).to.throw();
+    });
+
+    it("should throw an error when the value is an object", () => {
+        checkError(() => {
+            assert.isNumber({});
+        }, "expected {} to be a number");
+
+        expect(() => assert.isNumber({})).to.throw();
+    });
+
+    it("should throw an error when the value is an array", () => {
+        checkError(() => {
+            assert.isNumber([]);
+        }, "expected [] to be a number");
+
+        expect(() => assert.isNumber([])).to.throw();
+    });
+
+    it("should throw an error when the value is null", () => {
+        checkError(() => {
+            assert.isNumber(null);
+        }, "expected null to be a number");
+
+        expect(() => assert.isNumber(null)).to.throw();
+    });
+
+    it("should throw an error when the value is undefined", () => {
+        checkError(() => {
+            assert.isNumber(undefined);
+        }, "expected undefined to be a number");
+
+        expect(() => assert.isNumber(undefined)).to.throw();
+    });
+
+    it("should throw an error when the value is a boolean", () => {
+        checkError(() => {
+            assert.isNumber(true);
+        }, "expected true to be a number");
+
+        expect(() => assert.isNumber(true)).to.throw();
+    });
+});
+
+describe("isNotNumber", () => {
+    it("should pass when the value is a string", () => {
+        assert.isNotNumber("hello");
+        expect(() => assert.isNotNumber("hello")).to.not.throw();
+    });
+
+    it("should pass when the value is an object", () => {
+        assert.isNotNumber({});
+        expect(() => assert.isNotNumber({})).to.not.throw();
+    });
+
+    it("should throw an error when the value is a number", () => {
+        checkError(() => {
+            assert.isNotNumber(123);
+        }, "not expected 123 to be a number");
+
+        expect(() => assert.isNotNumber(123)).to.throw();
+    });
+
+    it("should pass when the value is null", () => {
+        assert.isNotNumber(null);
+        expect(() => assert.isNotNumber(null)).to.not.throw();
+    });
+
+    it("should pass when the value is undefined", () => {
+        assert.isNotNumber(undefined);
+        expect(() => assert.isNotNumber(undefined)).to.not.throw();
+    });
+
+    it("should throw an error with a custom message when the value is a number", () => {
+        checkError(() => {
+            assert.isNotNumber(42, "Custom error message");
+        }, "Custom error message");
+
+        expect(() => assert.isNotNumber(42, "Custom error message")).to.throw();
+    });
+
+    it("should pass when the value is a boolean", () => {
+        assert.isNotNumber(true);
+        expect(() => assert.isNotNumber(true)).to.not.throw();
+    });
+
+    it("should pass when the value is an array", () => {
+        assert.isNotNumber([]);
+        expect(() => assert.isNotNumber([])).to.not.throw();
+    });
+
+    it("should pass when the value is a function", () => {
+        assert.isNotNumber(() => {});
+        expect(() => assert.isNotNumber(() => {})).to.not.throw();
+    });
+
+    it("should throw an error when the value is zero", () => {
+        checkError(() => {
+            assert.isNotNumber(0);
+        }, "not expected 0 to be a number");
+
+        expect(() => assert.isNotNumber(0)).to.throw();
+    });
+});

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,8 +16,48 @@
 
 [Core Assertion Typedoc](https://nevware21.github.io/tripwire/typedoc/core/index.html)
 
-#### Guides
-- [Change/Increase/Decrease Assertions](change-assertions.md) - Testing value changes over function execution
+### Quick Start
+
+Install the package:
+```bash
+npm install @nevware21/tripwire --save-dev
+```
+
+**Recommended version range:**
+```json
+{
+  "devDependencies": {
+    "@nevware21/tripwire": ">= 0.1.4 < 2.x"
+  }
+}
+```
+
+### Basic Usage
+
+```ts
+import { assert, expect } from '@nevware21/tripwire';
+
+// Assert style - quick and direct
+assert.equal(1 + 1, 2);
+assert.isString("hello");
+assert.deepEqual({ a: 1 }, { a: 1 });
+
+// Expect style - fluent and readable
+expect(1 + 1).to.equal(2);
+expect("hello").to.be.a.string;
+expect({ a: 1 }).to.deep.equal({ a: 1 });
+```
+
+### Feature Highlights
+
+| Feature | Functions |
+|---------|-----------|
+| **Type Checking** | [`isObject`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#isobject), [`isArray`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#isarray), [`isString`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#isstring), [`isNumber`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#isnumber), [`isBoolean`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#isboolean), [`isFunction`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#isfunction), [`isNull`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#isnull), [`isUndefined`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#isundefined), [`isNaN`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#isnan), [`isFinite`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#isfinite), [`typeOf`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#typeof), [`isInstanceOf`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#isinstanceof), [`exists`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#exists) |
+| **Equality & Comparison** | [`equal`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#equal), [`strictEqual`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#strictequal), [`deepEqual`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#deepequal), [`closeTo`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#closeto), [`isAbove`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#isabove), [`isBelow`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#isbelow), [`isWithin`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#iswithin), [`isAtLeast`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#isatleast), [`isAtMost`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#isatmost) |
+| **Property Assertions** | [`hasProperty`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#hasproperty), [`hasOwnProperty`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#hasownproperty), [`hasDeepProperty`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#hasdeepproperty), [`nestedProperty`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#nestedproperty), [`deepNestedProperty`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#deepnestedproperty) |
+| **Collection Operations** | [`includes`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#includes), [`sameMembers`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#samemembers), [`includeMembers`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#includemembers), [`lengthOf`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#lengthof), [`sizeOf`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#sizeof) |
+| **Change Tracking** | [`changes`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#changes), [`increases`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#increases), [`decreases`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#decreases) - See [Change/Increase/Decrease Assertions Guide](change-assertions.md) |
+| **Error Testing** | [`throws`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#throws), [`doesNotThrow`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#doesnotthrow) |
 
 ## Shim Chai
 
@@ -28,3 +68,66 @@
 ### Documentation
 
 [Chai Shim Typedoc](https://nevware21.github.io/tripwire/typedoc/shim/chai/index.html)
+
+### Quick Start
+
+Install the package:
+```bash
+npm install @nevware21/tripwire-chai --save-dev
+```
+
+**Recommended version range:**
+```json
+{
+  "devDependencies": {
+    "@nevware21/tripwire-chai": ">= 0.1.4 < 2.x"
+  }
+}
+```
+
+### Migration from Chai
+
+**Step 1: Update your imports**
+```diff
+- import { assert } from 'chai';
++ import { assert } from '@nevware21/tripwire-chai';
+```
+
+**Step 2: Run your tests**
+
+Most `assert.*` functions should work immediately.
+
+**Step 3: Update error message tests (if needed)**
+
+Error messages differ from Chai - use regex for flexibility:
+```diff
+- assert.throws(() => fn(), "exact chai message");
++ assert.throws(() => fn(), /error message/);
+```
+
+### What's Supported
+
+The shim implements the Chai v5.x `assert` API including:
+
+- Basic assertions: `equal`, `strictEqual`, `deepEqual`, `isOk`, `isTrue`, etc.
+- Type checking: `isObject`, `isArray`, `isString`, `isNumber`, `isBoolean`, `isFunction`, etc.
+- Comparisons: `isAbove`, `isAtLeast`, `isBelow`, `isAtMost`, `closeTo`
+- Properties: `property`, `deepProperty`, `nestedProperty`, `ownProperty` with value checks
+- Collections: `include`, `deepInclude`, `members`, `sameMembers`, `keys`
+- Changes: `changes`, `increases`, `decreases` with delta tracking
+- Errors: `throws`, `doesNotThrow`
+- Object state: `isExtensible`, `isSealed`, `isFrozen`, `isEmpty`
+
+### What's NOT Supported
+
+- `expect` API - Use core tripwire instead
+- `should` API - No plans to implement
+- Plugins - `use()` function not available
+
+### When to Use Core Tripwire
+
+Consider migrating to `@nevware21/tripwire` for:
+- Better error messages
+- Fluent `expect` syntax
+- New features and improvements
+- Long-term maintenance

--- a/shim/chai/README.md
+++ b/shim/chai/README.md
@@ -1,4 +1,4 @@
-# Chai Shim
+# @nevware21/tripwire-chai
 
 ![GitHub Workflow Status (main)](https://img.shields.io/github/actions/workflow/status/nevware21/tripwire/ci.yml?branch=main)
 [![codecov](https://codecov.io/gh/nevware21/tripwire/graph/badge.svg?token=I9mMGSvfkk)](https://codecov.io/gh/nevware21/tripwire)
@@ -6,94 +6,118 @@
 [![downloads](https://img.shields.io/npm/dt/%40nevware21/tripwire-chai.svg)](https://www.npmjs.com/package/%40nevware21/tripwire-chai)
 [![downloads](https://img.shields.io/npm/dm/%40nevware21/tripwire-chai.svg)](https://www.npmjs.com/package/%40nevware21/tripwire-chai)
 
-This module is a Shim of the Chai.js assertion library which uses the [tripwire](https://github.com/nevware21/tripwire) assertion engine.
+Chai.js compatibility shim powered by tripwire - Drop-in replacement for Chai's `assert` API.
 
-> **Chai Version Compatibility:** This shim is designed to be compatible with the Chai v5.x API (as documented at [chaijs.com](https://www.chaijs.com/)).
+> **Chai v5.x Compatible** - Designed to match the Chai v5.x assert API
 
-This Shim is not designed to be a complete 1:1 replacement for Chai, it's primary focus is to provide a quicker migration option using your existing chai based `assert.*` functions.
+## Purpose
 
-As such the returned "error messages" do not and will not match the assertion text returned by `chai`, if your unit tests include validation of the returned error messages then they will need to be updated, it is recommended to use regular expressions to validate the returned error message when required.
+Migrate from Chai.js without rewriting your tests. Perfect when:
 
-As of the initial version not all functions are yet implemented
+- Chai dependencies are causing build issues
+- You need Web Worker support (broken in some Chai versions)
+- Your project is stuck due to Chai dependency conflicts
+- You want to unblock your tests and migrate gradually
 
-### Incomplete Shim implementation
+**Note**: This is NOT a complete Chai replacement. Only the `assert.*` API is implemented. The `expect` and `should` APIs are NOT available.
 
-**As of version 0.1.4:**
+## Installation
 
-#### Implemented
-
-- **`assert` API** - Most assert functions are now implemented
-  - Basic assertions: `equal`, `strictEqual`, `deepEqual`, `notEqual`, etc.
-  - Type checking: `isObject`, `isArray`, `isString`, `isNumber`, `isBoolean`, `isFunction`, etc.
-  - Comparison: `isAbove`, `isAtLeast`, `isBelow`, `isAtMost`
-  - Property checking: `property`, `ownProperty`, `deepProperty`, `nestedProperty`, etc.
-  - Property values: `propertyVal`, `ownPropertyVal`, `deepPropertyVal`, `nestedPropertyVal`, etc.
-  - Inclusion: `include`, `deepInclude`, `ownInclude`, `nestedInclude`, etc.
-  - Members: `sameMembers`, `includeMembers`, `sameDeepMembers`, `includeOrderedMembers`, etc.
-  - Keys: `hasAnyKeys`, `hasAllKeys`, `hasAnyDeepKeys`, `hasAllDeepKeys`, etc.
-  - Exception handling: `throw`, `throws`, `doesNotThrow`
-  - Value changes: `changes`, `increases`, `decreases` and their variants
-  - Object state: `isExtensible`, `isSealed`, `isFrozen`, `isEmpty`
-  - And many more!
-
-#### Not Yet Implemented
-
-- **`expect` API** - The BDD-style chainable expect API is not implemented
-  - `expect(value).to.be.equal(...)` syntax is **not available**
-  - Use `assert.*` functions or tripwire core instead
-- **`should` API** - No plans to implement this
-- **`use` function** - Plugin support is not available
-
-The unsupported assertions will return an AssertionError with text indicating that it's not implemented.
-
-## API Documentation
-
-The API documentation is generated from the source code via typedoc and is located [here](https://nevware21.github.io/tripwire/index.html)
-
-## Quickstart
-
-Install the npm packare: `npm install @nevware21/tripwire-chai --save-dev`
-
-> It is suggested / recommended that you use the following definition in your `package.json` so that you are compatible with any future releases as they become available
-> we do not intend to make ANY known breaking changes moving forward until v2.x 
-> ```json
-> "@nevware21/tripwire-chai": ">= 0.1.4 < 2.x"
-> ```
-
-### Importing into Browsers
-
-TBD. 
-
-```html
-<script src="./node_modules/@nevware21/tripwire-chai/bundle/es5/umd/tripwire-chai.min.js"></script>
+```bash
+npm install @nevware21/tripwire-chai --save-dev
 ```
 
-
-## Usage
-
-As a Shim and for all supported function and functionality, you should just need to change you `import` to reference this package instead of `chai`.
-
-```typescript
-import { assert } from "@nevware21/tripwire-chai";
-
-// Example usage
-assert.isObject([]);
+**Recommended version range:**
+```json
+{
+  "devDependencies": {
+    "@nevware21/tripwire-chai": ">= 0.1.4 < 2.x"
+  }
+}
 ```
-## API Documentation
 
-The API documentation is generated from the source code via typedoc and is located [here](https://nevware21.github.io/tripwire/index.html)
+## Quick Migration
+
+### Step 1: Update imports
+
+```diff
+- import { assert } from 'chai';
++ import { assert } from '@nevware21/tripwire-chai';
+```
+
+### Step 2: Run your tests
+
+Most `assert.*` functions should work immediately.
+
+### Step 3: Fix error message tests (if any)
+
+Error messages differ from Chai. Use regex instead of exact strings:
+
+```diff
+- assert.throws(() => fn(), "exact chai message");
++ assert.throws(() => fn(), /error message/);
+```
+
+## What's Supported?
+
+### Fully Implemented (assert API)
+
+- **Basic**: `equal`, `notEqual`, `strictEqual`, `deepEqual`, `isOk`, `isTrue`, etc.
+- **Types**: `isObject`, `isArray`, `isString`, `isNumber`, `isBoolean`, `isFunction`, `isNull`, `isUndefined`, `isNaN`, `isFinite`, etc.
+- **Comparisons**: `isAbove`, `isAtLeast`, `isBelow`, `isAtMost`, `closeTo`, `approximately`
+- **Properties**: `property`, `deepProperty`, `nestedProperty`, `ownProperty` with value validation
+- **Collections**: `include`, `deepInclude`, `members`, `sameMembers`, `keys`
+- **Size**: `lengthOf`, `sizeOf`
+- **Changes**: `changes`, `increases`, `decreases` with delta tracking
+- **Errors**: `throws`, `doesNotThrow`
+- **State**: `isExtensible`, `isSealed`, `isFrozen`, `isEmpty`
+
+### NOT Implemented
+
+- **`expect` API** - Use core `@nevware21/tripwire` instead
+- **`should` API** - No plans to implement
+- **Plugins** - `use()` function not available
+
+## Usage Example
+
+```ts
+import { assert } from '@nevware21/tripwire-chai';
+
+// Your existing Chai tests should work
+assert.equal(1 + 1, 2);
+assert.isArray([1, 2, 3]);
+assert.deepEqual({ a: 1 }, { a: 1 });
+assert.throws(() => { throw new Error(); });
+assert.property({ a: 1 }, 'a');
+assert.include([1, 2, 3], 2);
+```
+
+## Documentation
+
+**Migration Guide & Examples**: [Documentation Guide](https://nevware21.github.io/tripwire)
+
+**API Reference**: [TypeDoc Documentation](https://nevware21.github.io/tripwire/typedoc/shim/chai/index.html)
+
+**Core Package**: [@nevware21/tripwire](https://www.npmjs.com/package/@nevware21/tripwire) - Consider migrating for better features
+
+**Repository**: [github.com/nevware21/tripwire](https://github.com/nevware21/tripwire)
+
+## When to Use Core Tripwire
+
+Consider switching to `@nevware21/tripwire` for:
+- Better error messages
+- Fluent `expect` syntax
+- New features and improvements
+- Long-term maintenance
 
 ## Browser Support
 
-General support is currently set to ES5 supported runtimes and higher.
-
-This module uses [@nevware21/ts-utils](https://github.com/nevware21/ts-utils) to provide some of it core functionality which includes internal polyfills to provide support on older browsers.
-
-While every effort will be made to maintain as much technical compatibility as possible, some assertions and functionality will require later browsers to function correctly.
+- Comprehensive support from ES5+ for broad compatibility
+- Tested in Node.js, browsers, and Web Workers
 
 ## Contributing
 
-Read our primary [contributing guide](https://github.com/nevware21/tripwire/blob/main/CONTRIBUTING.md) to learn about our development process, how to propose bugfixes and improvements, and how to build and test your changes.
+See [Contributing Guide](https://github.com/nevware21/tripwire/blob/main/CONTRIBUTING.md)
 
 ## License
 


### PR DESCRIPTION
… documentation

## New Features
- Implemented `assert.isNumber()` and `assert.isNotNumber()` assertion methods
- Implemented `assert.isBoolean()` and `assert.isNotBoolean()` assertion methods

## Implementation Details
- Imported `isNumberFunc` and `isBooleanFunc` to assertClass.ts
- Added method signatures to IAssertClass interface with complete TypeDoc documentation

## Documentation Updates
- Enhanced all README files with improved structure and clarity
- Converted Feature Highlights to comprehensive HTML table format
- Added code formatting for all function names
- Expanded documentation with:
  - Quick Start guides for all modules
  - Installation and version range recommendations
  - Detailed usage examples and code snippets
  - Feature comparison tables
  - Migration guides for Chai shim
- Updated Type Checking section with isNumber and isBoolean examples
- Improved formatting and readability across all documentation files
- Fixed typo: "packare" → "package"