### PR TITLE
perf: Add max depth limits and optimize circular reference detection

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -99,11 +99,15 @@ grunt lint lint-fix            # Lint with auto-fix
 - No non-null assertions (`!` operator) - use proper null checks
 
 ### Versioning for New Features
-- **@since tags**: Check `core/package.json` version before adding new features
-- Current version in package.json is the **last published** version
-- Use the **next minor version** for @since tags on new features
-- Example: If package.json shows `0.1.4`, use `@since 0.1.5` for new features
-- This follows semver: new features increment the minor version
+- **@since tags**: Always use the **next unreleased version** for new features being added
+- Check `core/package.json` version - this is the version **currently being developed**, not yet released
+- For features added during development of version X.Y.Z, use `@since X.Y.Z` if unreleased, or `@since X.Y.(Z+1)` if X.Y.Z is already released
+- **Key rule**: If the version in package.json is already in a release PR or tagged, increment to the next patch/minor version
+- Example scenarios:
+  - package.json shows `0.1.7` and you're working on release branch `0.1.7` → use `@since 0.1.8` for new features
+  - package.json shows `0.1.7` and there's no release PR yet → use `@since 0.1.7` for new features
+  - package.json shows `0.1.7` and main branch already has commits after 0.1.7 release → use `@since 0.1.8`
+- This follows semver: new features should use the version they'll be released in
 
 ## Testing Patterns
 

--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -662,15 +662,15 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.12.0.tgz",
-      "integrity": "sha512-Xuq42yxcQJ54ti8ZHNzF5snFvtpgXzNToJ1bXUGQRaiO8t+B6UM8sTUJfvV+AJnqtkJU/7hdy6nbKyA12aHtRw==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.12.1.tgz",
+      "integrity": "sha512-fXa6uXLxfslBlus3MEpW8S6S9fe5RwmAE5Gd8u3krqOwnkZJV3/lQJiY3LaFdTctLLqJtyMgEUGkbDnRNf6vbQ==",
       "dependencies": {
         "debug": "^4.4.3",
         "extract-zip": "^2.0.1",
         "progress": "^2.0.3",
         "proxy-agent": "^6.5.0",
-        "semver": "^7.7.3",
+        "semver": "^7.7.4",
         "tar-fs": "^3.1.1",
         "yargs": "^17.7.2"
       },
@@ -1708,9 +1708,9 @@
       }
     },
     "node_modules/b4a": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
-      "integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.4.tgz",
+      "integrity": "sha512-u20zJLDaSWpxaZ+zaAkEIB2dZZ1o+DF4T/MRbmsvGp9nletHOyiai19OzX1fF8xUBYsO1bPXxODvcd0978pnug==",
       "peerDependencies": {
         "react-native-b4a": "*"
       },
