### PR TITLE
feat: Add ifError assertion for Node.js error handling

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -60,14 +60,14 @@ expect({ a: 1 }).to.deep.equal({ a: 1 });
 
 - **Type Checking** - `isObject`, `isArray`, `isString`, `isNumber`, `isBoolean`, `isFunction`, `isNull`, `isUndefined`, `isNaN`, `isFinite`, `typeOf`, `instanceOf`, `exists`
 - **Equality** - `equal`, `strictEqual`, `deepEqual`, `closeTo` (approximate equality)
-- **Comparisons** - `above`, `below`, `within`, `atLeast`, `atMost`
+- **Comparisons** - `above`, `below`, `within`, `atLeast`, `atMost`, `operator` (generic comparison)
 - **Properties** - `property`, `ownProperty`, `deepProperty`, `nestedProperty` with value validation
 - **Collections** - `include`, `keys`, `members` with deep equality and ordered comparison
 - **Deep Keys** - `hasAnyDeepKeys`, `hasAllDeepKeys` for Maps/Sets with object keys using deep equality
 - **Size/Length** - `lengthOf`, `sizeOf` for arrays, strings, maps, sets
 - **Array Operations** - `subsequence`, `endsWith`, `oneOf` matching
 - **Change Tracking** - Monitor value `changes`, `increases`, `decreases` with delta validation
-- **Error Testing** - `throw`, `throws`, `doesNotThrow` with type and message validation
+- **Error Testing** - `throw`, `throws`, `doesNotThrow`, `ifError` with type and message validation
 - **Object State** - `isExtensible`, `isSealed`, `isFrozen`, `isEmpty`
 
 ## Documentation

--- a/core/src/assert/assertClass.ts
+++ b/core/src/assert/assertClass.ts
@@ -46,6 +46,7 @@ import {
 } from "./funcs/members";
 import { changesFunc, increasesFunc, decreasesFunc } from "./funcs/changes";
 import { changesByFunc, increasesByFunc, decreasesByFunc, changesButNotByFunc, increasesButNotByFunc, decreasesButNotByFunc } from "./funcs/changesBy";
+import { ifErrorFunc } from "./funcs/ifError";
 
 /**
  * @internal
@@ -236,6 +237,8 @@ export function createAssert(): IAssertClass {
 
         exists: createExprAdapter("to.exist"),
         notExists: createExprAdapter("not.to.exist"),
+
+        ifError: { scopeFn: ifErrorFunc, nArgs: 1 },
 
         isInstanceOf: { scopeFn: instanceOfFunc, nArgs: 2 },
         isNotInstanceOf: { scopeFn: createExprAdapter("not", instanceOfFunc), nArgs: 2 },

--- a/core/src/assert/funcs/ifError.ts
+++ b/core/src/assert/funcs/ifError.ts
@@ -1,0 +1,59 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2026 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { isError } from "@nevware21/ts-utils";
+import { IAssertScope } from "../interface/IAssertScope";
+import { MsgSource } from "../type/MsgSource";
+
+/**
+ * Asserts that the target is falsy or throws the error if it is an Error instance.
+ * This is commonly used in Node.js-style callback error handling to check for errors.
+ * - If the value is falsy (null, undefined, false, 0, "", etc.), the assertion passes
+ * - If the value is an Error instance, that error is thrown
+ * - If the value is truthy but not an Error, an AssertionFailure is thrown
+ *
+ * @since 0.1.5
+ * @param this - The assert scope.
+ * @param evalMsg - The message to display if the assertion fails.
+ * @returns - The assert scope.
+ * @example
+ * ```typescript
+ * import { assert } from "@nevware21/tripwire";
+ *
+ * assert.ifError(null);          // Passes - null is falsy
+ * assert.ifError(undefined);     // Passes - undefined is falsy
+ * assert.ifError(false);         // Passes - false is falsy
+ * assert.ifError(0);             // Passes - 0 is falsy
+ * assert.ifError("");            // Passes - empty string is falsy
+ *
+ * // Throws the error itself
+ * assert.ifError(new Error("Something went wrong"));
+ *
+ * // Throws AssertionFailure
+ * assert.ifError(true);          // Truthy but not an Error
+ * assert.ifError("error");       // Truthy but not an Error
+ * assert.ifError(1);             // Truthy but not an Error
+ * ```
+ */
+export function ifErrorFunc<R>(this: IAssertScope, evalMsg?: MsgSource): R {
+    let context = this.context;
+    let value = context.value;
+
+    // If the value is an Error, throw it
+    if (isError(value)) {
+        throw value;
+    }
+
+    // If the value is truthy (but not an Error), fail the assertion
+    context.eval(
+        !value,
+        evalMsg || "expected {value} to be falsy or an Error"
+    );
+
+    return this.that;
+}

