### PR TITLE
feat: implement deep keys assertions for Maps/Sets

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -98,6 +98,13 @@ grunt lint lint-fix            # Lint with auto-fix
 - Use `@nevware21/ts-utils` for cross-platform utilities
 - No non-null assertions (`!` operator) - use proper null checks
 
+### Versioning for New Features
+- **@since tags**: Check `core/package.json` version before adding new features
+- Current version in package.json is the **last published** version
+- Use the **next minor version** for @since tags on new features
+- Example: If package.json shows `0.1.4`, use `@since 0.1.5` for new features
+- This follows semver: new features increment the minor version
+
 ## Testing Patterns
 
 ### Test Structure

--- a/core/README.md
+++ b/core/README.md
@@ -63,6 +63,7 @@ expect({ a: 1 }).to.deep.equal({ a: 1 });
 - **Comparisons** - `above`, `below`, `within`, `atLeast`, `atMost`
 - **Properties** - `property`, `ownProperty`, `deepProperty`, `nestedProperty` with value validation
 - **Collections** - `include`, `keys`, `members` with deep equality and ordered comparison
+- **Deep Keys** - `hasAnyDeepKeys`, `hasAllDeepKeys` for Maps/Sets with object keys using deep equality
 - **Size/Length** - `lengthOf`, `sizeOf` for arrays, strings, maps, sets
 - **Array Operations** - `subsequence`, `endsWith`, `oneOf` matching
 - **Change Tracking** - Monitor value `changes`, `increases`, `decreases` with delta validation

--- a/core/src/assert/assertClass.ts
+++ b/core/src/assert/assertClass.ts
@@ -339,7 +339,15 @@ export function createAssert(): IAssertClass {
         subsequence: { scopeFn: subsequenceFunc, nArgs: 2 },
         notSubsequence: { scopeFn: createExprAdapter("not", subsequenceFunc), nArgs: 2 },
         deepSubsequence: { scopeFn: deepSubsequenceFunc, nArgs: 2 },
-        notDeepSubsequence: { scopeFn: createExprAdapter("not", deepSubsequenceFunc), nArgs: 2 }
+        notDeepSubsequence: { scopeFn: createExprAdapter("not", deepSubsequenceFunc), nArgs: 2 },
+
+        // Deep keys operations
+        hasAnyDeepKeys: { scopeFn: createExprAdapter("has.any.deep.keys"), nArgs: 2 },
+        hasAllDeepKeys: { scopeFn: createExprAdapter("has.all.deep.keys"), nArgs: 2 },
+        notHaveAnyDeepKeys: { scopeFn: createExprAdapter("not.has.any.deep.keys"), nArgs: 2 },
+        doesNotHaveAnyDeepKeys: { alias: "notHaveAnyDeepKeys" },
+        notHaveAllDeepKeys: { scopeFn: createExprAdapter("not.has.all.deep.keys"), nArgs: 2 },
+        doesNotHaveAllDeepKeys: { alias: "notHaveAllDeepKeys" }
     };
 
     addAssertFuncs(assert, assertFuncs);

--- a/core/src/assert/funcs/keysFunc.ts
+++ b/core/src/assert/funcs/keysFunc.ts
@@ -2,14 +2,15 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024-2025 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2026 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 
-import { arrForEach, arrSlice, asString, isArray, isObject, isStrictNullOrUndefined, isString, objGetOwnPropertyDescriptor, objGetOwnPropertySymbols, objKeys } from "@nevware21/ts-utils";
+import { arrForEach, arrFrom, arrSlice, asString, dumpObj, isArray, isFunction, isObject, isStrictNullOrUndefined, isString, objGetOwnPropertyDescriptor, objGetOwnPropertySymbols, objKeys } from "@nevware21/ts-utils";
 import { IAssertScope } from "../interface/IAssertScope";
 import { KeysFn } from "../interface/funcs/KeysFn";
 import { EMPTY_STRING } from "../internal/const";
