### PR TITLE
perf(core): add lazy initialization for assert class functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The documentation site includes:
 - Feature highlights and comparison tables
 - Migration guides (e.g., from Chai.js)
 - Detailed guides for specific features (like change/increase/decrease assertions)
+- [Expression Adapter Guide](https://nevware21.github.io/tripwire/expression-adapter.html) - Creating custom assertions using expressions
 - Links to full TypeDoc API reference for each module
 
 **API Reference (TypeDoc)**:

--- a/core/src/assert/interface/IAssertClass.ts
+++ b/core/src/assert/interface/IAssertClass.ts
@@ -73,7 +73,7 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * @example
      * ```typescript
      * assert.fail(); // Throws AssertionFailure
-     * assert.fail("Hello Darkness, my old friend"); // Throws AssertionFailure
+     * assert.fail("Hello silence, my quiet friend"); // Throws AssertionFailure
      * assert.fail(() => "Looks like we have failed again"); // Throws AssertionFailure
      * ```
      */
@@ -103,7 +103,7 @@ export interface IAssertClass<AssertInst extends IAssertInst = IAssertInst> {
      * @example
      * ```typescript
      * assert.fatal(); // Throws AssertionFatal
-     * assert.fatal("Hello Darkness, my old friend"); // Throws AssertionFatal
+     * assert.fatal("Hello silence, my quiet friend"); // Throws AssertionFatal
      * assert.fatal(() => "Looks like we have failed again"); // Throws AssertionFatal
      * ```
      */

--- a/core/src/assert/interface/IAssertClassDef.ts
+++ b/core/src/assert/interface/IAssertClassDef.ts
@@ -24,6 +24,44 @@ export interface IAssertClassDef {
     alias?: string;
 
     /**
+     * Identifies the expression or path that is to be evaluated to obtain the value
+     * that is to be asserted against. This expression is evaluated against the
+     * current scope value (`this.context.value`) when the assertion is evaluated.
+     * This expression can either be a `string` using dot notation to identify
+     * the path to be evaluated or an array of `string`s where each entry in the
+     * array identifies a step in the path to be evaluated.
+     * For example:
+     * - `"myProperty.nestedProperty[0].value"` or
+     * - `["myProperty", "nestedProperty", "{0}", "value"]`
+     *
+     * When using an array of `string`s each entry in the array is treated as a
+     * step in the evaluation path, this enables more complex paths to be defined
+     * where property names may contain characters that would otherwise be
+     * interpreted as part of the path syntax, for example a property name
+     * that contains a dot (`.`) character.
+     * In addition, when using an array of `string`s, it enables the use
+     * of "dynamic" property names or indexes to be used via the use of the
+     * `{}` syntax. This syntax enables either a named value or an index
+     * to be specified which will be resolved against the current scope
+     * context's named values or the arguments that were passed to the
+     * assertion function.
+     * - Named values are resolved against the current scope context's
+     *   named values collection (`this.context.namedValues`).
+     * - Indexed values are resolved against the arguments that were
+     *  passed to the assertion function, where `{0}` identifies the
+     *  first argument, `{1}` the second argument and so on.
+     */
+    expr?: string | string[];
+
+    /**
+     * Indicates that the evaluation should be negated (i.e. NOT). This is equivalent to
+     * wrapping the evaluation within a logical NOT operation.
+     * For example if the evaluation would normally return `true` it would
+     * instead return `false` and vice versa.
+     */
+    not?: boolean;
+
+    /**
      * Identifies an {@link IScopeFn} function that will be called, this function
      * expects the current scope as the `this` value and any additional arguments
      * that are passed to the function. The function should return the current instance

--- a/core/src/assert/interface/IAssertInst.ts
+++ b/core/src/assert/interface/IAssertInst.ts
@@ -144,11 +144,11 @@ export interface IAssertInst extends INotOp<IAssertInst>, IAssertInstCore, IEqua
      * import { assert } from "@nevware21/tripwire";
      *
      * const arr = [1, 2, 3];
-     * const str = "hello darkness welcome back again";
+     * const str = "hello silence welcome back again";
      * const obj = { a: 1, b: 2, c: 3 };
      *
      * assert(arr).include(2); // Passes
-     * assert(str).include("darkness"); // Passes
+     * assert(str).include("silence"); // Passes
      * assert(obj).include.all.keys('a', 'b'); // Passes
      * assert(arr).include(4); // Fails
      * assert(str).include("planet"); // Fails
@@ -170,11 +170,11 @@ export interface IAssertInst extends INotOp<IAssertInst>, IAssertInstCore, IEqua
      * import { assert } from "@nevware21/tripwire";
      *
      * const arr = [1, 2, 3];
-     * const str = "hello darkness welcome back again";
+     * const str = "hello silence welcome back again";
      * const obj = { a: 1, b: 2, c: 3 };
      *
      * assert(arr).includes(2); // Passes
-     * assert(str).includes("darkness"); // Passes
+     * assert(str).includes("silence"); // Passes
      * assert(obj).includes.all.keys('a', 'b'); // Passes
      * assert(arr).includes(4); // Fails
      * assert(str).includes("planet"); // Fails
@@ -195,11 +195,11 @@ export interface IAssertInst extends INotOp<IAssertInst>, IAssertInstCore, IEqua
      * import { assert } from "@nevware21/tripwire";
      *
      * const arr = [1, 2, 3];
-     * const str = "hello darkness welcome back again";
+     * const str = "hello silence welcome back again";
      * const obj = { a: 1, b: 2, c: 3 };
      *
      * assert(arr).contain(2); // Passes
-     * assert(str).contain("darkness"); // Passes
+     * assert(str).contain("silence"); // Passes
      * assert(obj).contain.all.keys('a', 'b'); // Passes
      * assert(arr).contain(4); // Fails
      * assert(str).contain("planet"); // Fails
@@ -220,11 +220,11 @@ export interface IAssertInst extends INotOp<IAssertInst>, IAssertInstCore, IEqua
      * import { assert } from "@nevware21/tripwire";
      *
      * const arr = [1, 2, 3];
-     * const str = "hello darkness welcome back again";
+     * const str = "hello silence welcome back again";
      * const obj = { a: 1, b: 2, c: 3 };
      *
      * assert(arr).contains(2); // Passes
-     * assert(str).contains("darkness"); // Passes
+     * assert(str).contains("silence"); // Passes
      * assert(obj).contains.all.keys('a', 'b'); // Passes
      * assert(arr).contains(4); // Fails
      * assert(str).contains("planet"); // Fails

--- a/core/src/assert/interface/ops/IToOp.ts
+++ b/core/src/assert/interface/ops/IToOp.ts
@@ -101,11 +101,11 @@ export interface IToOp<R> extends INotOp<IToOp<R>> {
      * import { assert } from "@nevware21/tripwire";
      *
      * const arr = [1, 2, 3];
-     * const str = "hello darkness welcome back again";
+     * const str = "hello silence welcome back again";
      * const obj = { a: 1, b: 2, c: 3 };
      *
      * assert(arr).include(2); // Passes
-     * assert(str).include("darkness"); // Passes
+     * assert(str).include("silence"); // Passes
      * assert(obj).include.all.keys('a', 'b'); // Passes
      * assert(arr).include(4); // Fails
      * assert(str).include("planet"); // Fails
@@ -127,11 +127,11 @@ export interface IToOp<R> extends INotOp<IToOp<R>> {
      * import { assert } from "@nevware21/tripwire";
      *
      * const arr = [1, 2, 3];
-     * const str = "hello darkness welcome back again";
+     * const str = "hello silence welcome back again";
      * const obj = { a: 1, b: 2, c: 3 };
      *
      * assert(arr).includes(2); // Passes
-     * assert(str).includes("darkness"); // Passes
+     * assert(str).includes("silence"); // Passes
      * assert(obj).includes.all.keys('a', 'b'); // Passes
      * assert(arr).includes(4); // Fails
      * assert(str).includes("planet"); // Fails
@@ -152,11 +152,11 @@ export interface IToOp<R> extends INotOp<IToOp<R>> {
      * import { assert } from "@nevware21/tripwire";
      *
      * const arr = [1, 2, 3];
-     * const str = "hello darkness welcome back again";
+     * const str = "hello silence welcome back again";
      * const obj = { a: 1, b: 2, c: 3 };
      *
      * assert(arr).contain(2); // Passes
-     * assert(str).contain("darkness"); // Passes
+     * assert(str).contain("silence"); // Passes
      * assert(obj).contain.all.keys('a', 'b'); // Passes
      * assert(arr).contain(4); // Fails
      * assert(str).contain("planet"); // Fails
@@ -177,11 +177,11 @@ export interface IToOp<R> extends INotOp<IToOp<R>> {
      * import { assert } from "@nevware21/tripwire";
      *
      * const arr = [1, 2, 3];
-     * const str = "hello darkness welcome back again";
+     * const str = "hello silence welcome back again";
      * const obj = { a: 1, b: 2, c: 3 };
      *
      * assert(arr).contains(2); // Passes
-     * assert(str).contains("darkness"); // Passes
+     * assert(str).contains("silence"); // Passes
      * assert(obj).contains.all.keys('a', 'b'); // Passes
      * assert(arr).contains(4); // Fails
      * assert(str).contains("planet"); // Fails

--- a/core/test/src/assert/adapters/exprAdapter.test.ts
+++ b/core/test/src/assert/adapters/exprAdapter.test.ts
@@ -13,6 +13,10 @@ import { createAssertScope } from "../../../../src/assert/assertScope";
 import { checkError } from "../../support/checkError";
 import { IAssertScope } from "../../../../src/assert/interface/IAssertScope";
 import { assertConfig } from "../../../../src/assert/config";
+import { addAssertInstFunc, addAssertInstFuncDefs, addAssertInstProperty } from "../../../../src/assert/assertInst";
+import { _clearAssertInstFuncs } from "../../../../src/assert/internal/_AssertInstCore";
+import { expect } from "../../../../src/assert/expect";
+import { isArray } from "@nevware21/ts-utils";
 
 describe("createExprAdapter", () => {
     let originalIsVerbose: boolean | undefined;
@@ -421,5 +425,933 @@ describe("createExprAdapter", () => {
             assert.equal(callCount, 3, "Third invocation should call scope function once");
         });
     });
-});
 
+    describe("expression syntax", () => {
+        beforeEach(() => {
+            assertConfig.isVerbose = false;
+        });
+
+        describe("string expressions", () => {
+            it("should parse simple single-step expressions", () => {
+                let context = createContext(10);
+                let scope = createAssertScope(context);
+                let adapter = createExprAdapter("not");
+
+                let result = adapter.call(scope);
+                assert.ok(result, "Single-step expression should work");
+            });
+
+            it("should parse multi-step dot-separated expressions", () => {
+                let context = createContext(true);
+                let scope = createAssertScope(context);
+                let adapter = createExprAdapter("to.be");
+
+                let result = adapter.call(scope);
+                assert.ok(result, "Multi-step expression should work");
+            });
+
+            it("should parse complex chained expressions", () => {
+                let context = createContext([1, 2, 3]);
+                let scope = createAssertScope(context);
+                let adapter = createExprAdapter("to.be.not");
+
+                let result = adapter.call(scope);
+                assert.ok(result, "Complex expression chain should work");
+            });
+        });
+
+        describe("array expressions", () => {
+            it("should accept array syntax equivalent to dot notation", () => {
+                let context = createContext(10);
+                let scope = createAssertScope(context);
+
+                let adapter1 = createExprAdapter("to.be.not");
+                let adapter2 = createExprAdapter(["to", "be", "not"]);
+
+                let result1 = adapter1.call(scope);
+                
+                let context2 = createContext(10);
+                let scope2 = createAssertScope(context2);
+                let result2 = adapter2.call(scope2);
+
+                assert.ok(result1, "String syntax should work");
+                assert.ok(result2, "Array syntax should work");
+            });
+
+            it("should handle single element arrays", () => {
+                let context = createContext(10);
+                let scope = createAssertScope(context);
+                let adapter = createExprAdapter(["not"]);
+
+                let result = adapter.call(scope);
+                assert.ok(result, "Single element array should work");
+            });
+
+            it("should handle complex array expressions", () => {
+                let adapter = createExprAdapter(["deep", "own", "include"]);
+
+                // Just test that it parses and executes without error
+                // The actual assertion is handled by the operations
+                assert.ok(adapter, "Complex array expression should be created");
+            });
+        });
+    });
+
+    describe("invalid expression handling", () => {
+        beforeEach(() => {
+            assertConfig.isVerbose = false;
+        });
+
+        it("should throw on mismatched parentheses - missing close", () => {
+            checkError(() => {
+                createExprAdapter("func(arg");
+            }, /Invalid expression/);
+        });
+
+        it("should throw on nested parentheses in arguments", () => {
+            checkError(() => {
+                createExprAdapter("func({nested{arg}})");
+            }, /Invalid expression/);
+        });
+
+        it("should throw on multiple parentheses sections", () => {
+            checkError(() => {
+                createExprAdapter("func(arg)(arg2)");
+            }, /Invalid expression/);
+        });
+
+        it("should throw on spaces in arguments without braces", () => {
+            checkError(() => {
+                createExprAdapter("func(arg with space)");
+            }, /Invalid expression/);
+        });
+
+        it("should throw when step does not exist on assertion instance", () => {
+            let context = createContext(10);
+            let scope = createAssertScope(context);
+            let adapter = createExprAdapter("nonexistent.step");
+
+            checkError(() => {
+                adapter.call(scope);
+            }, /Invalid step.*nonexistent/);
+        });
+    });
+
+    describe("built-in expression patterns", () => {
+        beforeEach(() => {
+            assertConfig.isVerbose = false;
+        });
+
+        describe("type checking expressions", () => {
+            it("should work with is.string expression", () => {
+                let adapter = createExprAdapter("is.string");
+
+                let context1 = createContext("hello");
+                let scope1 = createAssertScope(context1);
+                adapter.call(scope1);
+
+                let context2 = createContext(123);
+                let scope2 = createAssertScope(context2);
+                checkError(() => {
+                    adapter.call(scope2);
+                }, /string/);
+            });
+
+            it("should work with is.array expression", () => {
+                let adapter = createExprAdapter("is.array");
+
+                let context1 = createContext([1, 2, 3]);
+                let scope1 = createAssertScope(context1);
+                adapter.call(scope1);
+
+                let context2 = createContext("not an array");
+                let scope2 = createAssertScope(context2);
+                checkError(() => {
+                    adapter.call(scope2);
+                }, /array/);
+            });
+
+            it("should work with is.nan expression", () => {
+                let adapter = createExprAdapter("is.nan");
+
+                let context1 = createContext(NaN);
+                let scope1 = createAssertScope(context1);
+                adapter.call(scope1);
+
+                let context2 = createContext(123);
+                let scope2 = createAssertScope(context2);
+                checkError(() => {
+                    adapter.call(scope2);
+                }, /NaN/);
+            });
+
+            it("should work with is.finite expression", () => {
+                let adapter = createExprAdapter("is.finite");
+
+                let context1 = createContext(100);
+                let scope1 = createAssertScope(context1);
+                adapter.call(scope1);
+
+                let context2 = createContext(Infinity);
+                let scope2 = createAssertScope(context2);
+                checkError(() => {
+                    adapter.call(scope2);
+                }, /finite/);
+            });
+        });
+
+        describe("negation expressions", () => {
+            it("should work with not.is.string expression", () => {
+                let adapter = createExprAdapter("not.is.string");
+
+                let context1 = createContext(123);
+                let scope1 = createAssertScope(context1);
+                adapter.call(scope1);
+
+                let context2 = createContext("hello");
+                let scope2 = createAssertScope(context2);
+                checkError(() => {
+                    adapter.call(scope2);
+                }, /not/);
+            });
+
+            it("should work with not.is.array expression", () => {
+                let adapter = createExprAdapter("not.is.array");
+
+                let context1 = createContext("not array");
+                let scope1 = createAssertScope(context1);
+                adapter.call(scope1);
+
+                let context2 = createContext([1, 2, 3]);
+                let scope2 = createAssertScope(context2);
+                checkError(() => {
+                    adapter.call(scope2);
+                }, /not/);
+            });
+
+            it("should work with not.to.exist expression", () => {
+                let adapter = createExprAdapter("not.to.exist");
+
+                let context1 = createContext(null);
+                let scope1 = createAssertScope(context1);
+                adapter.call(scope1);
+
+                let context2 = createContext("exists");
+                let scope2 = createAssertScope(context2);
+                checkError(() => {
+                    adapter.call(scope2);
+                }, /not/);
+            });
+        });
+
+        describe("existence expressions", () => {
+            it("should work with to.exist expression", () => {
+                let adapter = createExprAdapter("to.exist");
+
+                let context1 = createContext("value");
+                let scope1 = createAssertScope(context1);
+                adapter.call(scope1);
+
+                let context2 = createContext(null);
+                let scope2 = createAssertScope(context2);
+                checkError(() => {
+                    adapter.call(scope2);
+                }, /exist/);
+            });
+        });
+    });
+
+    describe("modifier combinations", () => {
+        beforeEach(() => {
+            assertConfig.isVerbose = false;
+        });
+
+        it("should work with deep modifier setting up deep comparison", () => {
+            // Test that the deep modifier is applied correctly
+            // We use a scope function to verify the deep flag is set
+            let deepFlagSet = false;
+            let scopeFn = function<R>(this: IAssertScope): R {
+                deepFlagSet = this.context.get("$deep") === true;
+                return this.that;
+            };
+
+            let adapter = createExprAdapter("deep", scopeFn);
+            let context = createContext({ a: { b: 1 } });
+            let scope = createAssertScope(context);
+            adapter.call(scope);
+            
+            assert.isTrue(deepFlagSet, "Deep flag should be set after deep expression");
+        });
+
+        it("should work with own modifier setting up own property checking", () => {
+            // Test that the own modifier is applied correctly
+            let ownFlagSet = false;
+            let scopeFn = function<R>(this: IAssertScope): R {
+                ownFlagSet = this.context.get("$own") === true;
+                return this.that;
+            };
+
+            let adapter = createExprAdapter("own", scopeFn);
+            let context = createContext({ a: 1, b: 2 });
+            let scope = createAssertScope(context);
+            adapter.call(scope);
+            
+            assert.isTrue(ownFlagSet, "Own flag should be set after own expression");
+        });
+
+        it("should work with combined modifiers setting multiple flags", () => {
+            // Test that combined modifiers set multiple flags
+            let deepFlagSet = false;
+            let ownFlagSet = false;
+            let scopeFn = function<R>(this: IAssertScope): R {
+                deepFlagSet = this.context.get("$deep") === true;
+                ownFlagSet = this.context.get("$own") === true;
+                return this.that;
+            };
+
+            let adapter = createExprAdapter("deep.own", scopeFn);
+            let context = createContext({ a: { b: 1 } });
+            let scope = createAssertScope(context);
+            adapter.call(scope);
+            
+            assert.isTrue(deepFlagSet, "Deep flag should be set after deep.own expression");
+            assert.isTrue(ownFlagSet, "Own flag should be set after deep.own expression");
+        });
+
+        it("should work with has.any modifier setting any flag", () => {
+            // Test that has.any sets the $any flag
+            let anyFlagSet = false;
+            let scopeFn = function<R>(this: IAssertScope): R {
+                anyFlagSet = this.context.get("$any") === true;
+                return this.that;
+            };
+
+            let adapter = createExprAdapter("has.any", scopeFn);
+            let context = createContext({ a: 1, b: 2 });
+            let scope = createAssertScope(context);
+            adapter.call(scope);
+            
+            assert.isTrue(anyFlagSet, "Any flag should be set after has.any expression");
+        });
+
+        it("should work with has.all modifier setting all flag", () => {
+            // Test that has.all sets the $all flag
+            let allFlagSet = false;
+            let scopeFn = function<R>(this: IAssertScope): R {
+                allFlagSet = this.context.get("$all") === true;
+                return this.that;
+            };
+
+            let adapter = createExprAdapter("has.all", scopeFn);
+            let context = createContext({ a: 1, b: 2 });
+            let scope = createAssertScope(context);
+            adapter.call(scope);
+            
+            assert.isTrue(allFlagSet, "All flag should be set after has.all expression");
+        });
+
+        it("should work with not.deep.own expression setting negation and flags", () => {
+            // Test combined negation and modifiers
+            let adapter = createExprAdapter("not.deep.own.include");
+            
+            // This should work: checking that {} does NOT deeply include something
+            let context = createContext({});
+            let scope = createAssertScope(context);
+            let result = adapter.call(scope);
+            assert.ok(result, "Negated combined modifier expression should work");
+        });
+    });
+
+    describe("custom assertion patterns from documentation", () => {
+        beforeEach(() => {
+            assertConfig.isVerbose = false;
+        });
+
+        it("should support creating custom assertions with scope functions", () => {
+            let isPositiveFunc = function<R>(this: IAssertScope): R {
+                let value = this.context.value;
+                this.context.eval(
+                    typeof value === "number" && value > 0,
+                    "expected {value} to be a positive number"
+                );
+                return this.that;
+            };
+
+            let adapter = createExprAdapter("not", isPositiveFunc);
+
+            // Should pass - not positive (negative)
+            let context1 = createContext(-5);
+            let scope1 = createAssertScope(context1);
+            adapter.call(scope1);
+
+            // Should fail - is positive
+            let context2 = createContext(10);
+            let scope2 = createAssertScope(context2);
+            checkError(() => {
+                adapter.call(scope2);
+            }, /not/);
+        });
+
+        it("should support string length validation pattern", () => {
+            let hasMinLengthFunc = function<R>(this: IAssertScope, minLength: number): R {
+                let value = this.context.value;
+                this.context.eval(
+                    typeof value === "string" && value.length >= minLength,
+                    "expected {value} to have at least " + minLength + " characters"
+                );
+                return this.that;
+            };
+
+            let notHasMinLengthAdapter = createExprAdapter("not", hasMinLengthFunc);
+
+            // Should pass - "hi" does NOT have min length 5
+            let context1 = createContext("hi");
+            let scope1 = createAssertScope(context1);
+            notHasMinLengthAdapter.call(scope1, 5);
+
+            // Should fail - "hello" DOES have min length 3
+            let context2 = createContext("hello");
+            let scope2 = createAssertScope(context2);
+            checkError(() => {
+                notHasMinLengthAdapter.call(scope2, 3);
+            }, /not/);
+        });
+
+        it("should support range validation pattern", () => {
+            let checkRangeFunc = function<R>(this: IAssertScope, min: number, max: number): R {
+                let value = this.context.value;
+                this.context.eval(
+                    typeof value === "number" && value >= min && value <= max,
+                    "expected {value} to be between " + min + " and " + max
+                );
+                return this.that;
+            };
+
+            let notInRangeAdapter = createExprAdapter("not", checkRangeFunc);
+
+            // Should pass - 100 is NOT in range 0-10
+            let context1 = createContext(100);
+            let scope1 = createAssertScope(context1);
+            notInRangeAdapter.call(scope1, 0, 10);
+
+            // Should fail - 5 IS in range 0-10
+            let context2 = createContext(5);
+            let scope2 = createAssertScope(context2);
+            checkError(() => {
+                notInRangeAdapter.call(scope2, 0, 10);
+            }, /not/);
+        });
+    });
+
+    describe("expression reuse and performance", () => {
+        beforeEach(() => {
+            assertConfig.isVerbose = false;
+        });
+
+        it("should allow expression reuse across multiple invocations", () => {
+            let callCount = 0;
+            let scopeFn = function<R>(this: IAssertScope): R {
+                callCount++;
+                return this.that;
+            };
+
+            let adapter = createExprAdapter("not", scopeFn);
+
+            // Reuse the same adapter many times
+            for (let i = 0; i < 100; i++) {
+                let context = createContext(i);
+                let scope = createAssertScope(context);
+                adapter.call(scope);
+            }
+
+            assert.equal(callCount, 100, "Adapter should be reusable");
+        });
+
+        it("should only parse expression once at creation time", () => {
+            // This test verifies the behavior - expressions are parsed once
+            // Use a simple expression that doesn't require arguments
+            let callCount = 0;
+            let scopeFn = function<R>(this: IAssertScope): R {
+                callCount++;
+                return this.that;
+            };
+            
+            let adapter = createExprAdapter("to.be", scopeFn);
+            
+            // Multiple calls should not re-parse, the expression is already parsed
+            let results: any[] = [];
+            for (let i = 0; i < 10; i++) {
+                let context = createContext({ value: i });
+                let scope = createAssertScope(context);
+                let result = adapter.call(scope);
+                results.push(result);
+            }
+
+            assert.equal(results.length, 10, "All invocations should work");
+            assert.equal(callCount, 10, "Scope function should be called for each invocation");
+            results.forEach((r) => assert.ok(r, "Each result should be valid"));
+        });
+    });
+
+    describe("verbose mode tracking", () => {
+        it("should track expression in opPath when verbose", () => {
+            assertConfig.isVerbose = true;
+
+            let context = createContext(10);
+            let scope = createAssertScope(context);
+            let adapter = createExprAdapter("to.be.not");
+
+            adapter.call(scope);
+
+            let opPath = scope.context.get("opPath");
+            assert.isTrue(opPath.length > 0, "opPath should have entries");
+            
+            // Check that the expression was tracked
+            let foundExpr = opPath.some((op: string) => op.indexOf("to.be.not") >= 0);
+            assert.isTrue(foundExpr, "Expression should be tracked in opPath");
+        });
+
+        it("should track scope function name in opPath when verbose", () => {
+            assertConfig.isVerbose = true;
+
+            function namedScopeFn<R>(this: IAssertScope): R {
+                return this.that;
+            }
+
+            let context = createContext(10);
+            let scope = createAssertScope(context);
+            let adapter = createExprAdapter("not", namedScopeFn);
+
+            adapter.call(scope);
+
+            let opPath = scope.context.get("opPath");
+            let foundScopeFn = opPath.some((op: string) => op.indexOf("namedScopeFn") >= 0);
+            assert.isTrue(foundScopeFn, "Named scope function should be tracked in opPath");
+        });
+
+        it("should track anonymous scope function in opPath when verbose", () => {
+            assertConfig.isVerbose = true;
+
+            let context = createContext(10);
+            let scope = createAssertScope(context);
+            let adapter = createExprAdapter("not", function<R>(this: IAssertScope): R {
+                return this.that;
+            });
+
+            adapter.call(scope);
+
+            let opPath = scope.context.get("opPath");
+            let foundAnonymous = opPath.some((op: string) => op.indexOf("anonymous") >= 0);
+            assert.isTrue(foundAnonymous, "Anonymous scope function should be tracked as 'anonymous' in opPath");
+        });
+    });
+
+    describe("integration with assert class", () => {
+        beforeEach(() => {
+            assertConfig.isVerbose = false;
+        });
+
+        it("should work with assert.isString which uses is.string expression", () => {
+            assert.isString("hello");
+            
+            checkError(() => {
+                assert.isString(123);
+            }, /string/);
+        });
+
+        it("should work with assert.isNotString which uses not.is.string expression", () => {
+            assert.isNotString(123);
+            
+            checkError(() => {
+                assert.isNotString("hello");
+            }, /not/);
+        });
+
+        it("should work with assert.exists which uses to.exist expression", () => {
+            assert.exists("value");
+            assert.exists(0);
+            assert.exists(false);
+            
+            checkError(() => {
+                assert.exists(null);
+            }, /exist/);
+        });
+
+        it("should work with assert.notExists which uses not.to.exist expression", () => {
+            assert.notExists(null);
+            assert.notExists(undefined);
+            
+            checkError(() => {
+                assert.notExists("value");
+            }, /not/);
+        });
+
+        it("should work with assert.isNaN which uses is.nan expression", () => {
+            assert.isNaN(NaN);
+            
+            checkError(() => {
+                assert.isNaN(123);
+            }, /NaN/);
+        });
+
+        it("should work with assert.isNotNaN which uses not.is.nan expression", () => {
+            assert.isNotNaN(123);
+            
+            checkError(() => {
+                assert.isNotNaN(NaN);
+            }, /not/);
+        });
+
+        it("should work with assert.isFinite which uses is.finite expression", () => {
+            assert.isFinite(100);
+            assert.isFinite(-50);
+            assert.isFinite(0);
+            
+            checkError(() => {
+                assert.isFinite(Infinity);
+            }, /finite/);
+        });
+
+        it("should work with assert.isNotFinite which uses not.is.finite expression", () => {
+            assert.isNotFinite(Infinity);
+            assert.isNotFinite(-Infinity);
+            
+            checkError(() => {
+                assert.isNotFinite(100);
+            }, /not/);
+        });
+    });
+
+    describe("calling custom instance functions from expressions", () => {
+        // These tests verify that custom functions added via addAssertInstFunc
+        // can be called from expressions created with createExprAdapter
+
+        beforeEach(() => {
+            assertConfig.isVerbose = false;
+        });
+
+        afterEach(() => {
+            // Clean up any added instance functions
+            _clearAssertInstFuncs();
+        });
+
+        it("should call a custom instance function from an expression", () => {
+            // Add a custom function to the assertion instance prototype
+            let customFuncCalled = false;
+            addAssertInstFunc("myCustomCheck", function(this: IAssertScope) {
+                customFuncCalled = true;
+                this.context.eval(true, "custom check passed");
+                return this.that;
+            });
+
+            // Create an expression that calls the custom function
+            let adapter = createExprAdapter("myCustomCheck");
+
+            let context = createContext(5);
+            let scope = createAssertScope(context);
+            adapter.call(scope);
+
+            assert.isTrue(customFuncCalled, "Custom instance function should be called from expression");
+        });
+
+        it("should call custom instance function with not modifier", () => {
+            let customFuncCalled = false;
+            addAssertInstFunc("isPositive", function(this: IAssertScope) {
+                customFuncCalled = true;
+                let value = this.context.value;
+                this.context.eval(
+                    typeof value === "number" && value > 0,
+                    "expected {value} to be a positive number"
+                );
+                return this.that;
+            });
+
+            // Create an expression that negates the custom function
+            let adapter = createExprAdapter("not.isPositive");
+
+            // Should pass for negative number (not positive)
+            let context1 = createContext(-5);
+            let scope1 = createAssertScope(context1);
+            adapter.call(scope1);
+            assert.isTrue(customFuncCalled, "Custom function should be called");
+
+            // Should fail for positive number
+            customFuncCalled = false;
+            let context2 = createContext(10);
+            let scope2 = createAssertScope(context2);
+            checkError(() => {
+                adapter.call(scope2);
+            }, /not/);
+            assert.isTrue(customFuncCalled, "Custom function should be called even when failing");
+        });
+
+        it("should call custom instance function without arguments", () => {
+            let receivedContext: any;
+            addAssertInstFunc("checkValue", function(this: IAssertScope) {
+                receivedContext = {
+                    value: this.context.value,
+                    hasContext: !!this.context
+                };
+                this.context.eval(
+                    typeof this.context.value === "number",
+                    "expected {value} to be a number"
+                );
+                return this.that;
+            });
+
+            let adapter = createExprAdapter("checkValue");
+
+            let context = createContext(42);
+            let scope = createAssertScope(context);
+            adapter.call(scope);
+
+            assert.isTrue(receivedContext.hasContext, "Custom function should have access to context");
+            assert.equal(receivedContext.value, 42, "Custom function should see the context value");
+        });
+
+        // Note: Expression argument passing (`{0}`, `{1}`, context names) has specific
+        // behavior that requires careful handling. For simple custom functions,
+        // accessing values directly from `this.context.value` is recommended.
+
+        it("should chain multiple custom instance functions in expression", () => {
+            let isPositiveCalled = false;
+            let isEvenCalled = false;
+
+            addAssertInstFunc("isPositive", function(this: IAssertScope) {
+                isPositiveCalled = true;
+                let value = this.context.value;
+                this.context.eval(
+                    typeof value === "number" && value > 0,
+                    "expected {value} to be a positive number"
+                );
+                return this.that;
+            });
+
+            addAssertInstFunc("isEven", function(this: IAssertScope) {
+                isEvenCalled = true;
+                let value = this.context.value;
+                this.context.eval(
+                    typeof value === "number" && value % 2 === 0,
+                    "expected {value} to be an even number"
+                );
+                return this.that;
+            });
+
+            // Test that isPositive works
+            let adapter = createExprAdapter("isPositive");
+
+            let context = createContext(4); // 4 is positive and even
+            let scope = createAssertScope(context);
+            adapter.call(scope);
+
+            assert.isTrue(isPositiveCalled, "isPositive should be called");
+
+            // Reset flags
+            isPositiveCalled = false;
+            isEvenCalled = false;
+
+            // Test isEven works too (separate adapter)
+            let adapterEven = createExprAdapter("isEven");
+            context = createContext(4);
+            scope = createAssertScope(context);
+            adapterEven.call(scope);
+
+            assert.isTrue(isEvenCalled, "isEven should be called via adapter");
+        });
+
+        it("should chain custom functions via expect API", () => {
+            let checkOneCalled = false;
+            let checkTwoCalled = false;
+
+            addAssertInstFunc("checkOne", function(this: IAssertScope) {
+                checkOneCalled = true;
+                this.context.eval(true, "check one passed");
+                return this.that;
+            });
+
+            addAssertInstFunc("checkTwo", function(this: IAssertScope) {
+                checkTwoCalled = true;
+                this.context.eval(true, "check two passed");
+                return this.that;
+            });
+
+            // Direct expect API calls work with custom instance functions
+            // Note: Return value is the instance, so each call is separate
+            let inst = expect(42) as any;
+            inst.checkOne();
+            assert.isTrue(checkOneCalled, "checkOne should be called via expect");
+
+            // The return value from checkOne() can also be chained
+            // but we call them separately here to verify both work
+            inst.checkTwo();
+            assert.isTrue(checkTwoCalled, "checkTwo should be called via expect");
+        });
+
+        it("should throw when custom function follows deep modifier in expression", () => {
+            // Custom functions cannot be used after modifiers like 'deep' in expressions
+            // because modifiers have a specific set of allowed steps
+            addAssertInstFunc("checkDeep", function(this: IAssertScope) {
+                this.context.eval(true, "check deep");
+                return this.that;
+            });
+
+            let adapter = createExprAdapter("deep.checkDeep");
+
+            let context = createContext({ a: 1 });
+            let scope = createAssertScope(context);
+
+            // This should throw because 'checkDeep' is not a valid step after 'deep'
+            checkError(() => {
+                adapter.call(scope);
+            }, /Invalid step: checkDeep/);
+        });
+
+        it("should throw when custom function follows own modifier in expression", () => {
+            // Custom functions cannot be used after 'own' modifier in expressions
+            addAssertInstFunc("checkOwn", function(this: IAssertScope) {
+                this.context.eval(true, "check own");
+                return this.that;
+            });
+
+            let adapter = createExprAdapter("own.checkOwn");
+
+            let context = createContext({ a: 1 });
+            let scope = createAssertScope(context);
+
+            // This should throw because 'checkOwn' is not a valid step after 'own'
+            checkError(() => {
+                adapter.call(scope);
+            }, /Invalid step: checkOwn/);
+        });
+
+        it("should throw when custom function follows not.deep in expression", () => {
+            // Custom functions cannot follow modifier chains
+            addAssertInstFunc("checkValue", function(this: IAssertScope) {
+                this.context.eval(true, "check value");
+                return this.that;
+            });
+
+            let adapter = createExprAdapter("not.deep.checkValue");
+
+            let context = createContext(10);
+            let scope = createAssertScope(context);
+
+            // This should throw because 'checkValue' is not a valid step after 'not.deep'
+            checkError(() => {
+                adapter.call(scope);
+            }, /Invalid step: checkValue/);
+        });
+
+        it("should allow custom function with not modifier at root only", () => {
+            // 'not' at the root level is handled specially and custom functions can follow
+            let customCalled = false;
+            let evalResult: boolean | undefined;
+
+            addAssertInstFunc("checkNotEmpty", function(this: IAssertScope) {
+                customCalled = true;
+                let value = this.context.value;
+                evalResult = isArray(value) && value.length > 0;
+                this.context.eval(evalResult, "expected {value} to not be empty");
+                return this.that;
+            });
+
+            // Using createNotAdapter or just 'not' followed by custom function accessed via API
+            // The expression 'not.checkNotEmpty' won't work directly, but we can use the expect API
+            let inst = expect([1, 2, 3]) as any;
+            inst.checkNotEmpty();
+
+            assert.isTrue(customCalled, "Custom function should be called");
+            assert.isTrue(evalResult, "Custom function should have evaluated correctly");
+        });
+
+        it("should work with addAssertInstFuncDefs to add multiple functions", () => {
+            let func1Called = false;
+            let func2Called = false;
+
+            addAssertInstFuncDefs({
+                customFunc1: {
+                    scopeFn: function(this: IAssertScope) {
+                        func1Called = true;
+                        this.context.eval(true, "func1 check");
+                        return this.that;
+                    }
+                },
+                customFunc2: {
+                    scopeFn: function(this: IAssertScope) {
+                        func2Called = true;
+                        this.context.eval(true, "func2 check");
+                        return this.that;
+                    }
+                }
+            });
+
+            // Test calling first custom function
+            let adapter1 = createExprAdapter("customFunc1");
+            let context1 = createContext(1);
+            let scope1 = createAssertScope(context1);
+            adapter1.call(scope1);
+            assert.isTrue(func1Called, "customFunc1 should be called");
+
+            // Test calling second custom function with not
+            let adapter2 = createExprAdapter("not.customFunc2");
+            let context2 = createContext(2);
+            let scope2 = createAssertScope(context2);
+            // Will fail because customFunc2 returns true, and we negate it
+            checkError(() => {
+                adapter2.call(scope2);
+            }, /not/);
+            assert.isTrue(func2Called, "customFunc2 should be called");
+        });
+
+        it("should work with addAssertInstProperty for property-style assertions", () => {
+            let propCalled = false;
+
+            addAssertInstProperty("isTheFive", function(scope: IAssertScope) {
+                propCalled = true;
+                scope.context.eval(scope.context.value === 5, "expected {value} to be five");
+            }, "expected {value} to be five");
+
+            // Access the property via expect (using 'any' cast since TypeScript doesn't know about custom properties)
+            (expect(5) as any).isTheFive;
+            assert.isTrue(propCalled, "Property assertion should be called");
+
+            propCalled = false;
+            checkError(() => {
+                (expect(10) as any).isTheFive;
+            }, /five/);
+            assert.isTrue(propCalled, "Property assertion should be called even when failing");
+        });
+
+        it("should allow reusing expression adapter with custom function multiple times", () => {
+            let callCount = 0;
+            addAssertInstFunc("countCalls", function(this: IAssertScope) {
+                callCount++;
+                this.context.eval(true, "counted");
+                return this.that;
+            });
+
+            let adapter = createExprAdapter("countCalls");
+
+            // Call the adapter multiple times
+            for (let i = 0; i < 5; i++) {
+                let context = createContext(i);
+                let scope = createAssertScope(context);
+                adapter.call(scope);
+            }
+
+            assert.equal(callCount, 5, "Custom function should be called 5 times");
+        });
+
+        it("should throw error when custom function doesn't exist in expression", () => {
+            // Don't add any custom function, just try to use it
+            let adapter = createExprAdapter("nonExistentCustomFunc");
+
+            let context = createContext(5);
+            let scope = createAssertScope(context);
+
+            checkError(() => {
+                adapter.call(scope);
+            }, /Invalid step: nonExistentCustomFunc/);
+        });
+    });
+});

--- a/core/test/src/assert/adapters/notAdapter.test.ts
+++ b/core/test/src/assert/adapters/notAdapter.test.ts
@@ -186,7 +186,6 @@ describe("createNotAdapter", () => {
             // To verify negation is active, we check that an eval(true) fails
             // and an eval(false) passes, which is the opposite of normal behavior
             let evalTrueResult: boolean | undefined;
-            let evalFalseResult: boolean | undefined;
 
             let scopeFn = function<R>(this: IAssertScope): R {
                 // When negation is active:

--- a/core/test/src/assert/addAssertFunc.test.ts
+++ b/core/test/src/assert/addAssertFunc.test.ts
@@ -71,6 +71,7 @@ describe("addAssertFunc", function () {
             myFunc: (value: any) => void;
             notNumber: (value: number) => void;
             funcNumber: (value: number) => void;
+            invalidExpr: (value: any) => void;
         }
     
         it("expression with functions", () => {
@@ -89,36 +90,45 @@ describe("addAssertFunc", function () {
 
         it("should throw AssertionError for invalid function definition", () => {
             checkError(() => {
-                addAssertFunc(assert, "invalidExpr", "hello({{}}).darkness.my.old.frield");
+                addAssertFunc(assert, "invalidExpr", "hello({{}}).silence.my.old.companion");
+                // Call the expression to trigger the evaluation
+                (assert as IExtendedAssert<ComplexUserAssertExtensions>).invalidExpr(123);
             }, "Invalid expression: {{}}");
 
             checkError(() => {
-                addAssertFunc(assert, "invalidExpr", "hello({{}).darkness.my.old.frield");
+                addAssertFunc(assert, "invalidExpr", "hello({{}).silence.my.old.companion");
+                (assert as IExtendedAssert<ComplexUserAssertExtensions>).invalidExpr(123);
             }, "Invalid expression: {{}");
 
             checkError(() => {
-                addAssertFunc(assert, "invalidExpr", "hello({{}}).darkness.my.old.frield");
+                addAssertFunc(assert, "invalidExpr", "hello({{}}).silence.my.old.companion");
+                (assert as IExtendedAssert<ComplexUserAssertExtensions>).invalidExpr(123);
             }, "Invalid expression: {{}}");
 
             checkError(() => {
-                addAssertFunc(assert, "invalidExpr", "hello({()}).darkness.my.old.frield");
+                addAssertFunc(assert, "invalidExpr", "hello({()}).silence.my.old.companion");
+                (assert as IExtendedAssert<ComplexUserAssertExtensions>).invalidExpr(123);
             }, "Invalid expression: hello({()})");
 
             checkError(() => {
-                addAssertFunc(assert, "invalidExpr", "hello({(}).darkness.my.old.frield");
+                addAssertFunc(assert, "invalidExpr", "hello({(}).silence.my.old.companion");
+                (assert as IExtendedAssert<ComplexUserAssertExtensions>).invalidExpr(123);
             }, "Invalid expression: hello({(})");
 
             checkError(() => {
-                addAssertFunc(assert, "invalidExpr", "hello({)}).darkness.my.old.frield");
+                addAssertFunc(assert, "invalidExpr", "hello({)}).silence.my.old.companion");
+                (assert as IExtendedAssert<ComplexUserAssertExtensions>).invalidExpr(123);
             }, "Invalid expression: hello({)})");
 
             checkError(() => {
-                addAssertFunc(assert, "invalidExpr", "hello().darkness({)}).my.old.frield");
-            }, "Invalid expression: hello().darkness({)})");
+                addAssertFunc(assert, "invalidExpr", "hello().silence({)}).my.old.companion");
+                (assert as IExtendedAssert<ComplexUserAssertExtensions>).invalidExpr(123);
+            }, "Invalid expression: hello().silence({)})");
 
             checkError(() => {
-                addAssertFunc(assert, "invalidExpr", [ "hello()", "darkness({()})", "my", "old", "frield" ]);
-            }, "Invalid expression: hello().darkness({()})");
+                addAssertFunc(assert, "invalidExpr", [ "hello()", "silence({()})", "my", "old", "companion" ]);
+                (assert as IExtendedAssert<ComplexUserAssertExtensions>).invalidExpr(123);
+            }, "Invalid expression: hello().silence({()})");
         });
     });
 

--- a/core/test/src/assert/assert.fail.test.ts
+++ b/core/test/src/assert/assert.fail.test.ts
@@ -17,8 +17,8 @@ describe("assert.fail", function () {
         }, /assert.*failure/);
 
         checkError(function () {
-            assert.fail("Hello Darkness, my old friend"); // Throws AssertionError
-        }, /Hello Darkness/);
+            assert.fail("Hello silence, my old companion"); // Throws AssertionError
+        }, /Hello silence/);
 
         checkError(function () {
             assert.fail(() => "Looks like we have failed again"); // Throws AssertionError
@@ -27,8 +27,8 @@ describe("assert.fail", function () {
 
     it("should always fail with message", function () {
         checkError(function () {
-            assert.fail("Hello Darkness, my old friend");
-        }, /Hello Darkness/);
+            assert.fail("Hello silence, my old companion");
+        }, /Hello silence/);
     });
 
     it("Should produce default message", function () {
@@ -43,8 +43,8 @@ describe("assert.fail", function () {
         }, /assert.*failure/);
 
         checkError(function () {
-            (assert as any)["fail"]("Hello Darkness, my old friend"); // Throws AssertionError
-        }, /Hello Darkness/);
+            (assert as any)["fail"]("Hello silence, my old companion"); // Throws AssertionError
+        }, /Hello silence/);
 
         checkError(function () {
             (assert as any)["fail"](() => "Looks like we have failed again"); // Throws AssertionError

--- a/core/test/src/assert/assert.fatal.test.ts
+++ b/core/test/src/assert/assert.fatal.test.ts
@@ -17,8 +17,8 @@ describe("assert.fatal", function () {
         }, /assert.*failure/);
 
         checkError(function () {
-            assert.fatal("Hello Darkness, my old friend"); // Throws AssertionError
-        }, /Hello Darkness/);
+            assert.fatal("Hello silence, my old companion"); // Throws AssertionError
+        }, /Hello silence/);
 
         checkError(function () {
             assert.fatal(() => "Looks like we have failed again"); // Throws AssertionError
@@ -27,8 +27,8 @@ describe("assert.fatal", function () {
 
     it("should always fail with message", function () {
         checkError(function () {
-            assert.fatal("Hello Darkness, my old friend");
-        }, /Hello Darkness/);
+            assert.fatal("Hello silence, my old companion");
+        }, /Hello silence/);
     });
 
     it("Should produce default message", function () {
@@ -43,8 +43,8 @@ describe("assert.fatal", function () {
         }, /assert.*failure/);
 
         checkError(function () {
-            (assert as any)["fatal"]("Hello Darkness, my old friend"); // Throws AssertionError
-        }, /Hello Darkness/);
+            (assert as any)["fatal"]("Hello silence, my old companion"); // Throws AssertionError
+        }, /Hello silence/);
 
         checkError(function () {
             (assert as any)["fatal"](() => "Looks like we have failed again"); // Throws AssertionError

--- a/core/test/src/assert/assert.includes.test.ts
+++ b/core/test/src/assert/assert.includes.test.ts
@@ -13,7 +13,7 @@ import { checkError } from "../support/checkError";
 
 describe("assert.includes", () => {
     it("should pass when the string includes the specified substring", () => {
-        assert.includes("hello darkness", "darkness");
+        assert.includes("hello silence", "silence");
     });
 
     it("should pass when the array includes the specified element", () => {
@@ -22,10 +22,10 @@ describe("assert.includes", () => {
 
     it("should throw AssertionFailure when the string does not include the specified substring", () => {
         checkError(() => {
-            assert.includes("hello darkness", "nomatch");
-        }, "expected \"hello darkness\" to include \"nomatch\"");
+            assert.includes("hello silence", "nomatch");
+        }, "expected \"hello silence\" to include \"nomatch\"");
 
-        expect(() => assert.includes("hello darkness", "nomatch")).toThrow(AssertionFailure);
+        expect(() => assert.includes("hello silence", "nomatch")).toThrow(AssertionFailure);
     });
 
     it("should throw AssertionFailure when the array does not include the specified element", () => {
@@ -40,10 +40,10 @@ describe("assert.includes", () => {
         const customMessage = "Custom error message";
 
         checkError(() => {
-            assert.includes("hello darkness", "nomatch", customMessage);
+            assert.includes("hello silence", "nomatch", customMessage);
         }, customMessage);
         
-        expect(() => assert.includes("hello darkness", "nomatch", customMessage)).toThrowError(new AssertionFailure(customMessage));
+        expect(() => assert.includes("hello silence", "nomatch", customMessage)).toThrowError(new AssertionFailure(customMessage));
     });
 
     describe("Error object property matching", () => {

--- a/core/test/src/assert/assert.isTrue.test.ts
+++ b/core/test/src/assert/assert.isTrue.test.ts
@@ -12,7 +12,7 @@ import { checkError } from "../support/checkError";
 describe("assert.isTrue", function () {
     it("isTrue", function () {
         assert.isTrue(true);
-        assert.isTrue(Boolean(1), "Hello Darkness");
+        assert.isTrue(Boolean(1), "Hello silence");
         assert.isTrue(Boolean("Hello"), "Darkness");
 
         checkError(function () {
@@ -44,12 +44,12 @@ describe("assert.isFalse", function () {
         }, "expected \"\" to be strictly false");
 
         checkError(function () {
-            assert.isFalse(true, "Hello Darkness");
-        }, "Hello Darkness: expected true to be strictly false");
+            assert.isFalse(true, "Hello silence");
+        }, "Hello silence: expected true to be strictly false");
 
         checkError(function () {
-            assert.isFalse(Boolean(1), "Hello Darkness");
-        }, "Hello Darkness: expected true to be strictly false");
+            assert.isFalse(Boolean(1), "Hello silence");
+        }, "Hello silence: expected true to be strictly false");
     });
 });
 

--- a/core/test/src/assert/assert.match.test.ts
+++ b/core/test/src/assert/assert.match.test.ts
@@ -13,32 +13,32 @@ import { checkError } from "../support/checkError";
 
 describe("assert.match", () => {
     it("should pass when the value matches the regular expression", () => {
-        assert.match("hello darkness", /hello/);
+        assert.match("hello silence", /hello/);
     });
 
     it("should pass when the value matches the entire regular expression", () => {
-        assert.match("hello darkness", /^hello darkness$/);
+        assert.match("hello silence", /^hello silence$/);
     });
 
     it("should pass when the value matches the regular expression at the end", () => {
-        assert.match("hello darkness", /darkness$/);
+        assert.match("hello silence", /silence$/);
     });
 
     it("should throw AssertionFailure when the value does not match the regular expression", () => {
         checkError(() => {
-            assert.match("hello darkness", /nomatch/);
-        }, "expected \"hello darkness\" to match /nomatch/");
+            assert.match("hello silence", /nomatch/);
+        }, "expected \"hello silence\" to match /nomatch/");
 
-        expect(() => assert.match("hello darkness", /nomatch/)).toThrow(AssertionFailure);
+        expect(() => assert.match("hello silence", /nomatch/)).toThrow(AssertionFailure);
     });
 
     it("should throw AssertionFailure with a custom message when the value does not match the regular expression", () => {
         const customMessage = "Custom error message";
 
         checkError(() => {
-            assert.match("hello darkness", /nomatch/, customMessage);
+            assert.match("hello silence", /nomatch/, customMessage);
         }, customMessage);
-        expect(() => assert.match("hello darkness", /nomatch/, customMessage)).toThrowError(new AssertionFailure(customMessage));
+        expect(() => assert.match("hello silence", /nomatch/, customMessage)).toThrowError(new AssertionFailure(customMessage));
     });
 });
 

--- a/core/test/src/assert/assert.ok.test.ts
+++ b/core/test/src/assert/assert.ok.test.ts
@@ -85,7 +85,7 @@ describe("assert.isOk", function () {
     it("isOk", function () {
         assert.isOk(true);
         assert.isOk(1);
-        assert.isOk("Hello Darkness");
+        assert.isOk("Hello silence");
 
         checkError(function () {
             assert.isOk(false, "Hello");
@@ -96,14 +96,14 @@ describe("assert.isOk", function () {
         }, "Darkness");
 
         checkError(function () {
-            assert.isOk("", "my old friend");
-        }, "my old friend");
+            assert.isOk("", "my old companion");
+        }, "my old companion");
     });
 
     it("as property", function () {
         (assert as any)["isOk"](true);
         (assert as any)["isOk"](1);
-        (assert as any)["isOk"]("Hello Darkness");
+        (assert as any)["isOk"]("Hello silence");
 
         checkError(function () {
             (assert as any)["isOk"](false, "Hello");
@@ -114,8 +114,8 @@ describe("assert.isOk", function () {
         }, "Darkness");
 
         checkError(function () {
-            (assert as any)["isOk"]("", "my old friend");
-        }, "my old friend");
+            (assert as any)["isOk"]("", "my old companion");
+        }, "my old companion");
 
     });
 });
@@ -196,7 +196,7 @@ describe("assert.ok", function () {
     it("ok", function () {
         assert.ok(true);
         assert.ok(1);
-        assert.ok("Hello Darkness");
+        assert.ok("Hello silence");
 
         checkError(function () {
             assert.ok(false, "Hello");
@@ -207,14 +207,14 @@ describe("assert.ok", function () {
         }, "Darkness");
 
         checkError(function () {
-            assert.ok("", "my old friend");
-        }, "my old friend");
+            assert.ok("", "my old companion");
+        }, "my old companion");
     });
 
     it("as property", function () {
         (assert as any)["ok"](true);
         (assert as any)["ok"](1);
-        (assert as any)["ok"]("Hello Darkness");
+        (assert as any)["ok"]("Hello silence");
 
         checkError(function () {
             (assert as any)["ok"](false, "Hello");
@@ -225,8 +225,8 @@ describe("assert.ok", function () {
         }, "Darkness");
 
         checkError(function () {
-            (assert as any)["ok"]("", "my old friend");
-        }, "my old friend");
+            (assert as any)["ok"]("", "my old companion");
+        }, "my old companion");
     });
 });
 

--- a/core/test/src/assert/assertInst.test.ts
+++ b/core/test/src/assert/assertInst.test.ts
@@ -156,7 +156,7 @@ describe("assertInst.ts", () => {
             }
 
             const func = function (scope: IAssertScope, evalMsg?: MsgSource) {
-                throw new Error("Test - " + scope.context.getMessage(evalMsg || "Hello darkness, my old friend -- failure"));
+                throw new Error("Test - " + scope.context.getMessage(evalMsg || "Hello silence, my old companion -- failure"));
             };
 
             // Create an inline function that will execute the `toThrow` function with
@@ -164,9 +164,9 @@ describe("assertInst.ts", () => {
             addAssertInstProperty("doThrow", func);
     
             checkError(() => {
-                let extendedExtend = expect("Hello darkness, my old friend -- failure") as IExtendedAssertInst<IInlineFunc>;
+                let extendedExtend = expect("Hello silence, my old companion -- failure") as IExtendedAssertInst<IInlineFunc>;
                 extendedExtend.doThrow;
-            }, "Hello darkness, my old friend -- failure");
+            }, "Hello silence, my old companion -- failure");
         });
 
         it("inline property func that throws with default evalMsg", () => {
@@ -175,7 +175,7 @@ describe("assertInst.ts", () => {
             }
 
             const func = function (scope: IAssertScope, evalMsg?: MsgSource) {
-                throw new Error("Test - " + scope.context.getMessage(evalMsg || "Hello darkness, my old friend -- failure"));
+                throw new Error("Test - " + scope.context.getMessage(evalMsg || "Hello silence, my old companion -- failure"));
             };
 
             // Create an inline function that will execute the `toThrow` function with
@@ -183,7 +183,7 @@ describe("assertInst.ts", () => {
             addAssertInstProperty("doThrow", func, "doThrow failure message");
     
             checkError(() => {
-                let extendedExtend = expect("Hello darkness, my old friend -- failure") as IExtendedAssertInst<IInlineFunc>;
+                let extendedExtend = expect("Hello silence, my old companion -- failure") as IExtendedAssertInst<IInlineFunc>;
                 extendedExtend.doThrow;
             }, "Test - doThrow failure message");
         });

--- a/core/test/src/assert/assertScope.test.ts
+++ b/core/test/src/assert/assertScope.test.ts
@@ -16,29 +16,29 @@ describe("assertScope", () => {
         let scope = createAssertScope(context);
 
         assert.strictEqual(scope.context, context);
-        scope.context.set("my", "old friend");
+        scope.context.set("my", "old companion");
 
         assert.equal(scope.context.value, "darkness");
         assert.equal(scope.context.getMessage(""), "");
         assert.equal(scope.context.getMessage("hello"), "hello");
         assert.equal(scope.context.getMessage("hello {value}"), "hello \"darkness\"");
         assert.equal(scope.context.getMessage("hello {message}"), "hello {message}");
-        assert.equal(scope.context.getMessage("hello {my}"), "hello \"old friend\"");
+        assert.equal(scope.context.getMessage("hello {my}"), "hello \"old companion\"");
     });
     
     it("Includes the initMsg in the message", () => {
-        let context = createContext("my", "hello darkness");
+        let context = createContext("my", "hello silence");
         let scope = createAssertScope(context);
 
         assert.strictEqual(scope.context, context);
-        context.set("my", "old friend");
+        context.set("my", "old companion");
 
         assert.equal(context.value, "my");
-        assert.equal(context.getMessage(""), "hello darkness");
-        assert.equal(context.getMessage("hello"), "hello darkness: hello");
-        assert.equal(context.getMessage("hello {value}"), "hello darkness: hello \"my\"");
-        assert.equal(context.getMessage("hello {message}"), "hello darkness: hello {message}");
-        assert.equal(context.getMessage("hello {my}"), "hello darkness: hello \"old friend\"");
+        assert.equal(context.getMessage(""), "hello silence");
+        assert.equal(context.getMessage("hello"), "hello silence: hello");
+        assert.equal(context.getMessage("hello {value}"), "hello silence: hello \"my\"");
+        assert.equal(context.getMessage("hello {message}"), "hello silence: hello {message}");
+        assert.equal(context.getMessage("hello {my}"), "hello silence: hello \"old companion\"");
     });
 
     it("Includes the initMsg in the message only once with child scope", () => {
@@ -48,7 +48,7 @@ describe("assertScope", () => {
         assert.strictEqual(scope.context, context);
         context.set("talk", "with you again");
         let childScope = scope.newScope("my");
-        childScope.context.set("old", "friend");
+        childScope.context.set("old", "companion");
 
         assert.equal(context.value, "hello");
         assert.equal(context.getMessage(""), "darkness");
@@ -64,7 +64,7 @@ describe("assertScope", () => {
         assert.equal(childScope.context.getMessage("hello"), "darkness: hello");
         assert.equal(childScope.context.getMessage("hello {value}"), "darkness: hello \"my\"");
         assert.equal(childScope.context.getMessage("hello {message}"), "darkness: hello {message}");
-        assert.equal(childScope.context.getMessage("hello {old}"), "darkness: hello \"friend\"");
+        assert.equal(childScope.context.getMessage("hello {old}"), "darkness: hello \"companion\"");
         // Child context should include parent context
         assert.equal(childScope.context.getMessage("hello {talk}"), "darkness: hello \"with you again\"");
     });
@@ -74,7 +74,7 @@ describe("assertScope", () => {
         let scope = createAssertScope(context);
         context.set("talk", "with you again");
         let childScope = scope.newScope();
-        childScope.context.set("old", "friend");
+        childScope.context.set("old", "companion");
 
         assert.notStrictEqual(childScope.context, context);
         assert.equal(childScope.context.getMessage("hello {talk}"), "darkness: hello \"with you again\"");
@@ -85,7 +85,7 @@ describe("assertScope", () => {
         let scope = createAssertScope(context);
         context.set("talk", "with you again");
         let childScope = scope.newScope();
-        childScope.context.set("old", "friend");
+        childScope.context.set("old", "companion");
 
         assert.notStrictEqual(childScope.context, context);
         assert.equal(childScope.context.getMessage("hello {talk}"), "darkness: hello \"with you again\"");

--- a/core/test/src/assert/context.test.ts
+++ b/core/test/src/assert/context.test.ts
@@ -108,7 +108,7 @@ describe("context", () => {
     
         describe("getMessage", () => {
             it("multiple messages with pre and post fixes", () => {
-                let ctx = createContext(1, "darkness");
+                let ctx = createContext(1, "silence");
                 let newCtx = ctx.new("newCtx", {
                     getMessage: (parent: IScopeContext, evalMsg?: MsgSource) => {
                         return "hello " + parent.getMessage(evalMsg);
@@ -116,7 +116,7 @@ describe("context", () => {
                 });
                 let subCtx = newCtx.new("subCtx", {
                     getMessage: (parent: IScopeContext, evalMsg?: MsgSource) => {
-                        return parent.getMessage(evalMsg) + ", my old friend";
+                        return parent.getMessage(evalMsg) + ", my old companion";
                     }
                 });
                 let childCtx = ctx.new("childCtx", {
@@ -125,11 +125,11 @@ describe("context", () => {
                     }
                 });
                     
-                assert.equal(ctx.getMessage(), "darkness");
+                assert.equal(ctx.getMessage(), "silence");
                 assert.equal(ctx.value, 1);
-                assert.equal(newCtx.getMessage(), "hello darkness");
+                assert.equal(newCtx.getMessage(), "hello silence");
                 assert.equal(newCtx.value, "newCtx");
-                assert.equal(subCtx.getMessage(), "hello darkness, my old friend");
+                assert.equal(subCtx.getMessage(), "hello silence, my old companion");
                 assert.equal(subCtx.value, "subCtx");
                 assert.equal(childCtx.getMessage(), "I've come to talk with you again");
                 assert.equal(childCtx.value, "childCtx");

--- a/core/test/src/assert/expect.fail.test.ts
+++ b/core/test/src/assert/expect.fail.test.ts
@@ -18,8 +18,8 @@ describe("expect.fail", () => {
         }, /assert.*failure/);
 
         checkError(function () {
-            expect(1).fail("Hello Darkness, my old friend"); // Throws AssertionError
-        }, /Hello Darkness/);
+            expect(1).fail("Hello silence, my old companion"); // Throws AssertionError
+        }, /Hello silence/);
 
         checkError(function () {
             expect(1).fail(() => "Looks like we have failed again"); // Throws AssertionError
@@ -71,8 +71,8 @@ describe("expect.fail", () => {
     });
     it("should always fail with message", function () {
         checkError(function () {
-            expect(1).fail("Hello Darkness, my old friend");
-        }, /Hello Darkness/);
+            expect(1).fail("Hello silence, my old companion");
+        }, /Hello silence/);
     });
 
     it("Should produce default message", function () {
@@ -87,8 +87,8 @@ describe("expect.fail", () => {
         }, /assert.*failure/);
 
         checkError(function () {
-            (expect(null) as any)["fail"]("Hello Darkness, my old friend"); // Throws AssertionError
-        }, /Hello Darkness/);
+            (expect(null) as any)["fail"]("Hello silence, my old companion"); // Throws AssertionError
+        }, /Hello silence/);
 
         checkError(function () {
             (expect(null) as any)["fail"](() => "Looks like we have failed again"); // Throws AssertionError
@@ -119,8 +119,8 @@ describe("expect.fail", () => {
             }, /assert.*failure/);
 
             checkError(function () {
-                expect(1).not.fail("Hello Darkness, my old friend"); // Throws AssertionError
-            }, /Hello Darkness/);
+                expect(1).not.fail("Hello silence, my old companion"); // Throws AssertionError
+            }, /Hello silence/);
 
             checkError(function () {
                 expect(1).not.fail(() => "Looks like we have failed again"); // Throws AssertionError
@@ -173,8 +173,8 @@ describe("expect.fail", () => {
 
         it("should always fail with message", function () {
             checkError(function () {
-                expect(1).not.fail("Hello Darkness, my old friend");
-            }, /Hello Darkness/);
+                expect(1).not.fail("Hello silence, my old companion");
+            }, /Hello silence/);
         });
 
         it("Should produce default message", function () {
@@ -189,8 +189,8 @@ describe("expect.fail", () => {
             }, /assert.*failure/);
 
             checkError(function () {
-                (expect(null).not as any)["fail"]("Hello Darkness, my old friend"); // Throws AssertionError
-            }, /Hello Darkness/);
+                (expect(null).not as any)["fail"]("Hello silence, my old companion"); // Throws AssertionError
+            }, /Hello silence/);
 
             checkError(function () {
                 (expect(null).not as any)["fail"](() => "Looks like we have failed again"); // Throws AssertionError

--- a/core/test/src/assert/funcs/anyValuesFunc.test.ts
+++ b/core/test/src/assert/funcs/anyValuesFunc.test.ts
@@ -132,21 +132,21 @@ describe("anyValuesFunc", () => {
     });
 
     it("should find substrings in a longer text string", () => {
-        const context = "hello darkness old friend";
+        const context = "hello old silent friend";
         const scope = createAssertScope(createContext(context));
         const valuesFn = anyValuesFunc(scope);
 
         expect(() => valuesFn.call(scope, "hello")).to.not.throw();
-        expect(() => valuesFn.call(scope, "darkness")).to.not.throw();
+        expect(() => valuesFn.call(scope, "silent")).to.not.throw();
         expect(() => valuesFn.call(scope, "old")).to.not.throw();
         expect(() => valuesFn.call(scope, "friend")).to.not.throw();
-        expect(() => valuesFn.call(scope, "hello darkness")).to.not.throw();
-        expect(() => valuesFn.call(scope, "darkness old")).to.not.throw();
-        expect(() => valuesFn.call(scope, "old friend")).to.not.throw();
+        expect(() => valuesFn.call(scope, "hello old")).to.not.throw();
+        expect(() => valuesFn.call(scope, "old silent")).to.not.throw();
+        expect(() => valuesFn.call(scope, "silent friend")).to.not.throw();
     });
 
     it("should detect when no substrings match in a longer text", () => {
-        const context = "hello darkness old friend";
+        const context = "hello silent old friend";
         const scope = createAssertScope(createContext(context));
         const valuesFn = anyValuesFunc(scope);
 
@@ -154,11 +154,11 @@ describe("anyValuesFunc", () => {
         
         checkError(() => {
             valuesFn.call(scope, "talking", "hearing", "whisper");
-        }, /expected any value: \["talking","hearing","whisper"\], found: "hello darkness old friend" \(1 value\)/);
+        }, /expected any value: \["talking","hearing","whisper"\], found: "hello silent old friend" \(1 value\)/);
     });
 
     it("should find at least one substring from a list of options", () => {
-        const context = "hello darkness old friend silence sound";
+        const context = "hello silence old friend silence sound";
         const scope = createAssertScope(createContext(context));
         const valuesFn = anyValuesFunc(scope);
 

--- a/core/test/src/assert/scopeContext.test.ts
+++ b/core/test/src/assert/scopeContext.test.ts
@@ -13,33 +13,33 @@ describe("scopeContext", () => {
     describe("getMessage", () => {
         it("creates a new scope context", () => {
             let context = createContext("darkness");
-            context.set("my", "old friend");
+            context.set("my", "old companion");
 
             assert.equal(context.value, "darkness");
             assert.equal(context.getMessage(""), "");
             assert.equal(context.getMessage("hello"), "hello");
             assert.equal(context.getMessage("hello {value}"), "hello \"darkness\"");
             assert.equal(context.getMessage("hello {message}"), "hello {message}");
-            assert.equal(context.getMessage("hello {my}"), "hello \"old friend\"");
+            assert.equal(context.getMessage("hello {my}"), "hello \"old companion\"");
         });
         
         it("Includes the initMsg in the message", () => {
-            let context = createContext("my", "hello darkness");
-            context.set("my", "old friend");
+            let context = createContext("my", "hello silence");
+            context.set("my", "old companion");
 
             assert.equal(context.value, "my");
-            assert.equal(context.getMessage(""), "hello darkness");
-            assert.equal(context.getMessage("hello"), "hello darkness: hello");
-            assert.equal(context.getMessage("hello {value}"), "hello darkness: hello \"my\"");
-            assert.equal(context.getMessage("hello {message}"), "hello darkness: hello {message}");
-            assert.equal(context.getMessage("hello {my}"), "hello darkness: hello \"old friend\"");
+            assert.equal(context.getMessage(""), "hello silence");
+            assert.equal(context.getMessage("hello"), "hello silence: hello");
+            assert.equal(context.getMessage("hello {value}"), "hello silence: hello \"my\"");
+            assert.equal(context.getMessage("hello {message}"), "hello silence: hello {message}");
+            assert.equal(context.getMessage("hello {my}"), "hello silence: hello \"old companion\"");
         });
 
         it("Includes the initMsg in the message only once with child context", () => {
             let context = createContext("hello", "darkness");
             context.set("talk", "with you again");
             let child = context.new("my");
-            child.set("old", "friend");
+            child.set("old", "companion");
 
             assert.equal(context.value, "hello");
             assert.equal(context.getMessage(""), "darkness");
@@ -55,7 +55,7 @@ describe("scopeContext", () => {
             assert.equal(child.getMessage("hello"), "darkness: hello");
             assert.equal(child.getMessage("hello {value}"), "darkness: hello \"my\"");
             assert.equal(child.getMessage("hello {message}"), "darkness: hello {message}");
-            assert.equal(child.getMessage("hello {old}"), "darkness: hello \"friend\"");
+            assert.equal(child.getMessage("hello {old}"), "darkness: hello \"companion\"");
             // Child context should include parent context
             assert.equal(child.getMessage("hello {talk}"), "darkness: hello \"with you again\"");
         });
@@ -64,7 +64,7 @@ describe("scopeContext", () => {
             let context = createContext("hello", "darkness");
             context.set("talk", "with you again");
             let child = context.new("my");
-            child.set("old", "friend");
+            child.set("old", "companion");
 
             assert.equal(context.getMessage("hello {{value}"), "darkness: hello {{value}");
             assert.equal(child.getMessage("hello {{value}"), "darkness: hello {{value}");
@@ -88,7 +88,7 @@ describe("scopeContext", () => {
             let context = createContext("hello", "darkness");
             context.set("talk", "with you again");
             let child = context.new("my");
-            child.set("old", "friend");
+            child.set("old", "companion");
 
             assert.equal(context._$stackFn.length, 0);
             assert.equal(child._$stackFn.length, 0);
@@ -107,7 +107,7 @@ describe("scopeContext", () => {
             context.set("talk", "with you again");
             context._$stackFn.push(hello);
             let child = context.new("my");
-            child.set("old", "friend");
+            child.set("old", "companion");
 
             assert.equal(context._$stackFn.length, 1);
             assert.equal(child._$stackFn.length, 1);
@@ -135,7 +135,7 @@ describe("scopeContext", () => {
             context.set("talk", "with you again");
             context._$stackFn.unshift(hello);
             let child = context.new("my");
-            child.set("old", "friend");
+            child.set("old", "companion");
 
             assert.equal(context._$stackFn.length, 1);
             assert.equal(child._$stackFn.length, 1);

--- a/core/test/src/operations/includeOp.test.ts
+++ b/core/test/src/operations/includeOp.test.ts
@@ -38,12 +38,12 @@ describe("includeOp", () => {
     });
 
     it("should include a value in a string", () => {
-        const scope = createAssertScope(createContext("Hello Darkness"));
+        const scope = createAssertScope(createContext("Hello silence"));
         const op = includeOp(scope);
 
         checkError(() => {
-            op.call(scope, "my old friend");
-        }, "expected \"Hello Darkness\" to include \"my old friend\"");
+            op.call(scope, "my quiet friend");
+        }, "expected \"Hello silence\" to include \"my quiet friend\"");
         op.call(scope, "Hello");
 
         expect(() => op.call(scope, "Hello")).to.not.throw();

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@
 | **Collection Operations** | [`includes`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#includes), [`sameMembers`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#samemembers), [`includeMembers`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#includemembers), [`lengthOf`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#lengthof), [`sizeOf`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#sizeof) |
 | **Change Tracking** | [`changes`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#changes), [`increases`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#increases), [`decreases`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#decreases) - See [Change/Increase/Decrease Assertions Guide](change-assertions.md) |
 | **Error Testing** | [`throws`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#throws), [`doesNotThrow`](https://nevware21.github.io/tripwire/typedoc/core/interfaces/IAssertClass.html#doesnotthrow) |
+| **Extensibility** | [`createExprAdapter`](https://nevware21.github.io/tripwire/typedoc/core/functions/createExprAdapter.html), [`addAssertFunc`](https://nevware21.github.io/tripwire/typedoc/core/functions/addAssertFunc.html) - See [Expression Adapter Guide](expression-adapter.md) |
 
 ### Quick Start
 

--- a/docs/expression-adapter.md
+++ b/docs/expression-adapter.md
@@ -1,0 +1,699 @@
+# Expression Adapter Guide
+
+The Expression Adapter is a powerful internal mechanism in Tripwire that allows you to compose assertion operations using a fluent, path-based expression syntax. It enables the creation of custom assertions by chaining operations together.
+
+## Overview
+
+The `createExprAdapter` function creates a scope function that evaluates expressions against assertion instances. It parses dot-notation strings or arrays into a sequence of operations, allowing you to build complex assertion chains programmatically.
+
+```ts
+import { createExprAdapter } from '@nevware21/tripwire';
+
+// Create an adapter for a simple "not" expression
+const notAdapter = createExprAdapter("not", myAssertionFunction);
+
+// Create an adapter for a chained expression
+const deepEqualAdapter = createExprAdapter("deep.equal");
+```
+
+## Expression Syntax
+
+### Basic Expressions
+
+Expressions are written as dot-separated paths that represent the chain of operations to perform on an assertion instance.
+
+```ts
+// Simple single-step expression
+createExprAdapter("not")           // Access .not property
+
+// Multi-step expression
+createExprAdapter("to.be")         // Access .to, then .be
+
+// Complex chain
+createExprAdapter("to.be.not")     // Access .to, then .be, then .not
+```
+
+### Array Syntax
+
+You can also pass expressions as an array of strings:
+
+```ts
+// Equivalent to "deep.equal"
+createExprAdapter(["deep", "equal"])
+
+// Equivalent to "not.deep.own.include"
+createExprAdapter(["not", "deep", "own", "include"])
+```
+
+### Function Calls with Arguments
+
+Expressions can include function calls with arguments using parentheses. Arguments can be:
+
+1. **Named context arguments** - Reference values from the scope context
+2. **Indexed arguments** - Reference arguments passed to the adapter
+3. **Literal values** - Direct string values
+
+```ts
+// Call a function with arguments from the adapter call
+createExprAdapter("include({0})")
+
+// Call with multiple arguments
+createExprAdapter("within({0},{1})")
+
+// Call with named context values
+createExprAdapter("equal({value})")
+```
+
+## Argument Reference Syntax
+
+Arguments in function calls use specific syntax patterns:
+
+### Indexed Arguments: `{0}`, `{1}`, `{2}`, ...
+
+Reference arguments passed to the adapter by their zero-based index:
+
+```ts
+const adapter = createExprAdapter("is.above({0})");
+// adapter.call(scope, 10) -> accesses is.above(10)
+// The {0} is replaced with the first argument (10)
+```
+
+### Named Context Arguments: `{name}`
+
+Reference values stored in the scope context:
+
+```ts
+const adapter = createExprAdapter("equal({expected})");
+// Retrieves scope.context.get("expected") as the argument
+```
+
+### Literal String Values
+
+Any argument that doesn't parse as an index becomes a literal string value:
+
+```ts
+const adapter = createExprAdapter("typeOf({string})");
+// Passes the literal string "string" as the argument
+```
+
+## Creating Custom Assertions
+
+There are two ways to add custom assertion functions, each with different capabilities:
+
+| API | Added To | Can be called from expressions? |
+|-----|----------|--------------------------------|
+| `addAssertFunc` | `assert` object | No - only callable directly via `assert.myFunc()` |
+| `addAssertInstFunc` | `IAssertInst` prototype | **Yes** - callable from expressions and via `expect().myFunc()` |
+
+### Basic Custom Assertion (addAssertFunc)
+
+Use `addAssertFunc` to add functions directly to the `assert` object:
+
+```ts
+import { createExprAdapter, addAssertFunc, assert, IAssertScope } from '@nevware21/tripwire';
+
+// Create an assertion that checks if a value is a positive number
+const isPositiveFunc = function(this: IAssertScope): any {
+    const value = this.context.value;
+    this.context.eval(
+        typeof value === 'number' && value > 0,
+        "expected {value} to be a positive number"
+    );
+    return this.that;
+};
+
+// Add it to the assert object
+addAssertFunc(assert, 'isPositive', isPositiveFunc);
+addAssertFunc(assert, 'isNotPositive', createExprAdapter("not", isPositiveFunc));
+
+// Usage
+assert.isPositive(5);      // Passes
+assert.isNotPositive(-3);  // Passes
+assert.isPositive(-1);     // Throws AssertionFailure
+```
+
+### Instance Custom Assertions (addAssertInstFunc) - Callable from Expressions
+
+Use `addAssertInstFunc` or `addAssertInstFuncDefs` to add functions to the `IAssertInst` prototype.
+These functions **can be called from expressions**:
+
+```ts
+import { 
+    addAssertInstFunc, 
+    addAssertInstFuncDefs,
+    createExprAdapter, 
+    expect,
+    IAssertScope,
+    IAssertInst,
+    IExtendedAssertInst
+} from '@nevware21/tripwire';
+
+// Define a custom function
+const isPositive = function(this: IAssertScope): any {
+    const value = this.context.value;
+    this.context.eval(
+        typeof value === 'number' && value > 0,
+        "expected {value} to be a positive number"
+    );
+    return this.that;
+};
+
+// Add to the assertion instance prototype
+addAssertInstFunc("isPositive", isPositive);
+
+// Define the type extension
+interface IMyAssertions {
+    isPositive(): IAssertInst;
+}
+
+// Now you can use it directly via expect()
+(expect(5) as IExtendedAssertInst<IMyAssertions>).isPositive();  // Passes
+
+// AND it can be called from expressions!
+const notPositiveAdapter = createExprAdapter("not.isPositive");
+// This adapter will: access .not, then call .isPositive()
+```
+
+### Expression-Based Assertion
+
+```ts
+import { createExprAdapter, addAssertFunc, assert } from '@nevware21/tripwire';
+
+// Create assertions using expressions
+addAssertFunc(assert, 'isNumericString', createExprAdapter("is.string"));
+addAssertFunc(assert, 'isFiniteNumber', createExprAdapter("is.finite"));
+addAssertFunc(assert, 'existsAndIsArray', createExprAdapter("to.exist.and.is.array"));
+```
+
+### Assertion with Scope Function
+
+The second parameter to `createExprAdapter` is an optional scope function that runs after the expression is evaluated:
+
+```ts
+const checkRange = function(this: IAssertScope, min: number, max: number): any {
+    const value = this.context.value;
+    this.context.eval(
+        value >= min && value <= max,
+        `expected {value} to be between ${min} and ${max}`
+    );
+    return this.that;
+};
+
+// Expression runs first, then scope function
+const notInRangeAdapter = createExprAdapter("not", checkRange);
+
+// Usage: first applies "not", then runs checkRange
+addAssertFunc(assert, 'isNotInRange', { scopeFn: notInRangeAdapter, nArgs: 3 });
+```
+
+## Expression Operations Reference
+
+### Chainable Operations
+
+These operations can be chained and don't require arguments:
+
+| Expression | Description |
+|------------|-------------|
+| `not` | Negates the following assertion |
+| `to` | Language chain (no-op) |
+| `be` | Language chain (no-op) |
+| `been` | Language chain (no-op) |
+| `is` | Language chain (no-op) |
+| `that` | Language chain (no-op) |
+| `which` | Language chain (no-op) |
+| `and` | Language chain (no-op) |
+| `has` | Access property operations |
+| `have` | Access property operations |
+| `with` | Language chain (no-op) |
+| `at` | Language chain (no-op) |
+| `of` | Language chain (no-op) |
+| `same` | Language chain (no-op) |
+| `but` | Language chain (no-op) |
+| `does` | Language chain (no-op) |
+| `still` | Language chain (no-op) |
+| `also` | Language chain (no-op) |
+| `deep` | Enable deep equality comparison |
+| `own` | Check only own properties |
+| `nested` | Enable nested property access |
+| `any` | Match any key/value |
+| `all` | Match all keys/values |
+| `strictly` | Enable strict equality |
+
+### Type Checking Operations
+
+| Expression | Description |
+|------------|-------------|
+| `is.string` | Check if value is a string |
+| `is.array` | Check if value is an array |
+| `is.number` | Check if value is a number |
+| `is.boolean` | Check if value is a boolean |
+| `is.function` | Check if value is a function |
+| `is.object` | Check if value is an object |
+| `is.null` | Check if value is null |
+| `is.undefined` | Check if value is undefined |
+| `is.nan` | Check if value is NaN |
+| `is.finite` | Check if value is finite |
+
+### Function Operations (Require Arguments)
+
+| Expression | Arguments | Description |
+|------------|-----------|-------------|
+| `equal({0})` | expected value | Check equality |
+| `include({0})` | expected value | Check inclusion |
+| `above({0})` | number | Check if greater than |
+| `below({0})` | number | Check if less than |
+| `least({0})` | number | Check if at least |
+| `most({0})` | number | Check if at most |
+| `within({0},{1})` | min, max | Check if within range |
+| `instanceof({0})` | constructor | Check instance type |
+| `typeOf({0})` | type string | Check typeof |
+| `keys({0})` | expected keys | Check object keys |
+
+## Combining Expressions
+
+### Negation Patterns
+
+```ts
+// Simple negation
+createExprAdapter("not.is.string")      // isNotString
+createExprAdapter("not.is.array")       // isNotArray
+createExprAdapter("not.to.exist")       // notExists
+
+// Deep negation
+createExprAdapter("not.deep.equal")     // notDeepEqual
+createExprAdapter("not.strictly.equal") // notStrictEqual
+```
+
+### Modifier Patterns
+
+```ts
+// Deep operations
+createExprAdapter("deep.equal")         // deepEqual
+createExprAdapter("deep.include")       // deepInclude
+createExprAdapter("deep.own.include")   // deepOwnInclude
+
+// Own property operations
+createExprAdapter("own.include")        // ownInclude
+createExprAdapter("own.property")       // ownProperty
+
+// Combined modifiers
+createExprAdapter("not.deep.own.include") // notDeepOwnInclude
+createExprAdapter("has.any.keys")         // hasAnyKeys
+createExprAdapter("has.all.keys")         // hasAllKeys
+createExprAdapter("has.any.deep.keys")    // hasAnyDeepKeys
+```
+
+## Examples in Practice
+
+### Built-in Assert Functions Using Expressions
+
+The tripwire assert class uses expressions internally:
+
+```ts
+// Type checking
+isString: createExprAdapter("is.string"),
+isNotString: createExprAdapter("not.is.string"),
+isArray: createExprAdapter("is.array"),
+isNotArray: createExprAdapter("not.is.array"),
+
+// Existence
+exists: createExprAdapter("to.exist"),
+notExists: createExprAdapter("not.to.exist"),
+
+// NaN/Finite
+isNaN: createExprAdapter("is.nan"),
+isNotNaN: createExprAdapter("not.is.nan"),
+isFinite: createExprAdapter("is.finite"),
+isNotFinite: createExprAdapter("not.is.finite"),
+
+// Include operations
+ownInclude: createExprAdapter("own.include"),
+notOwnInclude: createExprAdapter("not.own.include"),
+deepOwnInclude: createExprAdapter("deep.own.include"),
+notDeepOwnInclude: createExprAdapter("not.deep.own.include"),
+
+// Keys operations
+hasAnyKeys: createExprAdapter("has.any.keys"),
+hasAllKeys: createExprAdapter("has.all.keys"),
+doesNotHaveAnyKeys: createExprAdapter("not.has.any.keys"),
+hasAnyDeepKeys: createExprAdapter("has.any.deep.keys"),
+```
+
+### Custom Assertion Examples
+
+#### String Validation Assertion
+
+```ts
+import { createExprAdapter, addAssertFunc, assert, IAssertScope } from '@nevware21/tripwire';
+
+// Custom scope function to check string length
+const hasMinLengthFunc = function(this: IAssertScope, minLength: number): any {
+    const value = this.context.value;
+    this.context.eval(
+        typeof value === 'string' && value.length >= minLength,
+        `expected {value} to have at least ${minLength} characters`
+    );
+    return this.that;
+};
+
+// Register positive and negative versions
+addAssertFunc(assert, 'hasMinLength', { scopeFn: hasMinLengthFunc, nArgs: 2 });
+addAssertFunc(assert, 'notHasMinLength', { 
+    scopeFn: createExprAdapter("not", hasMinLengthFunc), 
+    nArgs: 2 
+});
+
+// Usage
+assert.hasMinLength("hello", 3);     // Passes
+assert.notHasMinLength("hi", 5);     // Passes
+assert.hasMinLength("ab", 5);        // Throws - "ab" has only 2 chars
+```
+
+#### Date Validation Assertion
+
+```ts
+const isAfterDateFunc = function(this: IAssertScope, date: Date): any {
+    const value = this.context.value;
+    this.context.eval(
+        value instanceof Date && value > date,
+        `expected {value} to be after ${date.toISOString()}`
+    );
+    return this.that;
+};
+
+addAssertFunc(assert, 'isAfter', { scopeFn: isAfterDateFunc, nArgs: 2 });
+addAssertFunc(assert, 'isNotAfter', { 
+    scopeFn: createExprAdapter("not", isAfterDateFunc), 
+    nArgs: 2 
+});
+
+// Usage
+const now = new Date();
+const yesterday = new Date(Date.now() - 86400000);
+assert.isAfter(now, yesterday);      // Passes
+assert.isNotAfter(yesterday, now);   // Passes
+```
+
+### Calling Custom Instance Functions from Expressions
+
+When you add functions using `addAssertInstFunc` or `addAssertInstFuncDefs`, those functions become
+available in the assertion instance prototype and **can be called from expressions**. This is a powerful
+pattern for creating reusable assertion building blocks.
+
+#### Complete Example: Custom Validation Library
+
+```ts
+import { 
+    addAssertInstFunc, 
+    addAssertInstFuncDefs,
+    createExprAdapter,
+    addAssertFunc,
+    assert,
+    expect,
+    IAssertScope,
+    IAssertInst,
+    IExtendedAssertInst
+} from '@nevware21/tripwire';
+
+// Step 1: Define custom assertion functions
+const isPositive = function(this: IAssertScope): any {
+    const value = this.context.value;
+    this.context.eval(
+        typeof value === 'number' && value > 0,
+        "expected {value} to be a positive number"
+    );
+    return this.that;
+};
+
+const isEven = function(this: IAssertScope): any {
+    const value = this.context.value;
+    this.context.eval(
+        typeof value === 'number' && value % 2 === 0,
+        "expected {value} to be an even number"
+    );
+    return this.that;
+};
+
+const isInRange = function(this: IAssertScope, min: number, max: number): any {
+    const value = this.context.value;
+    this.context.eval(
+        typeof value === 'number' && value >= min && value <= max,
+        `expected {value} to be between ${min} and ${max}`
+    );
+    return this.that;
+};
+
+// Step 2: Add functions to the assertion instance prototype
+// These will be available for expressions to call!
+addAssertInstFuncDefs({
+    isPositive: { scopeFn: isPositive },
+    isEven: { scopeFn: isEven },
+    isInRange: { scopeFn: isInRange }
+});
+
+// Step 3: Define TypeScript interface for type safety
+interface IMyCustomAssertions {
+    isPositive(): IAssertInst;
+    isEven(): IAssertInst;
+    isInRange(min: number, max: number): IAssertInst;
+}
+
+// Step 4: Create expressions that use the custom functions!
+// These expressions call our custom instance functions
+const isNotPositive = createExprAdapter("not.isPositive");
+const isNotEven = createExprAdapter("not.isEven");
+const isNotInRange = createExprAdapter("not.isInRange");
+
+// The expression "not.isPositive" will:
+// 1. Access .not (applies negation)
+// 2. Call .isPositive() (our custom function)
+
+// Step 5: Add convenience functions to assert object
+addAssertFunc(assert, 'isPositive', isPositive);
+addAssertFunc(assert, 'isNotPositive', { scopeFn: isNotPositive, nArgs: 1 });
+addAssertFunc(assert, 'isEven', isEven);
+addAssertFunc(assert, 'isNotEven', { scopeFn: isNotEven, nArgs: 1 });
+addAssertFunc(assert, 'isInRange', { scopeFn: isInRange, nArgs: 3 });
+addAssertFunc(assert, 'isNotInRange', { scopeFn: isNotInRange, nArgs: 3 });
+
+// Usage via assert
+assert.isPositive(5);           // Passes
+assert.isNotPositive(-3);       // Passes (negated - negative is not positive)
+assert.isEven(4);               // Passes
+assert.isNotEven(3);            // Passes (negated - 3 is not even)
+assert.isInRange(5, 1, 10);     // Passes
+assert.isNotInRange(15, 1, 10); // Passes (negated - 15 is not in 1-10)
+
+// Usage via expect with chaining
+type MyExpect = IExtendedAssertInst<IMyCustomAssertions>;
+(expect(5) as MyExpect).isPositive().isEven();  // Fails - 5 is not even
+(expect(4) as MyExpect).isPositive().isEven();  // Passes - 4 is positive AND even
+(expect(4) as MyExpect).not.isEven();           // Fails - 4 IS even
+(expect(3) as MyExpect).not.isEven().isPositive(); // Passes - 3 is NOT even AND is positive
+```
+
+#### Creating Composable Assertion Chains
+
+Custom instance functions enable powerful composable assertions:
+
+```ts
+import { addAssertInstFunc, createExprAdapter, expect, IAssertScope } from '@nevware21/tripwire';
+
+// Add a custom "isPrime" function to the instance prototype
+addAssertInstFunc("isPrime", function(this: IAssertScope) {
+    const value = this.context.value;
+    let isPrime = typeof value === 'number' && value > 1;
+    if (isPrime) {
+        for (let i = 2; i <= Math.sqrt(value); i++) {
+            if (value % i === 0) {
+                isPrime = false;
+                break;
+            }
+        }
+    }
+    this.context.eval(isPrime, "expected {value} to be a prime number");
+    return this.that;
+});
+
+// Now "isPrime" can be used in expressions!
+// Create complex assertion adapters
+const notPrimeAdapter = createExprAdapter("not.isPrime");
+
+// Usage
+expect(7).isPrime();      // Passes - 7 is prime
+expect(4).not.isPrime();  // Passes - 4 is not prime
+```
+
+#### Expressions with Arguments to Custom Functions
+
+Custom functions that take arguments can also be called from expressions:
+
+```ts
+import { addAssertInstFunc, createExprAdapter, expect, IAssertScope } from '@nevware21/tripwire';
+
+// Custom function that takes an argument
+addAssertInstFunc("isDivisibleBy", function(this: IAssertScope, divisor: number) {
+    const value = this.context.value;
+    this.context.eval(
+        typeof value === 'number' && value % divisor === 0,
+        `expected {value} to be divisible by ${divisor}`
+    );
+    return this.that;
+});
+
+// Create an expression adapter that calls the custom function with an argument
+// {0} refers to the first argument passed to the adapter
+const notDivisibleByAdapter = createExprAdapter("not.isDivisibleBy({0})");
+
+// Usage
+expect(10).isDivisibleBy(5);  // Passes
+expect(10).isDivisibleBy(3);  // Fails
+
+// Using the adapter
+// notDivisibleByAdapter.call(scope, 3) -> expect(value).not.isDivisibleBy(3)
+```
+
+### Important Limitations
+
+When using custom instance functions in expressions, there are some important limitations to be aware of:
+
+#### Modifiers Cannot Precede Custom Functions (except `not`)
+
+Custom functions added via `addAssertInstFunc` can only be called directly or after the `not` modifier. Modifiers like `deep`, `own`, and `strictly` do not support custom functions:
+
+```ts
+// ✅ Works: Direct call
+createExprAdapter("myCustomFunc");
+
+// ✅ Works: not modifier followed by custom function
+createExprAdapter("not.myCustomFunc");
+
+// ❌ Throws: deep modifier cannot be followed by custom function
+createExprAdapter("deep.myCustomFunc");  // Invalid step: myCustomFunc
+
+// ❌ Throws: own modifier cannot be followed by custom function  
+createExprAdapter("own.myCustomFunc");   // Invalid step: myCustomFunc
+
+// ❌ Throws: Combined modifiers don't work with custom functions
+createExprAdapter("not.deep.myCustomFunc"); // Invalid step: myCustomFunc
+```
+
+This is because modifiers like `deep` and `own` return specialized interfaces (`IDeepOp`, `IOwnOp`) that only expose specific built-in operations, not the full assertion instance.
+
+#### Workaround: Handle Modifiers Inside Custom Functions
+
+If you need modifier behavior in custom functions, handle it within the function:
+
+```ts
+addAssertInstFunc("myDeepEqual", function(this: IAssertScope, expected: any) {
+    // Manually set the deep flag and perform deep comparison
+    this.context.set("$deep", true);
+    // ... perform deep comparison logic
+    return this.that;
+});
+
+// Now use directly without deep modifier
+createExprAdapter("myDeepEqual");
+```
+
+#### Accessing Context Value in Custom Functions
+
+The recommended way to access values in custom functions is through `this.context.value`:
+
+```ts
+addAssertInstFunc("isPositive", function(this: IAssertScope) {
+    // Access the value directly from context
+    const value = this.context.value;
+    this.context.eval(
+        typeof value === 'number' && value > 0,
+        "expected {value} to be a positive number"
+    );
+    return this.that;
+});
+```
+
+## Performance Considerations
+
+### Expression Parsing
+
+Expressions are parsed once when `createExprAdapter` is called, not on every invocation. This means:
+
+```ts
+// Good: Parse once, reuse many times
+const adapter = createExprAdapter("deep.equal");
+for (let i = 0; i < 1000; i++) {
+    adapter.call(scope, expectedValue);
+}
+
+// The expression "deep.equal" is only parsed once
+```
+
+### The notAdapter Optimization
+
+For simple "not" operations with a scope function, tripwire provides an optimized `createNotAdapter`:
+
+```ts
+import { createNotAdapter, createExprAdapter } from '@nevware21/tripwire';
+
+// Optimized - no expression parsing overhead
+const optimized = createNotAdapter(myScopeFn);
+
+// Standard - parses "not" expression
+const standard = createExprAdapter("not", myScopeFn);
+
+// Both produce equivalent behavior, but createNotAdapter is slightly faster
+```
+
+Use `createNotAdapter` when you only need negation with a scope function.
+
+## Error Handling
+
+### Invalid Expression Errors
+
+Invalid expressions throw `AssertionError` at adapter creation time:
+
+```ts
+// Invalid: nested parentheses
+createExprAdapter("func((arg))")  // Throws AssertionError
+
+// Invalid: mismatched parentheses
+createExprAdapter("func(arg")     // Throws AssertionError
+
+// Invalid: multiple argument sections
+createExprAdapter("func()()")     // Throws AssertionError
+```
+
+### Step Resolution Errors
+
+If a step doesn't exist on the assertion instance, an error is thrown at runtime:
+
+```ts
+const adapter = createExprAdapter("nonexistent.step");
+// Runtime error: "Invalid step: nonexistent for [nonexistent->step]"
+```
+
+## TypeScript Support
+
+The expression adapter provides full TypeScript support:
+
+```ts
+import { createExprAdapter, IScopeFn, IAssertScope } from '@nevware21/tripwire';
+
+// Type-safe scope function
+const typedScopeFn: IScopeFn = function<R>(this: IAssertScope, arg1: string, arg2: number): R {
+    // Full type information available
+    const value = this.context.value;
+    this.context.eval(true, "assertion message");
+    return this.that;
+};
+
+// Returns IScopeFn
+const adapter: IScopeFn = createExprAdapter("not", typedScopeFn);
+```
+
+## See Also
+
+- [API Documentation](https://nevware21.github.io/tripwire/typedoc/core/functions/createExprAdapter.html)
+- [Change Assertions Guide](change-assertions.md)
+- [Core Module README](../core/README.md)
+- [addAssertFunc API](https://nevware21.github.io/tripwire/typedoc/core/functions/addAssertFunc.html)


### PR DESCRIPTION
Improve startup performance by deferring creation of assert function handlers until first use. Previously, all ~100 assertion functions were created eagerly at module load time. Now they are created on-demand using getDeferred().

Core changes:
- Refactor assertClass.ts to use lazy initialization via objDefine with `l` (lazy) property instead of `v` (value)
- Add expr and not properties to IAssertClassDef for cleaner definition parsing
- Improve definition parsing for string, array, and function definitions

Documentation:
- Add docs/expression-adapter.md with comprehensive guide for createExprAdapter
- Document custom assertion patterns, expression syntax, and limitations
- Add links from README.md and docs/README.md