--- a/core/src/assert/funcs/keysFunc.ts
+++ b/core/src/assert/funcs/keysFunc.ts
@@ -96,20 +96,20 @@ function _getArgKeys(scope: IAssertScope, theArgs: any[]): string[] {
  * Processes arguments for deep key comparisons, extracting the keys to compare.
  * This helper function handles ArrayLikeOrSizedIterable expansion and filters out
  * optional initMsg parameters.
- * 
+ *
  * @param scope - The assert scope (currently unused but matches signature pattern).
  * @param theArgs - The raw arguments array from the calling function.
  * @returns An array of keys to compare against the target value.
- * 
+ *
  * @remarks
  * This function handles three scenarios:
  * 1. If the last argument is a MsgSource (custom error message), it's excluded from processing
  * 2. If a single ArrayLikeOrSizedIterable is provided (Array, Set, Map, etc.), it's expanded into individual keys
  * 3. Otherwise, all arguments are treated as individual keys
- * 
+ *
  * This matches Chai behavior where `.keys([a, b, c])` checks for keys a, b, c,
  * while also supporting Sets, Maps, and other iterables as keys collections.
- * 
+ *
  * @example
  * ```typescript
  * // With array: _getArgKeysForDeep(scope, [[key1, key2]]) → [key1, key2]
@@ -208,20 +208,20 @@ export function allKeysFunc<R>(_scope: IAssertScope): KeysFn<R> {
  * Creates a KeysFn function that checks if any of the provided keys exist in the value using deep equality comparison.
  * This is used for deep key matching where keys are compared using deep equality instead of strict equality.
  * Particularly useful for Maps and Sets where object keys need to be compared by value rather than reference.
- * 
+ *
  * @param _scope - The assert scope.
  * @returns A KeysFn function that accepts keys as an Array, Set, Map, or other iterable, or a single key.
- * 
+ *
  * @remarks
  * The function performs deep equality comparison using {@link _deepEqual} which recursively compares
  * object properties, array elements, and handles special cases like Date, RegExp, Map, Set, etc.
- * 
+ *
  * Keys can be provided in multiple ways:
  * - Single key: `anyDeepKeysFunc(scope)({ id: 1 })`
  * - Array of keys: `anyDeepKeysFunc(scope)([{ id: 1 }, { id: 2 }])`
  * - Set of keys: `anyDeepKeysFunc(scope)(new Set([{ id: 1 }, { id: 2 }]))`
  * - Map of keys: `anyDeepKeysFunc(scope)(new Map([[{ id: 1 }, 'val']]))`  // Uses Map keys
- * 
+ *
  * @example
  * ```typescript
  * // With Map containing object keys
@@ -229,7 +229,7 @@ export function allKeysFunc<R>(_scope: IAssertScope): KeysFn<R> {
  * map.set({ id: 1 }, 'value1');
  * map.set({ id: 2 }, 'value2');
  * anyDeepKeysFunc(scope).call({ value: map }, [{ id: 1 }, { id: 3 }]);  // Passes - has { id: 1 }
- * 
+ *
  * // With regular object
  * const obj = { greeting: 'hello', subject: 'friend' };
  * anyDeepKeysFunc(scope).call({ value: obj }, ['greeting', 'unknown']);  // Passes - has 'greeting'
@@ -276,21 +276,21 @@ export function anyDeepKeysFunc<R>(_scope: IAssertScope): KeysFn<R> {
  * Creates a KeysFn function that checks if all of the provided keys exist in the value using deep equality comparison.
  * This is used for deep key matching where keys are compared using deep equality instead of strict equality.
  * Particularly useful for Maps and Sets where object keys need to be compared by value rather than reference.
- * 
+ *
  * @param _scope - The assert scope.
  * @returns A KeysFn function that accepts keys as an Array, Set, Map, or other iterable, or a single key.
- * 
+ *
  * @remarks
  * The function performs deep equality comparison using {@link _deepEqual} which recursively compares
  * object properties, array elements, and handles special cases like Date, RegExp, Map, Set, etc.
  * All provided keys must exist in the target for the assertion to pass.
- * 
+ *
  * Keys can be provided in multiple ways:
  * - Single key: `allDeepKeysFunc(scope)({ id: 1 })`
  * - Array of keys: `allDeepKeysFunc(scope)([{ id: 1 }, { id: 2 }])`
  * - Set of keys: `allDeepKeysFunc(scope)(new Set([{ id: 1 }, { id: 2 }]))`
  * - Map of keys: `allDeepKeysFunc(scope)(new Map([[{ id: 1 }, 'val']]))`  // Uses Map keys
- * 
+ *
  * @example
  * ```typescript
  * // With Map containing object keys
@@ -299,7 +299,7 @@ export function anyDeepKeysFunc<R>(_scope: IAssertScope): KeysFn<R> {
  * map.set({ id: 2 }, 'value2');
  * allDeepKeysFunc(scope).call({ value: map }, [{ id: 1 }, { id: 2 }]);  // Passes - has both
  * allDeepKeysFunc(scope).call({ value: map }, [{ id: 1 }, { id: 3 }]);  // Fails - missing { id: 3 }
- * 
+ *
  * // With Set containing object values
  * const set = new Set([{ id: 1 }, { id: 2 }]);
  * allDeepKeysFunc(scope).call({ value: set }, [{ id: 1 }, { id: 2 }]);  // Passes - has both

--- a/core/src/assert/interface/IAssertClass.ts
+++ b/core/src/assert/interface/IAssertClass.ts
@@ -1243,6 +1243,37 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
     notExists(value: any, initMsg?: MsgSource): AssertInst;
 
     /**
+     * Asserts that the target is falsy or throws the error if it is an Error instance.
+     * This is commonly used in Node.js-style callback error handling to check for errors.
+     *
+     * - If the value is falsy (null, undefined, false, 0, "", etc.), the assertion passes
+     * - If the value is an Error instance, that error is thrown
+     * - If the value is truthy but not an Error, an {@link AssertionFailure} is thrown
+     *
+     * @since 0.1.5
+     * @param value - The value to check.
+     * @param initMsg - The message to display if the assertion fails.
+     * @asserts That the `value` is falsy or throws the Error if it is an Error instance.
+     * @example
+     * ```typescript
+     * assert.ifError(null);          // Passes - null is falsy
+     * assert.ifError(undefined);     // Passes - undefined is falsy
+     * assert.ifError(false);         // Passes - false is falsy
+     * assert.ifError(0);             // Passes - 0 is falsy
+     * assert.ifError("");            // Passes - empty string is falsy
+     *
+     * // Throws the error itself
+     * assert.ifError(new Error("Something went wrong"));
+     *
+     * // Throws AssertionFailure
+     * assert.ifError(true);          // Truthy but not an Error
+     * assert.ifError("error");       // Truthy but not an Error
+     * assert.ifError(1);             // Truthy but not an Error
+     * ```
+     */
+    ifError(value: any, initMsg?: MsgSource): AssertInst;
+
+    /**
      * Asserts that the given value's type matches the expected type string.
      * Uses the JavaScript `typeof` operator for type comparison.
      *

--- a/core/src/assert/interface/ops/IToOp.ts
+++ b/core/src/assert/interface/ops/IToOp.ts
@@ -42,6 +42,26 @@ export interface IToOp<R> extends INotOp<IToOp<R>> {
     exist: AssertFn<R>;
 
     /**
+     * Asserts that the target is falsy or throws the error if it is an Error instance.
+     * This is commonly used in Node.js-style callback error handling.
+     *
+     * - If the value is falsy (null, undefined, false, 0, "", etc.), the assertion passes
+     * - If the value is an Error instance, that error is thrown
+     * - If the value is truthy but not an Error, an {@link AssertionFailure} is thrown
+     *
+     * @since 0.1.5
+     * @example
+     * ```typescript
+     * expect(null).to.ifError();          // Passes - null is falsy
+     * expect(undefined).to.ifError();     // Passes - undefined is falsy
+     * expect(false).to.ifError();         // Passes - false is falsy
+     * expect(new Error("fail")).to.ifError(); // Throws the Error itself
+     * expect(true).to.ifError();          // Throws AssertionFailure
+     * ```
+     */
+    ifError: AssertFn<R>;
+
+    /**
      * Provides access to operations that can be performed on the assertion scope,
      * based on the {@link IHasOp} interface.
      * @returns The operations that can be performed on the assertion scope.

--- a/core/src/assert/ops/keysOp.ts
+++ b/core/src/assert/ops/keysOp.ts
@@ -56,16 +56,16 @@ export function allKeyFilterOp<R>(scope: IAssertScope): IKeysOp<R> {
  * @param scope - The assert scope.
  * @returns The deep key filter operation that supports deep key matching.
  * @template R - The type of the key filter operation result.
- * 
+ *
  * @remarks
  * This operation creates a chainable `.keys()` method that accepts:
  * - Single keys
  * - Arrays of keys
  * - Sets, Maps, or other iterables containing keys
- * 
+ *
  * Deep equality is performed using {@link anyDeepKeysFunc} which recursively compares
  * object properties and handles special types.
- * 
+ *
  * @example
  * ```typescript
  * const map = new Map();
@@ -89,16 +89,16 @@ export function anyDeepKeyFilterOp<R>(scope: IAssertScope): IKeysOp<R> {
  * @template R - The type of the keys operation result.
  * @param scope - The assert scope.
  * @returns The deep keys operation that supports deep key matching.
- * 
+ *
  * @remarks
  * This operation creates a chainable `.keys()` method that accepts:
  * - Single keys
  * - Arrays of keys
  * - Sets, Maps, or other iterables containing keys
- * 
+ *
  * Deep equality is performed using {@link allDeepKeysFunc} which recursively compares
  * object properties and handles special types. All provided keys must exist for assertion to pass.
- * 
+ *
  * @example
  * ```typescript
  * const map = new Map();
@@ -124,22 +124,22 @@ export function allDeepKeyFilterOp<R>(scope: IAssertScope): IKeysOp<R> {
  *
  * @param scope - The assert scope.
  * @returns A IKeysOp operation configured for either any or all matching based on context.
- * 
+ *
  * @remarks
  * The operation checks the assertion context to determine behavior:
  * - If `ANY` context flag is set → uses {@link anyDeepKeyFilterOp} (at least one key must match)
  * - Otherwise → uses {@link allDeepKeyFilterOp} (all keys must match)
- * 
+ *
  * This allows natural assertion syntax like:
  * - `expect(map).to.have.deep.keys([...])` → defaults to "all"
  * - `expect(map).to.have.any.deep.keys([...])` → uses "any"
- * 
+ *
  * @example
  * ```typescript
  * // Without explicit any/all - defaults to "all"
  * const map = new Map([[{ id: 1 }, 'val1'], [{ id: 2 }, 'val2']]);
  * expect(map).to.have.deep.keys([{ id: 1 }, { id: 2 }]);  // Uses allDeepKeyFilterOp
- * 
+ *
  * // With explicit any - uses anyDeepKeyFilterOp
  * expect(map).to.have.any.deep.keys([{ id: 1 }, { id: 99 }]);  // Passes
  * ```

--- a/core/src/assert/ops/toOp.ts
+++ b/core/src/assert/ops/toOp.ts
@@ -18,6 +18,7 @@ import { includeOp } from "./includeOp";
 import { strictlyOp } from "./strictlyOp";
 import { deepOp } from "./deepOp";
 import { existsFunc } from "../funcs/exists";
+import { ifErrorFunc } from "../funcs/ifError";
 import { changesFunc, increasesFunc, decreasesFunc } from "../funcs/changes";
 import { changesByFunc, increasesByFunc, decreasesByFunc, changesButNotByFunc, increasesButNotByFunc, decreasesButNotByFunc } from "../funcs/changesBy";
 
@@ -36,6 +37,7 @@ export function toOp<R>(scope: IAssertScope): IToOp<R> {
         match: { scopeFn: matchFunc },
         throw: { scopeFn: throwsFunc },
         exist: { scopeFn: existsFunc },
+        ifError: { scopeFn: ifErrorFunc },
         change: { scopeFn: changesFunc },
         changes: { scopeFn: changesFunc },
         changeBy: { scopeFn: changesByFunc },

--- a/core/test/src/assert/assert.ifError.test.ts
+++ b/core/test/src/assert/assert.ifError.test.ts
@@ -1,0 +1,299 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2026 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { assert } from "../../../src/assert/assertClass";
+import { expect } from "../../../src/assert/expect";
+import { checkError } from "../support/checkError";
+
+describe("assert.ifError", () => {
+    describe("basic functionality - falsy values should pass", () => {
+        it("should pass for null", () => {
+            assert.ifError(null);
+        });
+
+        it("should pass for undefined", () => {
+            assert.ifError(undefined);
+        });
+
+        it("should pass for false", () => {
+            assert.ifError(false);
+        });
+
+        it("should pass for 0", () => {
+            assert.ifError(0);
+        });
+
+        it("should pass for empty string", () => {
+            assert.ifError("");
+        });
+
+        it("should pass for NaN", () => {
+            assert.ifError(NaN);
+        });
+    });
+
+    describe("Error instances should be thrown", () => {
+        it("should throw Error instance", () => {
+            let err = new Error("This is an error message");
+            try {
+                assert.ifError(err);
+                throw new Error("Should have thrown the error");
+            } catch (e: any) {
+                if (e.message !== "This is an error message") {
+                    throw new Error("Expected the original error to be thrown, got: " + e.message);
+                }
+            }
+        });
+
+        it("should throw TypeError instance", () => {
+            let err = new TypeError("Type error occurred");
+            try {
+                assert.ifError(err);
+                throw new Error("Should have thrown the error");
+            } catch (e: any) {
+                if (e.message !== "Type error occurred") {
+                    throw new Error("Expected the TypeError to be thrown, got: " + e.message);
+                }
+            }
+        });
+
+        it("should throw RangeError instance", () => {
+            let err = new RangeError("Range error occurred");
+            try {
+                assert.ifError(err);
+                throw new Error("Should have thrown the error");
+            } catch (e: any) {
+                if (e.message !== "Range error occurred") {
+                    throw new Error("Expected the RangeError to be thrown, got: " + e.message);
+                }
+            }
+        });
+
+        it("should throw custom Error subclass", () => {
+            class CustomError extends Error {
+                constructor(message: string) {
+                    super(message);
+                    this.name = "CustomError";
+                }
+            }
+
+            let err = new CustomError("Custom error occurred");
+            try {
+                assert.ifError(err);
+                throw new Error("Should have thrown the error");
+            } catch (e: any) {
+                if (e.message !== "Custom error occurred") {
+                    throw new Error("Expected the CustomError to be thrown, got: " + e.message);
+                }
+                if (e.name !== "CustomError") {
+                    throw new Error("Expected CustomError type, got: " + e.name);
+                }
+            }
+        });
+    });
+
+    describe("truthy non-Error values should fail", () => {
+        it("should fail for true", () => {
+            checkError(() => assert.ifError(true), "expected true to be falsy or an Error");
+        });
+
+        it("should fail for non-zero number", () => {
+            checkError(() => assert.ifError(1), "expected 1 to be falsy or an Error");
+            checkError(() => assert.ifError(-1), "expected -1 to be falsy or an Error");
+            checkError(() => assert.ifError(123), "expected 123 to be falsy or an Error");
+        });
+
+        it("should fail for non-empty string", () => {
+            checkError(() => assert.ifError("error"), "expected \"error\" to be falsy or an Error");
+            checkError(() => assert.ifError("hello"), "expected \"hello\" to be falsy or an Error");
+        });
+
+        it("should fail for objects", () => {
+            checkError(() => assert.ifError({}), "expected {} to be falsy or an Error");
+            checkError(() => assert.ifError({ a: 1 }), "to be falsy or an Error");
+        });
+
+        it("should fail for arrays", () => {
+            checkError(() => assert.ifError([]), "expected [] to be falsy or an Error");
+            checkError(() => assert.ifError([1, 2, 3]), "expected [1,2,3] to be falsy or an Error");
+        });
+
+        it("should fail for functions", () => {
+            checkError(() => assert.ifError(() => {}), "to be falsy or an Error");
+        });
+
+        it("should fail for Date", () => {
+            let date = new Date("2020-01-01");
+            checkError(() => assert.ifError(date), "to be falsy or an Error");
+        });
+
+        it("should fail for RegExp", () => {
+            checkError(() => assert.ifError(/test/), "expected /test/ to be falsy or an Error");
+        });
+
+        it("should fail for Symbol", () => {
+            let sym = Symbol("test");
+            checkError(() => assert.ifError(sym), "to be falsy or an Error");
+        });
+
+        it("should fail for Map", () => {
+            checkError(() => assert.ifError(new Map()), "to be falsy or an Error");
+        });
+
+        it("should fail for Set", () => {
+            checkError(() => assert.ifError(new Set()), "to be falsy or an Error");
+        });
+    });
+
+    describe("custom messages", () => {
+        it("should use custom message for truthy non-Error values", () => {
+            checkError(() => assert.ifError(true, "Custom error message"), "Custom error message");
+        });
+
+        it("should use custom message with other truthy values", () => {
+            checkError(() => assert.ifError("value", "Value should be falsy"), "Value should be falsy");
+            checkError(() => assert.ifError(123, "Number should be falsy"), "Number should be falsy");
+        });
+
+        // Note: custom message is NOT used when throwing an Error instance
+        // The Error instance itself is thrown, not an AssertionFailure
+    });
+
+    describe("edge cases", () => {
+        it("should handle Error with empty message", () => {
+            let err = new Error("");
+            try {
+                assert.ifError(err);
+                throw new Error("Should have thrown the error");
+            } catch (e: any) {
+                if (e.message !== "") {
+                    throw new Error("Expected empty error message, got: " + e.message);
+                }
+            }
+        });
+
+        it("should handle Error-like objects that are not Error instances", () => {
+            // Objects that look like errors but aren't Error instances should fail
+            let fakeError = {
+                message: "I look like an error",
+                name: "FakeError",
+                stack: "fake stack"
+            };
+            checkError(() => assert.ifError(fakeError), "to be falsy or an Error");
+        });
+
+        it("should handle Infinity", () => {
+            checkError(() => assert.ifError(Infinity), "expected Infinity to be falsy or an Error");
+            checkError(() => assert.ifError(-Infinity), "expected -Infinity to be falsy or an Error");
+        });
+
+        it("should handle BigInt values", () => {
+            // BigInt(0) is falsy, so it should pass
+            assert.ifError(BigInt(0));
+            // BigInt(1) is truthy, so it should fail
+            checkError(() => assert.ifError(BigInt(1)), "to be falsy or an Error");
+        });
+    });
+
+    describe("expect syntax", () => {
+        it("should pass for falsy values using expect", () => {
+            expect(null).to.ifError();
+            expect(undefined).to.ifError();
+            expect(false).to.ifError();
+            expect(0).to.ifError();
+            expect("").to.ifError();
+            expect(NaN).to.ifError();
+        });
+
+        it("should throw Error instance when using expect", () => {
+            let err = new Error("Test error");
+            try {
+                expect(err).to.ifError();
+                throw new Error("Should have thrown the error");
+            } catch (e: any) {
+                if (e.message !== "Test error") {
+                    throw new Error("Expected the original error to be thrown, got: " + e.message);
+                }
+            }
+        });
+
+        it("should fail for truthy non-Error values using expect", () => {
+            checkError(() => expect(true).to.ifError(), "to be falsy or an Error");
+            checkError(() => expect(1).to.ifError(), "to be falsy or an Error");
+            checkError(() => expect("error").to.ifError(), "to be falsy or an Error");
+        });
+    });
+
+    describe("typical use cases", () => {
+        it("should work in Node.js-style callback pattern", () => {
+            function someAsyncOperation(callback: (err: Error | null, result?: string) => void) {
+                // Simulate success
+                callback(null, "success");
+            }
+
+            someAsyncOperation((err, result) => {
+                assert.ifError(err); // Should pass
+                if (result !== "success") {
+                    throw new Error("Expected success");
+                }
+            });
+        });
+
+        it("should throw in Node.js-style callback with error", () => {
+            function someAsyncOperation(callback: (err: Error | null, result?: string) => void) {
+                // Simulate error
+                callback(new Error("Operation failed"));
+            }
+
+            someAsyncOperation((err, result) => {
+                try {
+                    assert.ifError(err);
+                    throw new Error("Should have thrown the error");
+                } catch (e: any) {
+                    if (e.message !== "Operation failed") {
+                        throw new Error("Expected operation error, got: " + e.message);
+                    }
+                }
+            });
+        });
+
+        it("should work with try-catch error handling", () => {
+            let err: Error | null = null;
+            
+            try {
+                // Some operation that might throw
+                throw new Error("Something went wrong");
+            } catch (e: any) {
+                err = e;
+            }
+            
+            try {
+                assert.ifError(err);
+                throw new Error("Should have thrown the error");
+            } catch (e: any) {
+                if (e.message !== "Something went wrong") {
+                    throw new Error("Expected the caught error to be thrown, got: " + e.message);
+                }
+            }
+        });
+
+        it("should work when no error occurs", () => {
+            let err: Error | null = null;
+            
+            try {
+                // Some operation that doesn't throw
+                let x = 1 + 1;
+            } catch (e: any) {
+                err = e;
+            }
+            
+            // Should pass since err is null
+            assert.ifError(err);
+        });
+    });
+});

--- a/shim/chai/README.md
+++ b/shim/chai/README.md
@@ -64,13 +64,13 @@ Error messages differ from Chai. Use regex instead of exact strings:
 
 - **Basic**: `equal`, `notEqual`, `strictEqual`, `deepEqual`, `isOk`, `isTrue`, etc.
 - **Types**: `isObject`, `isArray`, `isString`, `isNumber`, `isBoolean`, `isFunction`, `isNull`, `isUndefined`, `isNaN`, `isFinite`, etc.
-- **Comparisons**: `isAbove`, `isAtLeast`, `isBelow`, `isAtMost`, `closeTo`, `approximately`
+- **Comparisons**: `isAbove`, `isAtLeast`, `isBelow`, `isAtMost`, `closeTo`, `approximately`, `operator`
 - **Properties**: `property`, `deepProperty`, `nestedProperty`, `ownProperty` with value validation
 - **Collections**: `include`, `deepInclude`, `members`, `sameMembers`, `keys`
 - **Deep Keys**: `hasAnyDeepKeys`, `hasAllDeepKeys`, `containsAllDeepKeys`, `doesNotHaveAnyDeepKeys`, `doesNotHaveAllDeepKeys` for Maps/Sets with object keys
 - **Size**: `lengthOf`, `sizeOf`
 - **Changes**: `changes`, `increases`, `decreases` with delta tracking
-- **Errors**: `throws`, `doesNotThrow`
+- **Errors**: `throws`, `doesNotThrow`, `ifError`
 - **State**: `isExtensible`, `isSealed`, `isFrozen`, `isEmpty`
 
 ### NOT Implemented

--- a/shim/chai/src/assert/chaiAssert.ts
+++ b/shim/chai/src/assert/chaiAssert.ts
@@ -180,7 +180,7 @@ function _createChaiAssert(): IChaiAssert {
         doesNotDecreaseBy: { scopeFn: createExprAdapter("not.decreaseBy"), nArgs: 4 },
         decreasesButNotBy: { scopeFn: createExprAdapter("decreasesButNotBy"), nArgs: 4 },
 
-        ifError: notImplemented,
+        ifError: { scopeFn: createExprAdapter("to.ifError"), nArgs: 1 },
         isExtensible: "is.extensible",
         extensible: "is.extensible",
         isNotExtensible: "is.not.extensible",

--- a/shim/chai/test/src/chaiAssert.test.ts
+++ b/shim/chai/test/src/chaiAssert.test.ts
@@ -1864,16 +1864,16 @@ describe("assert", function () {
         }, "blah: expected {} to be a function");
     });
 
-    // it("ifError", function() {
-    //     assert.ifError(false);
-    //     assert.ifError(null);
-    //     assert.ifError(undefined);
+    it("ifError", function() {
+        assert.ifError(false);
+        assert.ifError(null);
+        assert.ifError(undefined);
 
-    //     err(function () {
-    //         var err = new Error("This is an error message");
-    //         assert.ifError(err);
-    //     }, "This is an error message");
-    // });
+        err(function () {
+            var err = new Error("This is an error message");
+            assert.ifError(err);
+        }, "This is an error message");
+    });
 
     it("operator", function() {
     // For testing undefined and null with == and ===


### PR DESCRIPTION
Add assert.ifError() and expect().to.ifError() assertions for Node.js-style callback error checking. Passes for falsy values, throws Error instances, and fails for truthy non-Error values.

Includes comprehensive tests (35 cases), chai shim integration, and full documentation updates.