+import { _deepEqual } from "./equal";
 
 function _objKeys(value: any): any[] {
     let keys: any[] = [];
@@ -27,16 +28,25 @@ function _objKeys(value: any): any[] {
     return keys;
 }
 
-function _formatKeys(keys: string[]): string {
+function _formatKeys(keys: any[]): string {
     let formattedKeys: string = EMPTY_STRING;
     arrForEach(keys, (key) => {
         if (formattedKeys.length > 0) {
             formattedKeys += ",";
         }
         if (key || isStrictNullOrUndefined(key)) {
-            formattedKeys += asString(key);
+            try {
+                formattedKeys += asString(key);
+            } catch (e) {
+                // Handle objects that can't be converted to string (e.g., null prototype)
+                formattedKeys += dumpObj(key);
+            }
         } else if (!isString(key)) {
-            formattedKeys += asString(key);
+            try {
+                formattedKeys += asString(key);
+            } catch (e) {
+                formattedKeys += dumpObj(key);
+            }
         } else {
             // special case for empty string keys
             formattedKeys += "\"\"";
@@ -46,10 +56,17 @@ function _formatKeys(keys: string[]): string {
     return formattedKeys;
 }
 
-function _getValueKeys(scope: IAssertScope, value: any): string[] {
-    let theKeys: string[] = [];
+function _getValueKeys(value: any): any[] {
+    let theKeys: any[] = [];
     if (!isStrictNullOrUndefined(value)) {
-        theKeys = _objKeys(value);
+        // Check if it's a Map or Set
+        if (isFunction(value.keys)) {
+            // For Maps and Sets, use the keys() iterator
+            theKeys = arrFrom(value.keys());
+        } else {
+            // For regular objects, use _objKeys
+            theKeys = _objKeys(value);
+        }
     }
 
     return theKeys;
@@ -73,6 +90,17 @@ function _getArgKeys(scope: IAssertScope, theArgs: any[]): string[] {
     return theKeys;
 }
 
+function _getArgKeysForDeep(scope: IAssertScope, theArgs: any[]): any[] {
+    // For deep keys, if a single array argument is provided, unwrap it to get multiple keys
+    // This matches Chai behavior: .keys([a, b, c]) checks for keys a, b, c
+    // Otherwise, treat all arguments as individual keys
+    if (theArgs && theArgs.length === 1 && isArray(theArgs[0])) {
+        return theArgs[0];
+    }
+
+    return theArgs;
+}
+
 export function anyKeysFunc<R>(_scope: IAssertScope): KeysFn<R> {
 
     function _keys(this: IAssertScope, _argKeys: Array<string|number|symbol> | Object | readonly any[]): R {
@@ -80,7 +108,7 @@ export function anyKeysFunc<R>(_scope: IAssertScope): KeysFn<R> {
         let context = scope.context;
         let args = arrSlice(arguments);
         let expectedKeys = _getArgKeys(scope, args);
-        let valueKeys = _getValueKeys(scope, context.value);
+        let valueKeys = _getValueKeys(context.value);
 
         if (expectedKeys.length === 0) {
             scope.context.set("expectedKeys", expectedKeys);
@@ -111,7 +139,7 @@ export function allKeysFunc<R>(_scope: IAssertScope): KeysFn<R> {
         let context = scope.context;
         let args = arrSlice(arguments);
         let theKeys = _getArgKeys(scope, args);
-        let valueKeys = _getValueKeys(scope, context.value);
+        let valueKeys = _getValueKeys(context.value);
 
         if (theKeys.length === 0) {
             scope.context.set("theKeys", theKeys);
@@ -133,3 +161,88 @@ export function allKeysFunc<R>(_scope: IAssertScope): KeysFn<R> {
     return _keys;
 }
 
+/**
+ * Creates a KeysFn function that checks if any of the provided keys exist in the value using deep equality comparison.
+ * This is used for deep key matching where keys are compared using deep equality instead of strict equality.
+ * @param _scope - The assert scope.
+ * @returns A KeysFn function.
+ */
+export function anyDeepKeysFunc<R>(_scope: IAssertScope): KeysFn<R> {
+
+    function _keys(this: IAssertScope, _argKeys: Array<string|number|symbol> | Object | readonly any[]): R {
+        let scope = this;
+        let context = scope.context;
+        let args = arrSlice(arguments);
+        let expectedKeys = _getArgKeysForDeep(scope, args);
+        let valueKeys = _getValueKeys(context.value);
+
+        if (expectedKeys.length === 0) {
+            scope.context.set("expectedKeys", expectedKeys);
+            scope.fatal("expected at least one key to be provided {expectedKeys}");
+        }
+
+        let found = false;
+        arrForEach(expectedKeys, (expKey) => {
+            arrForEach(valueKeys, (valKey) => {
+                if (_deepEqual(valKey, expKey)) {
+                    // Found at least one key using deep equality
+                    found = true;
+                    return -1;
+                }
+            });
+
+            if (found) {
+                return -1;
+            }
+        });
+
+        context.eval(found, `expected any deep key: [${_formatKeys(expectedKeys)}], found: [${_formatKeys(valueKeys)}] (${valueKeys.length} keys)`);
+
+        return scope.that;
+    }
+
+    return _keys;
+}
+
+/**
+ * Creates a KeysFn function that checks if all of the provided keys exist in the value using deep equality comparison.
+ * This is used for deep key matching where keys are compared using deep equality instead of strict equality.
+ * @param _scope - The assert scope.
+ * @returns A KeysFn function.
+ */
+export function allDeepKeysFunc<R>(_scope: IAssertScope): KeysFn<R> {
+
+    function _keys(this: IAssertScope, argKeys: string[] | Object | readonly any[]): R {
+        let scope = this;
+        let context = scope.context;
+        let args = arrSlice(arguments);
+        let theKeys = _getArgKeysForDeep(scope, args);
+        let valueKeys = _getValueKeys(context.value);
+
+        if (theKeys.length === 0) {
+            scope.context.set("theKeys", theKeys);
+            scope.fatal("expected at least one key to be provided {theKeys}");
+        }
+
+        let missingKeys: any[] = [];
+        arrForEach(theKeys, (expKey) => {
+            let found = false;
+            arrForEach(valueKeys, (valKey) => {
+                if (_deepEqual(valKey, expKey)) {
+                    found = true;
+                    return -1;
+                }
+            });
+
+            if (!found) {
+                missingKeys.push(expKey);
+            }
+        });
+
+        context.eval(missingKeys.length === 0, `expected all deep keys: [${_formatKeys(theKeys)}], missing: [${_formatKeys(missingKeys)}], found: [${_formatKeys(valueKeys)}]`);
+
+        return scope.that;
+    }
+
+    return _keys;
+}

--- a/core/src/assert/interface/IAssertClass.ts
+++ b/core/src/assert/interface/IAssertClass.ts
@@ -3354,6 +3354,147 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * ```
      */
     decreasesButNotBy<T>(fn: () => void, target: T, prop: keyof T, delta: number, initMsg?: MsgSource): AssertInst;
+
+    /**
+     * Asserts that the target has any of the specified keys using deep equality comparison.
+     * This method checks if at least one of the given keys exists in the target using deep equality
+     * for key comparison. Particularly useful for Maps and Sets where keys may be objects.
+     *
+     * @param target - The object, Map, or Set to check for keys.
+     * @param keys - The keys to search for (can be individual arguments or an array of keys).
+     * @param initMsg - The message to display if the assertion fails.
+     * @asserts That the `target` has at least one of the specified keys and throws {@link AssertionFailure} if it does not.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * const obj = { greeting: "hello", subject: "friend" };
+     * assert.hasAnyDeepKeys(obj, "greeting", "message");  // Passes - has "greeting"
+     * assert.hasAnyDeepKeys(obj, ["greeting", "message"]);  // Passes - has "greeting"
+     *
+     * const map = new Map([[{ id: 1 }, "value1"], [{ id: 2 }, "value2"]]);
+     * assert.hasAnyDeepKeys(map, { id: 1 });  // Passes - deep key match
+     * assert.hasAnyDeepKeys(map, { id: 1 }, { id: 3 });  // Passes - has { id: 1 }
+     * assert.hasAnyDeepKeys(obj, "unknown", "missing");  // Throws AssertionFailure
+     * ```
+     */
+    hasAnyDeepKeys(target: any, ...keys: any[]): AssertInst;
+
+    /**
+     * Asserts that the target has all of the specified keys using deep equality comparison.
+     * This method checks if all of the given keys exist in the target using deep equality
+     * for key comparison. Particularly useful for Maps and Sets where keys may be objects.
+     *
+     * @param target - The object, Map, or Set to check for keys.
+     * @param keys - The keys to search for (can be individual arguments or an array of keys).
+     * @param initMsg - The message to display if the assertion fails.
+     * @asserts That the `target` has all of the specified keys and throws {@link AssertionFailure} if it does not.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * const obj = { greeting: "hello", subject: "friend", message: "darkness" };
+     * assert.hasAllDeepKeys(obj, "greeting", "subject");  // Passes - has both keys
+     * assert.hasAllDeepKeys(obj, ["greeting", "subject"]);  // Passes - has both keys
+     *
+     * const map = new Map([[{ id: 1 }, "value1"], [{ id: 2 }, "value2"]]);
+     * assert.hasAllDeepKeys(map, { id: 1 }, { id: 2 });  // Passes - has both keys
+     * assert.hasAllDeepKeys(obj, "greeting", "unknown");  // Throws AssertionFailure - missing "unknown"
+     * ```
+     */
+    hasAllDeepKeys(target: any, ...keys: any[]): AssertInst;
+
+    /**
+     * Asserts that the target does NOT have any of the specified keys using deep equality comparison.
+     * This method checks that none of the given keys exist in the target using deep equality
+     * for key comparison. This is the inverse of {@link hasAnyDeepKeys}.
+     *
+     * @param target - The object, Map, or Set to check for keys.
+     * @param keys - The keys to search for (can be individual arguments or an array of keys).
+     * @param initMsg - The message to display if the assertion fails.
+     * @asserts That the `target` does not have any of the specified keys and throws {@link AssertionFailure} if it does.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * const obj = { greeting: "hello", subject: "friend" };
+     * assert.notHaveAnyDeepKeys(obj, "unknown", "missing");  // Passes - has neither key
+     * assert.notHaveAnyDeepKeys(obj, ["unknown", "missing"]);  // Passes - has neither key
+     *
+     * const map = new Map([[{ id: 1 }, "value1"]]);
+     * assert.notHaveAnyDeepKeys(map, { id: 3 }, { id: 4 });  // Passes - has neither key
+     * assert.notHaveAnyDeepKeys(obj, "greeting", "unknown");  // Throws AssertionFailure - has "greeting"
+     * ```
+     */
+    notHaveAnyDeepKeys(target: any, ...keys: any[]): AssertInst;
+
+    /**
+     * Asserts that the target does NOT have any of the specified keys using deep equality comparison.
+     * This method checks that none of the given keys exist in the target using deep equality
+     * for key comparison. This is the inverse of {@link hasAnyDeepKeys}.
+     *
+     * @param target - The object, Map, or Set to check for keys.
+     * @param keys - The keys to search for (can be individual arguments or an array of keys).
+     * @param initMsg - The message to display if the assertion fails.
+     * @asserts That the `target` does not have any of the specified keys and throws {@link AssertionFailure} if it does.
+     * @alias notHaveAnyDeepKeys
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * const obj = { greeting: "hello", subject: "friend" };
+     * assert.doesNotHaveAnyDeepKeys(obj, "unknown", "missing");  // Passes - has neither key
+     * assert.doesNotHaveAnyDeepKeys(obj, ["unknown", "missing"]);  // Passes - has neither key
+     *
+     * const map = new Map([[{ id: 1 }, "value1"]]);
+     * assert.doesNotHaveAnyDeepKeys(map, { id: 3 }, { id: 4 });  // Passes - has neither key
+     * assert.doesNotHaveAnyDeepKeys(obj, "greeting", "unknown");  // Throws AssertionFailure - has "greeting"
+     * ```
+     */
+    doesNotHaveAnyDeepKeys(target: any, ...keys: any[]): AssertInst;
+
+    /**
+     * Asserts that the target does NOT have all of the specified keys using deep equality comparison.
+     * This method checks that at least one of the given keys does not exist in the target using deep equality
+     * for key comparison. This is the inverse of {@link hasAllDeepKeys}.
+     *
+     * @param target - The object, Map, or Set to check for keys.
+     * @param keys - The keys to search for (can be individual arguments or an array of keys).
+     * @param initMsg - The message to display if the assertion fails.
+     * @asserts That the `target` does not have all of the specified keys and throws {@link AssertionFailure} if it does.
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * const obj = { greeting: "hello", subject: "friend" };
+     * assert.notHaveAllDeepKeys(obj, "greeting", "unknown");  // Passes - missing "unknown"
+     * assert.notHaveAllDeepKeys(obj, ["greeting", "unknown"]);  // Passes - missing "unknown"
+     *
+     * const map = new Map([[{ id: 1 }, "value1"]]);
+     * assert.notHaveAllDeepKeys(map, { id: 1 }, { id: 2 });  // Passes - missing { id: 2 }
+     * assert.notHaveAllDeepKeys(obj, "greeting", "subject");  // Throws AssertionFailure - has both keys
+     * ```
+     */
+    notHaveAllDeepKeys(target: any, ...keys: any[]): AssertInst;
+
+    /**
+     * Asserts that the target does NOT have all of the specified keys using deep equality comparison.
+     * This method checks that at least one of the given keys does not exist in the target using deep equality
+     * for key comparison. This is the inverse of {@link hasAllDeepKeys}.
+     *
+     * @param target - The object, Map, or Set to check for keys.
+     * @param keys - The keys to search for (can be individual arguments or an array of keys).
+     * @param initMsg - The message to display if the assertion fails.
+     * @asserts That the `target` does not have all of the specified keys and throws {@link AssertionFailure} if it does.
+     * @alias notHaveAllDeepKeys
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * const obj = { greeting: "hello", subject: "friend" };
+     * assert.doesNotHaveAllDeepKeys(obj, "greeting", "unknown");  // Passes - missing "unknown"
+     * assert.doesNotHaveAllDeepKeys(obj, ["greeting", "unknown"]);  // Passes - missing "unknown"
+     *
+     * const map = new Map([[{ id: 1 }, "value1"]]);
+     * assert.doesNotHaveAllDeepKeys(map, { id: 1 }, { id: 2 });  // Passes - missing { id: 2 }
+     * assert.doesNotHaveAllDeepKeys(obj, "greeting", "subject");  // Throws AssertionFailure - has both keys
+     * ```
+     */
+    doesNotHaveAllDeepKeys(target: any, ...keys: any[]): AssertInst;
 }
 
 export type IExtendedAssert<T = any> = IAssertClass<IAssertInst & T> & T;

--- a/core/src/assert/interface/ops/IAllOp.ts
+++ b/core/src/assert/interface/ops/IAllOp.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024-2025 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2026 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 
@@ -14,4 +14,14 @@ import { IKeysOp } from "./IKeysOp";
  * @template R - The type of the result of the operation.
  */
 export interface IAllOp<R> extends ValuesFn<R>, IKeysOp<R> {
+    /**
+     * Provides deep equality operations for keys.
+     * @example
+     * ```typescript
+     * const map = new Map();
+     * map.set({ a: 1 }, "value");
+     * expect(map).to.have.all.deep.keys({ a: 1 });
+     * ```
+     */
+    deep: IKeysOp<R>;
 }

--- a/core/src/assert/interface/ops/IAnyOp.ts
+++ b/core/src/assert/interface/ops/IAnyOp.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024-2025 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2026 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 
@@ -14,4 +14,14 @@ import { IKeysOp } from "./IKeysOp";
  * @template R - The type of the result of the operation.
  */
 export interface IAnyOp<R> extends ValuesFn<R>, IKeysOp<R>{
+    /**
+     * Provides deep equality operations for keys.
+     * @example
+     * ```typescript
+     * const map = new Map();
+     * map.set({ a: 1 }, "value");
+     * expect(map).to.have.any.deep.keys({ a: 1 });
+     * ```
+     */
+    deep: IKeysOp<R>;
 }

--- a/core/src/assert/interface/ops/IDeepOp.ts
+++ b/core/src/assert/interface/ops/IDeepOp.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2026 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 
@@ -13,6 +13,7 @@ import { IEqualOp } from "./IEqualOp";
 import { IIncludeOp } from "./IIncludeOp";
 import { INotOp } from "./INotOp";
 import { INestedOp } from "./INestedOp";
+import { IKeysOp } from "./IKeysOp";
 
 
 /**
@@ -70,4 +71,9 @@ export interface IDeepOp<R> extends INotOp<IDeepOp<R>>, IEqualOp<R> {
      * Provides nested property operations using dot notation with deep equality.
      */
     nested: INestedOp<R>;
+
+    /**
+     * Provides operations to assert that the value has specific keys using deep equality.
+     */
+    keys: IKeysOp<R>;
 }

--- a/core/src/assert/ops/allOp.ts
+++ b/core/src/assert/ops/allOp.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024-2025 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2026 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 
@@ -13,13 +13,15 @@ import { allKeysFunc, anyKeysFunc } from "../funcs/keysFunc";
 import { IAssertScope } from "../interface/IAssertScope";
 import { AssertScopeFuncDefs } from "../interface/IAssertInst";
 import { allValuesFunc, anyValuesFunc } from "../funcs/valuesFunc";
+import { allDeepKeyFilterOp, anyDeepKeyFilterOp } from "./keysOp";
 
 export function anyOp<R>(scope: IAssertScope): IAnyOp<R> {
     scope.context.set(ANY, true);
     scope.context.set(ALL, false);
 
     const props: AssertScopeFuncDefs<IAnyOp<R>> = {
-        keys: { propFn: anyKeysFunc }
+        keys: { propFn: anyKeysFunc },
+        deep: { propFn: anyDeepKeyFilterOp }
     };
 
     return scope.createOperation(props, anyValuesFunc(scope));
@@ -30,7 +32,8 @@ export function allOp<R>(scope: IAssertScope): IAllOp<R> {
     scope.context.set(ALL, true);
 
     const props: AssertScopeFuncDefs<IAllOp<R>> = {
-        keys: { propFn: allKeysFunc }
+        keys: { propFn: allKeysFunc },
+        deep: { propFn: allDeepKeyFilterOp }
     };
 
     return scope.createOperation(props, allValuesFunc(scope));

--- a/core/src/assert/ops/deepOp.ts
+++ b/core/src/assert/ops/deepOp.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2026 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 
@@ -17,6 +17,7 @@ import { hasDeepPropertyFunc, hasPropertyDescriptorFunc } from "../funcs/hasProp
 import { AssertScopeFuncDefs } from "../interface/IAssertInst";
 import { IAssertScope } from "../interface/IAssertScope";
 import { deepNestedOp } from "./nestedOp";
+import { deepKeysOp } from "./keysOp";
 
 export function deepOp<R>(scope: IAssertScope): IDeepOp<R> {
     scope.context.set(DEEP, true);
@@ -34,7 +35,8 @@ export function deepOp<R>(scope: IAssertScope): IDeepOp<R> {
         property: { scopeFn: hasDeepPropertyFunc },
         propertyDescriptor: { scopeFn: hasPropertyDescriptorFunc },
         own: { propFn: ownDeepOp },
-        nested: { propFn: deepNestedOp }
+        nested: { propFn: deepNestedOp },
+        keys: { propFn: deepKeysOp }
     };
 
     return scope.createOperation(props);

--- a/core/src/assert/ops/keysOp.ts
+++ b/core/src/assert/ops/keysOp.ts
@@ -2,15 +2,16 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2026 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 
 import { ObjDefinePropDescriptor, objDefineProps } from "@nevware21/ts-utils";
-import { allKeysFunc, anyKeysFunc } from "../funcs/keysFunc";
+import { allDeepKeysFunc, allKeysFunc, anyDeepKeysFunc, anyKeysFunc } from "../funcs/keysFunc";
 import { IKeysOp } from "../interface/ops/IKeysOp";
 import { IAssertScope } from "../interface/IAssertScope";
 import { IAssertInst } from "../interface/IAssertInst";
+import { ANY } from "../internal/const";
 
 type KeyFilterOpProps = {
     readonly [key in keyof IKeysOp<IAssertInst> extends string | number | symbol ? keyof IKeysOp<IAssertInst> : never]: ObjDefinePropDescriptor
@@ -46,4 +47,52 @@ export function allKeyFilterOp<R>(scope: IAssertScope): IKeysOp<R> {
     };
 
     return objDefineProps({} as IKeysOp<R>, props);
+}
+
+/**
+ * Creates a deep key filter operation that matches any key using deep equality in the given assert scope.
+ *
+ * @param scope - The assert scope.
+ * @returns The deep key filter operation.
+ * @template R - The type of the key filter operation result.
+ */
+export function anyDeepKeyFilterOp<R>(scope: IAssertScope): IKeysOp<R> {
+    
+    const props: KeyFilterOpProps = {
+        keys: { g: () => anyDeepKeysFunc(scope) }
+    };
+
+    return objDefineProps({} as IKeysOp<R>, props);
+}
+
+/**
+ * Returns a deep keys operation that filters all keys using deep equality in the given assert scope.
+ *
+ * @template R - The type of the keys operation result.
+ * @param scope - The assert scope.
+ * @returns The deep keys operation.
+ */
+export function allDeepKeyFilterOp<R>(scope: IAssertScope): IKeysOp<R> {
+    
+    const props: KeyFilterOpProps = {
+        keys: { g: () => allDeepKeysFunc(scope) }
+    };
+
+    return objDefineProps({} as IKeysOp<R>, props);
+}
+
+/**
+ * Creates a keys operation that uses deep equality for key comparison.
+ * This function automatically determines whether to use any or all based on the context.
+ *
+ * @param scope - The assert scope.
+ * @returns A IKeysOp operation.
+ */
+export function deepKeysOp<R>(scope: IAssertScope): IKeysOp<R> {
+    let context = scope.context;
+    
+    // Check if we're in ANY context
+    let isAny = context.get(ANY) === true;
+    
+    return isAny ? anyDeepKeyFilterOp(scope) : allDeepKeyFilterOp(scope);
 }

--- a/core/test/src/assert/assert.deepKeys.test.ts
+++ b/core/test/src/assert/assert.deepKeys.test.ts
@@ -1,0 +1,260 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2026 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { AssertionFailure } from "../../../src/assert/assertionError";
+import { expect } from "../../../src/assert/expect";
+
+describe("assert deep keys", () => {
+    describe("has.any.deep.keys", () => {
+        it("should pass when Map has any deep key match", () => {
+            const map = new Map();
+            map.set({ greeting: "hello", subject: "friend" }, "value1");
+            map.set({ message: "darkness", type: "familiar" }, "value2");
+            
+            expect(map).to.have.any.deep.keys({ greeting: "hello", subject: "friend" });
+            expect(map).to.have.any.deep.keys({ message: "darkness", type: "familiar" });
+            expect(map).to.have.any.deep.keys([{ greeting: "hello", subject: "friend" }, { echo: "calling" }]);
+        });
+
+        it("should pass when Set has any deep key match", () => {
+            const set = new Set();
+            set.add({ greeting: "hello", subject: "friend" });
+            set.add({ message: "darkness", type: "familiar" });
+            
+            expect(set).to.have.any.deep.keys({ greeting: "hello", subject: "friend" });
+            expect(set).to.have.any.deep.keys({ message: "darkness", type: "familiar" });
+            expect(set).to.have.any.deep.keys([{ greeting: "hello", subject: "friend" }, { echo: "calling" }]);
+        });
+
+        it("should pass when object has any deep key match", () => {
+            const obj: any = {};
+            obj[JSON.stringify({ greeting: "hello", subject: "friend" })] = "value1";
+            obj[JSON.stringify({ message: "darkness", type: "familiar" })] = "value2";
+            
+            // Note: Regular objects can't have deep object keys, so this tests string keys
+            expect(obj).to.have.any.deep.keys(JSON.stringify({ greeting: "hello", subject: "friend" }));
+        });
+
+        it("should fail when Map does not have any deep key match", () => {
+            const map = new Map();
+            map.set({ greeting: "hello", subject: "friend" }, "value1");
+            map.set({ message: "darkness", type: "familiar" }, "value2");
+            
+            expect(() => {
+                expect(map).to.have.any.deep.keys({ echo: "calling", void: "silence" });
+            }).to.throw(AssertionFailure);
+            
+            expect(() => {
+                expect(map).to.have.any.deep.keys([{ echo: "calling" }, { vision: "softly" }]);
+            }).to.throw(AssertionFailure);
+        });
+
+        it("should work with expect syntax", () => {
+            const map = new Map();
+            map.set({ greeting: "hello", subject: "friend" }, "val");
+            
+            expect(map).to.have.any.deep.keys({ greeting: "hello", subject: "friend" });
+            expect(() => expect(map).to.have.any.deep.keys({ echo: "calling" })).to.throw();
+        });
+
+        it("should work with complex nested objects as keys", () => {
+            const map = new Map();
+            map.set({ nested: { value: [1, 2, 3] } }, "data");
+            
+            expect(map).to.have.any.deep.keys({ nested: { value: [1, 2, 3] } });
+        });
+    });
+
+    describe("has.all.deep.keys", () => {
+        it("should pass when Map has all deep key matches", () => {
+            const map = new Map();
+            map.set({ greeting: "hello", subject: "friend" }, "value1");
+            map.set({ message: "darkness", type: "familiar" }, "value2");
+            map.set({ echo: "calling", void: "silence" }, "value3");
+            
+            expect(map).to.have.all.deep.keys([{ greeting: "hello", subject: "friend" }, { message: "darkness", type: "familiar" }]);
+            expect(map).to.have.all.deep.keys([{ greeting: "hello", subject: "friend" }, { message: "darkness", type: "familiar" }, { echo: "calling", void: "silence" }]);
+        });
+
+        it("should pass when Set has all deep key matches", () => {
+            const set = new Set();
+            set.add({ greeting: "hello", subject: "friend" });
+            set.add({ message: "darkness", type: "familiar" });
+            
+            expect(set).to.have.all.deep.keys([{ greeting: "hello", subject: "friend" }, { message: "darkness", type: "familiar" }]);
+        });
+
+        it("should fail when Map is missing some deep keys", () => {
+            const map = new Map();
+            map.set({ greeting: "hello", subject: "friend" }, "value1");
+            map.set({ message: "darkness", type: "familiar" }, "value2");
+            
+            expect(() => {
+                expect(map).to.have.all.deep.keys([{ greeting: "hello", subject: "friend" }, { echo: "calling" }]);
+            }).to.throw(AssertionFailure);
+        });
+
+        it("should work with expect syntax", () => {
+            const map = new Map();
+            map.set({ greeting: "hello", subject: "friend" }, "val1");
+            map.set({ message: "darkness", type: "familiar" }, "val2");
+            
+            expect(map).to.have.all.deep.keys([{ greeting: "hello", subject: "friend" }, { message: "darkness", type: "familiar" }]);
+            expect(() => expect(map).to.have.all.deep.keys([{ greeting: "hello", subject: "friend" }, { echo: "calling" }])).to.throw();
+        });
+
+        it("should work with single key", () => {
+            const map = new Map();
+            map.set({ greeting: "hello", subject: "friend" }, "value");
+            
+            expect(map).to.have.all.deep.keys({ greeting: "hello", subject: "friend" });
+        });
+    });
+
+    describe("not.has.any.deep.keys", () => {
+        it("should pass when Map does not have any deep key match", () => {
+            const map = new Map();
+            map.set({ greeting: "hello", subject: "friend" }, "value1");
+            map.set({ message: "darkness", type: "familiar" }, "value2");
+            
+            expect(map).to.not.have.any.deep.keys({ echo: "calling", void: "silence" });
+            expect(map).to.not.have.any.deep.keys([{ echo: "calling" }, { vision: "softly" }]);
+        });
+
+        it("should fail when Map has at least one deep key match", () => {
+            const map = new Map();
+            map.set({ greeting: "hello", subject: "friend" }, "value1");
+            map.set({ message: "darkness", type: "familiar" }, "value2");
+            
+            expect(() => {
+                expect(map).to.not.have.any.deep.keys({ greeting: "hello", subject: "friend" });
+            }).to.throw(AssertionFailure);
+            
+            expect(() => {
+                expect(map).to.not.have.any.deep.keys([{ greeting: "hello", subject: "friend" }, { echo: "calling" }]);
+            }).to.throw(AssertionFailure);
+        });
+
+        it("should work with expect syntax", () => {
+            const map = new Map();
+            map.set({ greeting: "hello", subject: "friend" }, "val");
+            
+            expect(map).to.not.have.any.deep.keys({ message: "darkness" });
+            expect(() => expect(map).to.not.have.any.deep.keys({ greeting: "hello", subject: "friend" })).to.throw();
+        });
+    });
+
+    describe("not.has.all.deep.keys", () => {
+        it("should pass when Map does not have all deep key matches", () => {
+            const map = new Map();
+            map.set({ greeting: "hello", subject: "friend" }, "value1");
+            map.set({ message: "darkness", type: "familiar" }, "value2");
+            
+            expect(map).to.not.have.all.deep.keys([{ greeting: "hello", subject: "friend" }, { echo: "calling" }]);
+            expect(map).to.not.have.all.deep.keys([{ echo: "calling" }, { vision: "softly" }]);
+        });
+
+        it("should fail when Map has all deep key matches", () => {
+            const map = new Map();
+            map.set({ greeting: "hello", subject: "friend" }, "value1");
+            map.set({ message: "darkness", type: "familiar" }, "value2");
+            
+            expect(() => {
+                expect(map).to.not.have.all.deep.keys([{ greeting: "hello", subject: "friend" }, { message: "darkness", type: "familiar" }]);
+            }).to.throw(AssertionFailure);
+        });
+
+        it("should work with expect syntax", () => {
+            const map = new Map();
+            map.set({ greeting: "hello", subject: "friend" }, "val1");
+            map.set({ message: "darkness", type: "familiar" }, "val2");
+            
+            expect(map).to.not.have.all.deep.keys([{ greeting: "hello", subject: "friend" }, { echo: "calling" }]);
+            expect(() => expect(map).to.not.have.all.deep.keys([{ greeting: "hello", subject: "friend" }, { message: "darkness", type: "familiar" }])).to.throw();
+        });
+    });
+
+    describe("contains.all.deep.keys", () => {
+        it("should pass when Map contains all deep keys", () => {
+            const map = new Map();
+            map.set({ greeting: "hello", subject: "friend" }, "value1");
+            map.set({ message: "darkness", type: "familiar" }, "value2");
+            map.set({ echo: "calling", void: "silence" }, "value3");
+            
+            expect(map).to.contain.all.deep.keys([{ greeting: "hello", subject: "friend" }, { message: "darkness", type: "familiar" }]);
+        });
+
+        it("should work with expect syntax", () => {
+            const map = new Map();
+            map.set({ greeting: "hello", subject: "friend" }, "val1");
+            map.set({ message: "darkness", type: "familiar" }, "val2");
+            
+            expect(map).to.contain.all.deep.keys([{ greeting: "hello", subject: "friend" }]);
+        });
+    });
+
+    describe("edge cases", () => {
+        it("should work with symbol keys in objects", () => {
+            const sym1 = Symbol("test");
+            const obj: any = {};
+            obj[sym1] = "value";
+            
+            expect(obj).to.have.any.deep.keys(sym1);
+        });
+
+        it("should work with numeric keys", () => {
+            const obj: any = { 1: "one", 2: "two" };
+            expect(obj).to.have.any.deep.keys("1");
+        });
+
+        it("should work with empty Map", () => {
+            const map = new Map();
+            
+            expect(() => {
+                expect(map).to.have.any.deep.keys({ a: 1 });
+            }).to.throw(AssertionFailure);
+        });
+
+        it("should work with null prototype objects as keys", () => {
+            const map = new Map();
+            const nullProtoKey = Object.create(null);
+            nullProtoKey.a = 1;
+            map.set(nullProtoKey, "value");
+            
+            const testKey = Object.create(null);
+            testKey.a = 1;
+            
+            expect(map).to.have.any.deep.keys(testKey);
+        });
+
+        it("should distinguish between similar but not equal objects", () => {
+            const map = new Map();
+            map.set({ greeting: "hello", subject: "friend", extra: "data" }, "value");
+            
+            expect(() => {
+                expect(map).to.have.any.deep.keys({ greeting: "hello", subject: "friend" });
+            }).to.throw(AssertionFailure);
+        });
+
+        it("should work with arrays as Map keys", () => {
+            const map = new Map();
+            map.set([1, 2, 3], "value");
+            
+            // Use double array wrapping to check for array as literal key
+            expect(map).to.have.any.deep.keys([[1, 2, 3]]);
+        });
+
+        it("should work with Date objects as keys", () => {
+            const map = new Map();
+            const date = new Date("2020-01-01");
+            map.set(date, "value");
+            
+            expect(map).to.have.any.deep.keys(new Date("2020-01-01"));
+        });
+    });
+});

--- a/shim/chai/README.md
+++ b/shim/chai/README.md
@@ -67,6 +67,7 @@ Error messages differ from Chai. Use regex instead of exact strings:
 - **Comparisons**: `isAbove`, `isAtLeast`, `isBelow`, `isAtMost`, `closeTo`, `approximately`
 - **Properties**: `property`, `deepProperty`, `nestedProperty`, `ownProperty` with value validation
 - **Collections**: `include`, `deepInclude`, `members`, `sameMembers`, `keys`
+- **Deep Keys**: `hasAnyDeepKeys`, `hasAllDeepKeys`, `containsAllDeepKeys`, `doesNotHaveAnyDeepKeys`, `doesNotHaveAllDeepKeys` for Maps/Sets with object keys
 - **Size**: `lengthOf`, `sizeOf`
 - **Changes**: `changes`, `increases`, `decreases` with delta tracking
 - **Errors**: `throws`, `doesNotThrow`

--- a/shim/chai/src/assert/chaiAssert.ts
+++ b/shim/chai/src/assert/chaiAssert.ts
@@ -208,11 +208,11 @@ function _createChaiAssert(): IChaiAssert {
         doesNotHaveAnyKeys: { scopeFn: createExprAdapter("not.has.any.keys"), nArgs: 2 },
         doesNotHaveAllKeys: { scopeFn: createExprAdapter("not.has.all.keys"), nArgs: 2 },
 
-        hasAnyDeepKeys: notImplemented,
-        hasAllDeepKeys: notImplemented,
-        containsAllDeepKeys: notImplemented,
-        doesNotHaveAnyDeepKeys: notImplemented,
-        doesNotHaveAllDeepKeys: notImplemented,
+        hasAnyDeepKeys: { scopeFn: createExprAdapter("has.any.deep.keys"), nArgs: 2 },
+        hasAllDeepKeys: { scopeFn: createExprAdapter("has.all.deep.keys"), nArgs: 2 },
+        containsAllDeepKeys: { scopeFn: createExprAdapter("contains.all.deep.keys"), nArgs: 2 },
+        doesNotHaveAnyDeepKeys: { scopeFn: createExprAdapter("not.has.any.deep.keys"), nArgs: 2 },
+        doesNotHaveAllDeepKeys: { scopeFn: createExprAdapter("not.has.all.deep.keys"), nArgs: 2 },
 
         nestedProperty: { scopeFn: createExprAdapter("has.nested.property"), nArgs: 2 },
         notNestedProperty: { scopeFn: createExprAdapter("not.has.nested.property"), nArgs: 2 },

--- a/shim/chai/test/src/chaiAssert.test.ts
+++ b/shim/chai/test/src/chaiAssert.test.ts
@@ -1097,12 +1097,12 @@ describe("assert", function () {
         assert.hasAllKeys(obj, [sym1, sym2, str]);
         assert.doesNotHaveAllKeys(obj, [sym1, sym2, sym3, str]);
 
-        // var aKey = {thisIs: "anExampleObject"}
-        //     , anotherKey = {doingThisBecauseOf: "referential equality"}
-        //     , testMap = new Map();
+        var aKey = {thisIs: "anExampleObject"}
+            , anotherKey = {doingThisBecauseOf: "referential equality"}
+            , testMap = new Map();
 
-        // testMap.set(aKey, "aValue");
-        // testMap.set(anotherKey, "anotherValue");
+        testMap.set(aKey, "aValue");
+        testMap.set(anotherKey, "anotherValue");
 
         // assert.hasAnyKeys(testMap, [ aKey ]);
         // assert.hasAnyKeys(testMap, [ "thisDoesNotExist", "thisToo", aKey ]);
@@ -1135,21 +1135,22 @@ describe("assert", function () {
         //     assert.containsAllKeys(testMap, [ {thisIs: "anExampleObject"} ]);
         // });
 
-        // // Tests for the deep variations of the keys assertion
-        // assert.hasAnyDeepKeys(testMap, {thisIs: "anExampleObject"});
-        // assert.hasAnyDeepKeys(testMap, [{thisIs: "anExampleObject"}, {three: "three"}]);
-        // assert.hasAnyDeepKeys(testMap, [{thisIs: "anExampleObject"}, {doingThisBecauseOf: "referential equality"}]);
+        // Tests for the deep variations of the keys assertion
+        assert.hasAnyDeepKeys(testMap, {thisIs: "anExampleObject"});
+        assert.hasAnyDeepKeys(testMap, [{thisIs: "anExampleObject"}, {three: "three"}]);
+        assert.hasAnyDeepKeys(testMap, [{thisIs: "anExampleObject"}, {doingThisBecauseOf: "referential equality"}]);
 
-        // assert.hasAllDeepKeys(testMap, [{thisIs: "anExampleObject"}, {doingThisBecauseOf: "referential equality"}]);
+        assert.hasAllDeepKeys(testMap, [{thisIs: "anExampleObject"}, {doingThisBecauseOf: "referential equality"}]);
 
-        // assert.containsAllDeepKeys(testMap, {thisIs: "anExampleObject"});
-        // assert.containsAllDeepKeys(testMap, [{thisIs: "anExampleObject"}, {doingThisBecauseOf: "referential equality"}]);
+        assert.containsAllDeepKeys(testMap, {thisIs: "anExampleObject"});
+        assert.containsAllDeepKeys(testMap, [{thisIs: "anExampleObject"}, {doingThisBecauseOf: "referential equality"}]);
 
-        // assert.doesNotHaveAnyDeepKeys(testMap, {thisDoesNot: "exist"});
-        // assert.doesNotHaveAnyDeepKeys(testMap, [{twenty: "twenty"}, {fifty: "fifty"}]);
+        assert.doesNotHaveAnyDeepKeys(testMap, {thisDoesNot: "exist"});
+        assert.doesNotHaveAnyDeepKeys(testMap, [{twenty: "twenty"}, {fifty: "fifty"}]);
 
-        // assert.doesNotHaveAllDeepKeys(testMap, {thisDoesNot: "exist"});
-        // assert.doesNotHaveAllDeepKeys(testMap, [{twenty: "twenty"}, {thisIs: "anExampleObject"}]);
+        assert.doesNotHaveAllDeepKeys(testMap, {thisDoesNot: "exist"});
+        assert.doesNotHaveAllDeepKeys(testMap, [{twenty: "twenty"}, {thisIs: "anExampleObject"}]);
+
 
         // var weirdMapKey1 = Object.create(null)
         //     , weirdMapKey2 = {toString: NaN}
@@ -1211,12 +1212,12 @@ describe("assert", function () {
         //   assert.containsAllDeepKeys(new Map([[{foo: 1}, \"bar\"]]), { iDoNotExist: 0 })
         // }, 'expected [ { foo: 1 } ] to deeply contain key { iDoNotExist: 0 }');
 
-        // var aKey = {thisIs: "anExampleObject"}
-        //     , anotherKey = {doingThisBecauseOf: "referential equality"}
-        //     , testSet = new Set();
+        var aKey = {thisIs: "anExampleObject"}
+            , anotherKey = {doingThisBecauseOf: "referential equality"}
+            , testSet = new Set();
 
-        // testSet.add(aKey);
-        // testSet.add(anotherKey);
+        testSet.add(aKey);
+        testSet.add(anotherKey);
 
         // assert.hasAnyKeys(testSet, [ aKey ]);
         // assert.hasAnyKeys(testSet, [ 20, 1, aKey ]);
@@ -1249,21 +1250,23 @@ describe("assert", function () {
         //     assert.containsAllKeys(testSet, [ {thisIs: "anExampleObject"} ]);
         // });
 
-        // // Tests for the deep variations of the keys assertion
-        // assert.hasAnyDeepKeys(testSet, {thisIs: "anExampleObject"});
-        // assert.hasAnyDeepKeys(testSet, [{thisIs: "anExampleObject"}, {three: "three"}]);
-        // assert.hasAnyDeepKeys(testSet, [{thisIs: "anExampleObject"}, {doingThisBecauseOf: "referential equality"}]);
+        // Tests for the deep variations of the keys assertion
+        assert.hasAnyDeepKeys(testSet, {thisIs: "anExampleObject"});
+        assert.hasAnyDeepKeys(testSet, [{thisIs: "anExampleObject"}, {three: "three"}]);
+        assert.hasAnyDeepKeys(testSet, [{thisIs: "anExampleObject"}, {doingThisBecauseOf: "referential equality"}]);
 
-        // assert.hasAllDeepKeys(testSet, [{thisIs: "anExampleObject"}, {doingThisBecauseOf: "referential equality"}]);
+        assert.hasAllDeepKeys(testSet, [{thisIs: "anExampleObject"}, {doingThisBecauseOf: "referential equality"}]);
 
-        // assert.containsAllDeepKeys(testSet, {thisIs: "anExampleObject"});
-        // assert.containsAllDeepKeys(testSet, [{thisIs: "anExampleObject"}, {doingThisBecauseOf: "referential equality"}]);
+        assert.containsAllDeepKeys(testSet, {thisIs: "anExampleObject"});
+        assert.containsAllDeepKeys(testSet, [{thisIs: "anExampleObject"}, {doingThisBecauseOf: "referential equality"}]);
 
-        // assert.doesNotHaveAnyDeepKeys(testSet, {twenty: "twenty"});
-        // assert.doesNotHaveAnyDeepKeys(testSet, [{twenty: "twenty"}, {fifty: "fifty"}]);
+        assert.doesNotHaveAnyDeepKeys(testSet, {twenty: "twenty"});
+        assert.doesNotHaveAnyDeepKeys(testSet, [{twenty: "twenty"}, {fifty: "fifty"}]);
 
-        // assert.doesNotHaveAllDeepKeys(testSet, {twenty: "twenty"});
-        // assert.doesNotHaveAllDeepKeys(testSet, [{thisIs: "anExampleObject"}, {fifty: "fifty"}]);
+        assert.doesNotHaveAllDeepKeys(testSet, {twenty: "twenty"});
+
+        assert.doesNotHaveAllDeepKeys(testSet, [{thisIs: "anExampleObject"}, {fifty: "fifty"}]);
+
 
         // var weirdSetKey1 = Object.create(null)
         //     , weirdSetKey2 = {toString: NaN}


### PR DESCRIPTION
Add deep equality key comparison for Maps and Sets with object keys. Implements anyDeepKeysFunc, allDeepKeysFunc, and six assert methods (hasAnyDeepKeys, hasAllDeepKeys, and their negations).

Addresses Chai v5.x compatibility for deep keys operations.