@@ -2167,9 +2167,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001769",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001769.tgz",
-      "integrity": "sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==",
+      "version": "1.0.30001770",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001770.tgz",
+      "integrity": "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==",
       "funding": [
         {
           "type": "opencollective",
@@ -2235,9 +2235,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "13.1.1",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-13.1.1.tgz",
-      "integrity": "sha512-zB9MpoPd7VJwjowQqiW3FKOvQwffFMjQ8Iejp5ZW+sJaKLRhZX1sTxzl3Zt22TDB4zP0OOqs8lRoY7eAW5geyQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
       "dependencies": {
         "mitt": "^3.0.1",
         "zod": "^3.24.1"
@@ -6405,16 +6405,16 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "24.37.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.37.2.tgz",
-      "integrity": "sha512-FV1W/919ve0y0oiS/3Rp5XY4MUNUokpZOH/5M4MMDfrrvh6T9VbdKvAHrAFHBuCxvluDxhjra20W7Iz6HJUcIQ==",
+      "version": "24.37.3",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.37.3.tgz",
+      "integrity": "sha512-AUGGWq0BhPM+IOS2U9A+ZREH3HDFkV1Y5HERYGDg5cbGXjoGsTCT7/A6VZRfNU0UJJdCclyEimZICkZW6pqJyw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@puppeteer/browsers": "2.12.0",
-        "chromium-bidi": "13.1.1",
+        "@puppeteer/browsers": "2.12.1",
+        "chromium-bidi": "14.0.0",
         "cosmiconfig": "^9.0.0",
         "devtools-protocol": "0.0.1566079",
-        "puppeteer-core": "24.37.2",
+        "puppeteer-core": "24.37.3",
         "typed-query-selector": "^2.12.0"
       },
       "bin": {
@@ -6425,16 +6425,16 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.37.2",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.37.2.tgz",
-      "integrity": "sha512-nN8qwE3TGF2vA/+xemPxbesntTuqD9vCGOiZL2uh8HES3pPzLX20MyQjB42dH2rhQ3W3TljZ4ZaKZ0yX/abQuw==",
+      "version": "24.37.3",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.37.3.tgz",
+      "integrity": "sha512-fokQ8gv+hNgsRWqVuP5rUjGp+wzV5aMTP3fcm8ekNabmLGlJdFHas1OdMscAH9Gzq4Qcf7cfI/Pe6wEcAqQhqg==",
       "dependencies": {
-        "@puppeteer/browsers": "2.12.0",
-        "chromium-bidi": "13.1.1",
+        "@puppeteer/browsers": "2.12.1",
+        "chromium-bidi": "14.0.0",
         "debug": "^4.4.3",
         "devtools-protocol": "0.0.1566079",
         "typed-query-selector": "^2.12.0",
-        "webdriver-bidi-protocol": "0.4.0",
+        "webdriver-bidi-protocol": "0.4.1",
         "ws": "^8.19.0"
       },
       "engines": {
@@ -7685,9 +7685,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/text-decoder": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
-      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
       "dependencies": {
         "b4a": "^1.6.4"
       }
@@ -7887,9 +7887,9 @@
       "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg=="
     },
     "node_modules/typedoc": {
-      "version": "0.28.16",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.16.tgz",
-      "integrity": "sha512-x4xW77QC3i5DUFMBp0qjukOTnr/sSg+oEs86nB3LjDslvAmwe/PUGDWbe3GrIqt59oTqoXK5GRK9tAa0sYMiog==",
+      "version": "0.28.17",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.17.tgz",
+      "integrity": "sha512-ZkJ2G7mZrbxrKxinTQMjFqsCoYY6a5Luwv2GKbTnBCEgV2ihYm5CflA9JnJAwH0pZWavqfYxmDkFHPt4yx2oDQ==",
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.17.0",
         "lunr": "^2.3.9",
@@ -8200,9 +8200,9 @@
       }
     },
     "node_modules/webdriver-bidi-protocol": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.0.tgz",
-      "integrity": "sha512-U9VIlNRrq94d1xxR9JrCEAx5Gv/2W7ERSv8oWRoNe/QYbfccS0V3h/H6qeNeCRJxXGMhhnkqvwNrvPAYeuP9VA=="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw=="
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/core/src/assert/funcs/keysFunc.ts
+++ b/core/src/assert/funcs/keysFunc.ts
@@ -230,7 +230,7 @@ export function anyDeepKeysFunc<R>(_scope: IAssertScope): KeysFn<R> {
         let found = false;
         arrForEach(expectedKeys, (expKey) => {
             arrForEach(valueKeys, (valKey) => {
-                if (_deepEqual(valKey, expKey)) {
+                if (_deepEqual(valKey, expKey, false, context)) {
                     // Found at least one key using deep equality
                     found = true;
                     return -1;
@@ -304,7 +304,7 @@ export function allDeepKeysFunc<R>(_scope: IAssertScope): KeysFn<R> {
         arrForEach(theKeys, (expKey) => {
             let found = false;
             arrForEach(valueKeys, (valKey) => {
-                if (_deepEqual(valKey, expKey)) {
+                if (_deepEqual(valKey, expKey, false, context)) {
                     found = true;
                     return -1;
                 }

--- a/core/src/assert/funcs/nested.ts
+++ b/core/src/assert/funcs/nested.ts
@@ -166,7 +166,7 @@ export function hasDeepNestedPropertyFunc(this: IAssertScope, path: string, valu
         context.set("expected", value);
         if (valueResult.exists) {
             context.set("nestedValue", valueResult.value);
-            context.eval(valueResult.exists && _deepEqual(valueResult.value, value), evalMsg || "expected {value} to have a nested property {property} deeply equal {expected}, but got {nestedValue}");
+            context.eval(valueResult.exists && _deepEqual(valueResult.value, value, false, context), evalMsg || "expected {value} to have a nested property {property} deeply equal {expected}, but got {nestedValue}");
         } else {
             // Property doesn't exist - fail the assertion
             context.eval(false, evalMsg || "expected {value} to have a nested property {property} deeply equal {expected}");
@@ -249,7 +249,7 @@ export function deepNestedIncludeFunc(this: IAssertScope, expected: any, evalMsg
             context.set("expected", expectedValue);
             if (valueResult.exists) {
                 context.set("nestedValue", valueResult.value);
-                context.eval(valueResult.exists && _deepEqual(valueResult.value, expectedValue), evalMsg || "expected {value} to have a nested property {property} deeply equal {expected}, but got {nestedValue}");
+                context.eval(valueResult.exists && _deepEqual(valueResult.value, expectedValue, false, context), evalMsg || "expected {value} to have a nested property {property} deeply equal {expected}, but got {nestedValue}");
             } else {
                 context.eval(false, evalMsg || "expected {value} to have a nested property {property} deeply equal {expected}, but the property does not exist");
             }

--- a/core/src/assert/ops/includeOp.ts
+++ b/core/src/assert/ops/includeOp.ts
@@ -144,7 +144,7 @@ export function deepIncludeOp<R>(scope: IAssertScope): IIncludeOp<R> {
         } else if (isArray(context.value)) {
             // Check if any item in the array deeply equals match
             arrForEach(value, (item) => {
-                if (_deepEqual(item, match)) {
+                if (_deepEqual(item, match, false, context)) {
                     found = true;
                     return -1; // break
                 }
@@ -152,7 +152,7 @@ export function deepIncludeOp<R>(scope: IAssertScope): IIncludeOp<R> {
         } else if (isMap(value)) {
             // For Maps, check if any value in the map deeply equals match
             iterForOf(value.keys(), (v: any) => {
-                if (_deepEqual(value.get(v), match)) {
+                if (_deepEqual(value.get(v), match, false, context)) {
                     found = true;
                     return -1;
                 }
@@ -160,7 +160,7 @@ export function deepIncludeOp<R>(scope: IAssertScope): IIncludeOp<R> {
         } else if (isSet(value)) {
             // For Sets, iterate and check deep equality for each item
             iterForOf(value, (v: any) => {
-                if (_deepEqual(v, match)) {
+                if (_deepEqual(v, match, false, context)) {
                     found = true;
                     return -1;
                 }
@@ -181,7 +181,7 @@ export function deepIncludeOp<R>(scope: IAssertScope): IIncludeOp<R> {
                     found = false;
                     return -1; // break
                 }
-                if (!_deepEqual(value[key], match[key])) {
+                if (!_deepEqual(value[key], match[key], false, context)) {
                     found = false;
                     return -1; // break
                 }
@@ -312,7 +312,7 @@ export function deepOwnIncludeOp<R>(scope: IAssertScope): IIncludeOp<R> {
         } else if (isArray(context.value)) {
             // Check if any item in the array deeply equals match
             arrForEach(value, (item) => {
-                if (_deepEqual(item, match)) {
+                if (_deepEqual(item, match, false, context)) {
                     found = true;
                     return -1; // break
                 }
@@ -320,7 +320,7 @@ export function deepOwnIncludeOp<R>(scope: IAssertScope): IIncludeOp<R> {
         } else if (isMap(value)) {
             // For Maps, check if any value in the map deeply equals match
             iterForOf(value.keys(), (v: any) => {
-                if (_deepEqual(value.get(v), match)) {
+                if (_deepEqual(value.get(v), match, false, context)) {
                     found = true;
                     return -1;
                 }
@@ -328,7 +328,7 @@ export function deepOwnIncludeOp<R>(scope: IAssertScope): IIncludeOp<R> {
         } else if (isSet(value) || (value && isFunction(value.has))) {
             // For Sets, deeply compare each entry against match
             iterForOf(value, (entry: any) => {
-                if (_deepEqual(entry, match)) {
+                if (_deepEqual(entry, match, false, context)) {
                     found = true;
                     return -1; // break
                 }
@@ -339,7 +339,7 @@ export function deepOwnIncludeOp<R>(scope: IAssertScope): IIncludeOp<R> {
             found = true;
 
             arrForEach(matchKeys, (key) => {
-                if (!objHasOwnProperty(value, key) || !_deepEqual(value[key], match[key])) {
+                if (!objHasOwnProperty(value, key) || !_deepEqual(value[key], match[key], false, context)) {
                     found = false;
                     return -1; // break
                 }

--- a/core/src/config/defaultConfig.ts
+++ b/core/src/config/defaultConfig.ts
@@ -31,5 +31,8 @@ export const DEFAULT_CONFIG: Readonly<IConfig> = (/* $__PURE__ */objFreeze({
         finalizeFn: undefined
     },
     circularMsg: () => cyan("[<Circular>]"),
-    showDiff: true
+    showDiff: true,
+    maxFormatDepth: 50,
+    maxCompareDepth: 100,
+    maxCompareCheckDepth: 50
 }));

--- a/core/src/interface/IConfig.ts
+++ b/core/src/interface/IConfig.ts
@@ -120,4 +120,28 @@ export interface IConfig {
      * @since 0.1.5
      */
     showDiff?: boolean;
+
+    /**
+     * Maximum depth for formatting nested values before treating as circular reference.
+     * This prevents pathological cases with deeply nested structures.
+     * @default 50
+     * @since 0.1.8
+     */
+    maxFormatDepth?: number;
+
+    /**
+     * Maximum depth for deep equality comparisons before throwing a fatal error.
+     * This prevents stack overflow with extremely deep object structures.
+     * @default 100
+     * @since 0.1.8
+     */
+    maxCompareDepth?: number;
+
+    /**
+     * Maximum number of recently visited items to check for circular references during deep comparisons.
+     * Limiting this prevents O(n²) performance degradation in deeply nested structures.
+     * @default 50
+     * @since 0.1.8
+     */
+    maxCompareCheckDepth?: number;
 }

--- a/core/test/src/config/maxDepth.test.ts
+++ b/core/test/src/config/maxDepth.test.ts
@@ -1,0 +1,129 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2026 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { assert, assertConfig, expect } from "../../../src/index";
+
+describe("Config max depth limits", () => {
+    let originalMaxFormatDepth: number;
+    let originalMaxCompareDepth: number;
+    let originalMaxCompareCheckDepth: number;
+
+    beforeEach(() => {
+        // Save original config values
+        originalMaxFormatDepth = assertConfig.maxFormatDepth;
+        originalMaxCompareDepth = assertConfig.maxCompareDepth;
+        originalMaxCompareCheckDepth = assertConfig.maxCompareCheckDepth;
+    });
+
+    afterEach(() => {
+        // Restore original config values
+        assertConfig.maxFormatDepth = originalMaxFormatDepth;
+        assertConfig.maxCompareDepth = originalMaxCompareDepth;
+        assertConfig.maxCompareCheckDepth = originalMaxCompareCheckDepth;
+    });
+
+    describe("maxFormatDepth", () => {
+        it("should use default value of 50", () => {
+            assert.equal(assertConfig.maxFormatDepth, 50);
+        });
+
+        it("should allow custom maxFormatDepth to be set", () => {
+            assertConfig.maxFormatDepth = 25;
+            assert.equal(assertConfig.maxFormatDepth, 25);
+        });
+
+        it("should detect deeply nested object as circular when depth exceeds maxFormatDepth", () => {
+            assertConfig.maxFormatDepth = 5;
+
+            // Create deeply nested object
+            let obj: any = {};
+            let current = obj;
+            for (let i = 0; i < 10; i++) {
+                current.nested = {};
+                current = current.nested;
+            }
+
+            try {
+                assert.equal(obj, {});
+            } catch (e) {
+                // Should contain circular reference indicator due to max depth
+                assert.includes(e.message, "Circular");
+            }
+        });
+    });
+
+    describe("maxCompareDepth", () => {
+        it("should use default value of 100", () => {
+            assert.equal(assertConfig.maxCompareDepth, 100);
+        });
+
+        it("should allow custom maxCompareDepth to be set", () => {
+            assertConfig.maxCompareDepth = 50;
+            assert.equal(assertConfig.maxCompareDepth, 50);
+        });
+
+        it("should throw fatal error when comparison depth exceeds maxCompareDepth", () => {
+            assertConfig.maxCompareDepth = 10;
+
+            // Create deeply nested object
+            let deep1: any = {};
+            let deep2: any = {};
+            let curr1 = deep1;
+            let curr2 = deep2;
+
+            for (let i = 0; i < 15; i++) {
+                curr1.nested = { value: i };
+                curr2.nested = { value: i };
+                curr1 = curr1.nested;
+                curr2 = curr2.nested;
+            }
+
+            try {
+                assert.deepEqual(deep1, deep2);
+                assert.fail("Should have thrown fatal error");
+            } catch (e) {
+                assert.includes(e.message, "Maximum comparison depth exceeded");
+                assert.includes(e.message, "10");
+            }
+        });
+    });
+
+    describe("maxCompareCheckDepth", () => {
+        it("should use default value of 50", () => {
+            assert.equal(assertConfig.maxCompareCheckDepth, 50);
+        });
+
+        it("should allow custom maxCompareCheckDepth to be set", () => {
+            assertConfig.maxCompareCheckDepth = 25;
+            assert.equal(assertConfig.maxCompareCheckDepth, 25);
+        });
+    });
+
+    describe("config integration", () => {
+        it("should allow all depth limits to be configured together", () => {
+            assertConfig.maxFormatDepth = 30;
+            assertConfig.maxCompareDepth = 80;
+            assertConfig.maxCompareCheckDepth = 40;
+
+            assert.equal(assertConfig.maxFormatDepth, 30);
+            assert.equal(assertConfig.maxCompareDepth, 80);
+            assert.equal(assertConfig.maxCompareCheckDepth, 40);
+        });
+
+        it("should work with per-assertion config override", () => {
+            let obj1 = { a: 1 };
+            let obj2 = { a: 1 };
+
+            // Use custom config for this specific assertion
+            expect(obj1, "should match", {
+                maxCompareDepth: 200,
+                maxFormatDepth: 100
+            }).to.deep.equal(obj2);
+        });
+    });
+});


### PR DESCRIPTION
- Add configurable depth limits to prevent stack overflow and O(n²) degradation:
  - maxFormatDepth (default: 50): Limits formatting recursion depth
  - maxCompareDepth (default: 100): Limits deep equality comparison depth
  - maxCompareCheckDepth (default: 50): Limits circular reference check iterations

- Refactor _deepEqual to require context parameter (never optional):
  - Ensures configuration flows through deep equality checks properly

- Optimize circular reference detection for better performance:
  - Search backwards through visited list (better cache locality)
  - Respect maxCompareCheckDepth to prevent O(n²) behavior in deep structures

- Update _formatValue to respect maxFormatDepth limit:
  - Prevents pathological formatting of extremely nested objects
  - Treats excessive nesting as circular references for safety

- Add comprehensive tests for depth limit configuration and behavior

- Update copilot-instructions.md with refined @since tag guidance

**Critical fixes:**
- Fixes regression where _deepEqual created null context
- Prevents stack overflow with deeply nested structures
- Maintains backward search optimization (better performance than forward search)