### PR TITLE
perf: Implement critical performance optimizations for hot paths

### DIFF
--- a/core/src/assert/adapters/exprAdapter.ts
+++ b/core/src/assert/adapters/exprAdapter.ts
@@ -6,7 +6,10 @@
  * Licensed under the MIT license.
  */
 
-import { arrForEach, arrSlice, dumpObj, fnApply, isArray, isFunction, isNumber, isString, objDefine, objKeys, strEndsWith, strIndexOf, strLeft, strStartsWith } from "@nevware21/ts-utils";
+import {
+    arrForEach, arrSlice, dumpObj, fnApply, isArray, isFunction, isNumber, isString,
+    objDefine, objKeys, strEndsWith, strIndexOf, strLeft, strStartsWith
+} from "@nevware21/ts-utils";
 import { IAssertScope } from "../interface/IAssertScope";
 import { IScopeContext } from "../interface/IScopeContext";
 import { IScopeFn } from "../interface/IScopeFuncs";
@@ -136,7 +139,7 @@ function _runExpr(theAssert: any, scope: IAssertScope, steps: IStepDef[], scopeF
 
         if (!(step.name in scope.that)) {
             throw new AssertionError(
-                "" + idx + " Invalid step: " + step.name + " for [" + steps.map((s: any) => s.name).join("->") + "] available steps: [" + objKeys(scope.that).join(";") + "] - " + _formatValue(scope.context.opts, scope.that),
+                "" + idx + " Invalid step: " + step.name + " for [" + steps.map((s: any) => s.name).join("->") + "] available steps: [" + objKeys(scope.that).join(";") + "] - " + _formatValue(scope.context, scope.that),
                 {
                     expected: step.name,
                     actual: objKeys(scope.that).join(";")
@@ -191,7 +194,7 @@ function _processFn(scope: IAssertScope, scopeFn: IScopeFn, theArgs: any[], theR
         // The last step is a function, so we call it
         theResult = scope.exec(theResult, theArgs);
         if (scope.context.opts.isVerbose) {
-            scope.context.setOp("=>[[r:" + _formatValue(scope.context.opts, theResult) + "]]");
+            scope.context.setOp("=>[[r:" + _formatValue(scope.context, theResult) + "]]");
         }
     }
 

--- a/core/src/assert/assertionError.ts
+++ b/core/src/assert/assertionError.ts
@@ -219,15 +219,15 @@ function _formatProps(ctx: IScopeContext | null, props: any): string {
                         thePath = props.opPath.join("->") + "->" + lastOp;
                     }
                 } else {
-                    thePath = _formatValue(ctx.opts, props.opPath) + "->" + lastOp;
+                    thePath = _formatValue(ctx, props.opPath) + "->" + lastOp;
                 }
             } else {
-                thePath = _formatValue(ctx.opts, props.opPath);
+                thePath = _formatValue(ctx, props.opPath);
             }
 
             let parts: string[] = [formatted, "running \"", thePath, "\""];
             if (props.actual) {
-                parts.push(" with (", _formatValue(ctx.opts, props.actual), ")");
+                parts.push(" with (", _formatValue(ctx, props.actual), ")");
             }
             let leftOver: any = {};
             objForEachKey(props, (key, value) => {

--- a/core/src/assert/funcs/equal.ts
+++ b/core/src/assert/funcs/equal.ts
@@ -298,7 +298,7 @@ function _isVisiting<T>(value: any, options: IEqualOptions, cb: () => T): T {
                     visitCount++;
                     if (visitCount > 10) {
                         // Early exit on excessive visits
-                        let errorMsg = "Unresolvable Circular reference detected for " + _formatValue(options.context.opts, visiting[0]) + " @ depth " + depth + " reference count: " + visitCount;
+                        let errorMsg = "Unresolvable Circular reference detected for " + _formatValue(options.context, visiting[0]) + " @ depth " + depth + " reference count: " + visitCount;
                         options.context.fatal(errorMsg);
                     }
                 }

--- a/core/src/config/defaultConfig.ts
+++ b/core/src/config/defaultConfig.ts
@@ -30,7 +30,8 @@ export const DEFAULT_CONFIG: Readonly<IConfig> = (/* $__PURE__ */objFreeze({
         finalize: false,
         finalizeFn: undefined,
         maxProps: 8,
-        maxFormatDepth: 50
+        maxFormatDepth: 50,
+        maxProtoDepth: 4
     },
     circularMsg: () => cyan("[<Circular>]"),
     showDiff: true,

--- a/core/src/interface/IFormatManager.ts
+++ b/core/src/interface/IFormatManager.ts
@@ -51,4 +51,15 @@ export interface IFormatManager {
      * Reset the format manager to its initial state, removing all registered formatters
      */
     reset(): void;
+
+    /**
+     * Format a value using the configured formatters and format options.
+     * This is a convenience method that uses the internal formatting logic,
+     * applying all registered formatters, circular reference detection,
+     * and finalization options.
+     * @param value - The value to format
+     * @returns The formatted string representation of the value
+     * @since 0.1.8
+     */
+    format(value: any): string;
 }

--- a/core/src/interface/IFormatterOptions.ts
+++ b/core/src/interface/IFormatterOptions.ts
@@ -162,4 +162,26 @@ export interface IFormatterOptions {
      * ```
      */
     maxFormatDepth?: number;
+
+    /**
+     * Maximum depth to walk up the prototype chain when collecting object keys for display.
+     * Limits how many levels of inherited properties are included when formatting objects.
+     * Most relevant properties are typically within the first 2-3 prototype levels.
+     *
+     * @default 4
+     * @since 0.1.8
+     * @example
+     * ```typescript
+     * // Walk further up the prototype chain
+     * assertConfig.format = {
+     *     maxProtoDepth: 5
+     * };
+     *
+     * // Only show own properties (no inherited)
+     * assertConfig.format = {
+     *     maxProtoDepth: 1
+     * };
+     * ```
+     */
+    maxProtoDepth?: number;
 }

--- a/core/src/internal/_formatValue.ts
+++ b/core/src/internal/_formatValue.ts
@@ -6,153 +6,16 @@
  * Licensed under the MIT license.
  */
 
-import { arrForEach, asString, dumpObj, isFunction, isPrimitive, objDefine } from "@nevware21/ts-utils";
-import { EMPTY_STRING } from "../assert/internal/const";
-import { eFormatResult, IFormatCtx, IFormattedValue } from "../interface/IFormatter";
-import { escapeAnsi, yellow } from "@nevware21/chromacon";
-import { IFormatter } from "../interface/IFormatter";
-import { IConfigInst } from "../interface/IConfigInst";
-import { _defaultFormatters } from "./_defaultFormatters";
-
-
-function _isVisited(value: any, visited: any[], maxDepth?: number): boolean {
-    if (isPrimitive(value)) {
-        return false;
-    }
-
-    // Depth limit optimization - most structures don't go beyond 50 levels
-    // This prevents pathological cases while maintaining reasonable depth
-    let depth = visited.length;
-    if (maxDepth && depth > maxDepth) {
-        return true; // Treat as circular to prevent deep recursion
-    }
-
-    // Search backwards - more likely to find recent values
-    // Most circular references are to recently visited objects (better cache locality)
-    for (let idx = depth - 1; idx >= 0; idx--) {
-        if (visited[idx] === value) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-/**
- * Perform the default formatting of a value using the provided format context.
- * @param formatCtx The format context to use for formatting the value.
- * @param value The value to format.
- * @returns A string representation of the value.
- */
-function _doFormat(formatCtx: IFormatCtx, value: any): string {
-    let formattedValue: IFormattedValue;
-    let result: string;
-
-    function _format(formatter: IFormatter) {
-        try {
-            let fn = formatter.value;
-
-            if (isFunction(fn)) {
-                let formatted = fn(formatCtx, value);
-                if (formatted && (formatted.res === eFormatResult.Ok || formatted.res === eFormatResult.Continue)) {
-                    formattedValue = formatted;
-                    if (formatted.res === eFormatResult.Ok) {
-                        return -1;
-                    }
-                }
-            }
-        } catch (e) {
-            formattedValue = {
-                res: eFormatResult.Failed,
-                err: e,
-                val: asString(value)
-            };
-        }
-    }
-
-    try {
-        // Process the custom formatters first
-        formatCtx.cfg.$ops.formatMgr.forEach(_format);
-        if (!formattedValue || formattedValue.res !== eFormatResult.Ok) {
-            // Iterate through the default formatters to find one that can format the value
-            arrForEach(_defaultFormatters, _format);
-        }
-
-        if (formattedValue) {
-            if (formattedValue.res === eFormatResult.Ok || formattedValue.res === eFormatResult.Continue) {
-                result = formattedValue.val;
-            } else if (formattedValue.res === eFormatResult.Failed) {
-                result = dumpObj(formattedValue.err);
-            } else {
-                result = asString(value);
-            }
-        } else {
-            result = asString(value);
-        }
-    } catch (e) {
-        result = yellow("(" + _doFormat(formatCtx, e) + ")");
-    }
-
-    return result;
-}
-
-/**
- * @internal
- * @ignore
- * Creates a format context bound to the supplied scope context.
- * The returned context handles circular references while formatting values.
- * @param ctx - The scope context used to resolve formatting options.
- * @returns A format context that can be passed to `_doFormat` or used via its `format` method.
- */
-function _createFormatCtx(cfg: IConfigInst): IFormatCtx {
-    let visited: any[] = [];
-
-    let formatCtx: IFormatCtx = {
-        cfg: cfg,
-        format: (value: any): string => {
-            let maxDepth = (cfg.format && cfg.format.maxFormatDepth) || 50;
-            let isVisited = _isVisited(value, visited, maxDepth);
-            if (isVisited) {
-                // Circular reference detected or max depth exceeded
-                return cfg.circularMsg() || EMPTY_STRING;
-            }
-
-            visited.push(value);
-
-            let formattedValue: string;
-            try {
-                formattedValue = _doFormat(formatCtx, value);
-            } finally {
-                visited.pop();
-            }
-
-            return formattedValue;
-        }
-    };
-
-    return objDefine(formatCtx, "cfg", { v: cfg, w: false });
-}
+import { IScopeContext } from "../assert/interface/IScopeContext";
 
 /**
  * @internal
  * @ignore
  * Internal helper to format a value for display in an error messages.
- * @param cfg - Configuration instance containing the formatters to use.
+ * @param ctx - Scope context containing the configuration and formatters to use.
  * @param value - The value to format.
  * @returns - A string representation of the value.
  */
-export function _formatValue(cfg: IConfigInst, value: any): string {
-    let formatCtx = _createFormatCtx(cfg);
-    let formatOpts = formatCtx.cfg.format;
-    let result = _doFormat(formatCtx, value);
-
-    if (formatOpts && formatOpts.finalize) {
-        if (isFunction(formatOpts.finalizeFn)) {
-            result = formatOpts.finalizeFn(result);
-        } else {
-            result = escapeAnsi(result);
-        }
-    }
-
-    return result;
+export function _formatValue(ctx: IScopeContext, value: any): string {
+    return ctx.opts.$ops.formatMgr.format(value);
 }

--- a/core/src/internal/formatManager.ts
+++ b/core/src/internal/formatManager.ts
@@ -6,11 +6,179 @@
  * Licensed under the MIT license.
  */
 
-import { arrAppend, arrForEach, arrIndexOf, isArray } from "@nevware21/ts-utils";
+import { arrAppend, arrForEach, arrIndexOf, asString, dumpObj, getDeferred, ICachedValue, isArray, isFunction, isPrimitive, objDefine } from "@nevware21/ts-utils";
 import { IFormatManager } from "../interface/IFormatManager";
-import { IFormatter } from "../interface/IFormatter";
+import { eFormatResult, IFormatCtx, IFormattedValue, IFormatter } from "../interface/IFormatter";
 import { IRemovable } from "../interface/IRemovable";
 import { _noOpFn } from "./_noOp";
+import { IConfigInst } from "../interface/IConfigInst";
+import { EMPTY_STRING } from "../assert/internal/const";
+import { escapeAnsi, yellow } from "@nevware21/chromacon";
+import { _defaultFormatters } from "./_defaultFormatters";
+
+let _circularTrack: any[];
+function _withCircularTrack(fn: () => string): string {
+    let currentTrack = _circularTrack;
+
+    _circularTrack = [];
+    try {
+        return fn();
+    } finally {
+        _circularTrack = currentTrack;
+    }
+}
+
+function _isVisited(value: any, visited: any[], maxDepth?: number): boolean {
+    let result = false;
+
+    if (!isPrimitive(value)) {
+        const depth = visited.length;
+        if (depth > 0) {
+            if (depth === 1) {
+                result = visited[0] === value;
+            } else if (maxDepth && depth > maxDepth) {
+                // Depth limit optimization - most structures don't go beyond 50 levels
+                // This prevents pathological cases while maintaining reasonable depth
+                result = true; // Treat as circular to prevent deep recursion
+            } else {
+                // Search backwards - more likely to find recent values
+                // Most circular references are to recently visited objects (better cache locality)
+                for (let idx = depth - 1; idx >= 0; idx--) {
+                    if (visited[idx] === value) {
+                        result = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Perform the default formatting of a value using the provided format context.
+ * @param formatCtx The format context to use for formatting the value.
+ * @param value The value to format.
+ * @returns A string representation of the value.
+ */
+function _doFormat(formatCtx: IFormatCtx, value: any): string {
+    let formattedValue: IFormattedValue;
+    let result: string;
+
+    function _format(formatter: IFormatter) {
+        try {
+            let fn = formatter.value;
+
+            if (isFunction(fn)) {
+                let formatted = fn(formatCtx, value);
+                if (formatted && (formatted.res === eFormatResult.Ok || formatted.res === eFormatResult.Continue)) {
+                    formattedValue = formatted;
+                    if (formatted.res === eFormatResult.Ok) {
+                        return -1;
+                    }
+                }
+            }
+        } catch (e) {
+            formattedValue = {
+                res: eFormatResult.Failed,
+                err: e,
+                val: asString(value)
+            };
+        }
+    }
+
+    try {
+        // Process the custom formatters first
+        formatCtx.cfg.$ops.formatMgr.forEach(_format);
+        if (!formattedValue || formattedValue.res !== eFormatResult.Ok) {
+            // Iterate through the default formatters to find one that can format the value
+            arrForEach(_defaultFormatters, _format);
+        }
+
+        if (formattedValue) {
+            if (formattedValue.res === eFormatResult.Ok || formattedValue.res === eFormatResult.Continue) {
+                result = formattedValue.val;
+            } else if (formattedValue.res === eFormatResult.Failed) {
+                result = dumpObj(formattedValue.err);
+            } else {
+                result = asString(value);
+            }
+        } else {
+            result = asString(value);
+        }
+    } catch (e) {
+        result = yellow("(" + _doFormat(formatCtx, e) + ")");
+    }
+
+    return result;
+}
+
+/**
+ * @internal
+ * @ignore
+ * Creates a format context bound to the supplied scope context.
+ * The returned context handles circular references while formatting values.
+ * @param ctx - The scope context used to resolve formatting options.
+ * @returns A format context that can be passed to `_doFormat` or used via its `format` method.
+ */
+function _createFormatCtx(cfg: IConfigInst): IFormatCtx {
+    let formatCtx: IFormatCtx = {
+        cfg: cfg,
+        format: (value: any): string => {
+            if (!_circularTrack) {
+                _circularTrack = [];
+            }
+
+            let maxDepth = (cfg.format && cfg.format.maxFormatDepth) || 50;
+            let isVisited = _isVisited(value, _circularTrack, maxDepth);
+            if (isVisited) {
+                // Circular reference detected or max depth exceeded
+                return cfg.circularMsg() || EMPTY_STRING;
+            }
+
+            _circularTrack.push(value);
+
+            let formattedValue: string;
+            try {
+                formattedValue = _doFormat(formatCtx, value);
+            } finally {
+                _circularTrack.pop();
+            }
+
+            return formattedValue;
+        }
+    };
+
+    return objDefine(formatCtx, "cfg", { v: cfg, w: false });
+}
+
+/**
+ * @internal
+ * @ignore
+ * Internal helper to format a value for display in an error messages.
+ * @param ctx - Scope context containing the configuration and formatters to use.
+ * @param value - The value to format.
+ * @returns - A string representation of the value.
+ */
+function _formatCtxValue(formatCtx: IFormatCtx, value: any): string {
+    let formatOpts = formatCtx.cfg.format;
+
+    return _withCircularTrack(() => {
+        let result = _doFormat(formatCtx, value);
+
+        // Apply finalization if configured
+        if (formatOpts && formatOpts.finalize) {
+            if (isFunction(formatOpts.finalizeFn)) {
+                result = formatOpts.finalizeFn(result);
+            } else {
+                result = escapeAnsi(result);
+            }
+        }
+
+        return result;
+    });
+}
 
 /**
  * Creates a new format manager instance that manages value formatters.
@@ -23,8 +191,11 @@ import { _noOpFn } from "./_noOp";
  * @since 0.1.5
  * @group Formatter
  */
-export function createFormatMgr(parent?: IFormatManager): IFormatManager {
+export function createFormatMgr(cfg: IConfigInst, parent?: IFormatManager): IFormatManager {
     const _formatters: IFormatter[] = [];
+    let formatCtx: ICachedValue<IFormatCtx> = getDeferred(() => {
+        return _createFormatCtx(cfg);
+    });
 
     function _addFormatter(formatter: IFormatter | Array<IFormatter>): IRemovable {
         arrAppend(_formatters, formatter);
@@ -81,11 +252,17 @@ export function createFormatMgr(parent?: IFormatManager): IFormatManager {
         _formatters.length = 0;
     }
 
+    function _format(value: any): string {
+        return _formatCtxValue(formatCtx.v, value);
+    }
+
     return {
         addFormatter: _addFormatter,
         removeFormatter: _removeFormatter,
         getFormatters: _getFormatters,
         forEach: _forEach,
-        reset: _reset
+        reset: _reset,
+        format: _format
+
     };
 }

--- a/core/test/src/assert/assert.changes.test.ts
+++ b/core/test/src/assert/assert.changes.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { assert } from "../../../src/assert/assertClass";
-import { expect } from "../../../src/index";
+import { expect } from "../../../src/assert/expect";
 import { checkError } from "../support/checkError";
 
 describe("assert.changes", () => {

--- a/core/test/src/assert/assert.isInstanceOf.test.ts
+++ b/core/test/src/assert/assert.isInstanceOf.test.ts
@@ -6,7 +6,9 @@
  * Licensed under the MIT license.
  */
 
-import { assert, AssertionFailure, expect } from "../../../src/index";
+import { assert } from "../../../src/assert/assertClass";
+import { AssertionFailure } from "../../../src/assert/assertionError";
+import { expect } from "../../../src/assert/expect";
 
 describe("assert.isInstanceOf", () => {
 

--- a/core/test/src/assert/deepEqual.edgeCases.test.ts
+++ b/core/test/src/assert/deepEqual.edgeCases.test.ts
@@ -6,7 +6,8 @@
  * Licensed under the MIT license.
  */
 
-import { assert, assertConfig } from "../../../src/index";
+import { assert } from "../../../src/assert/assertClass";
+import { assertConfig } from "../../../src/config/assertConfig";
 import { checkError } from "../support/checkError";
 
 describe("deepEqual edge cases and depth limits", () => {

--- a/core/test/src/assert/extractArgs.test.ts
+++ b/core/test/src/assert/extractArgs.test.ts
@@ -1,0 +1,350 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2026 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { _extractArgs, assert } from "../../../src/assert/assertClass";
+
+describe("_extractArgs", function () {
+    this.timeout(5000);
+
+    describe("with no message index (default -1)", () => {
+        it("should extract message from last position by default", () => {
+            const result = _extractArgs([42, "test message"], -1, 1);
+
+            assert.equal(result.act, 42);
+            assert.equal(result.msg, "test message");
+            assert.isArray(result.args);
+            assert.equal(result.args.length, 0);
+            assert.equal(result.m, 12);
+        });
+
+        it("should extract actual value when only one arg and no message", () => {
+            const result = _extractArgs([42], -1, 1);
+
+            assert.equal(result.act, 42);
+            assert.isUndefined(result.msg);
+            assert.isArray(result.args);
+            assert.equal(result.args.length, 0);
+            assert.equal(result.m, 2);
+        });
+
+        it("should extract message from last position when numArgs < theArgs.length", () => {
+            const result = _extractArgs([42, 100, 200], -1, 1);
+
+            assert.equal(result.act, 42);
+            assert.equal(result.msg, 200); // Last arg is extracted as message when numArgs (1) < theArgs.length (3)
+            assert.isArray(result.args);
+            assert.equal(result.args.length, 1);
+            assert.equal(result.args[0], 100);
+            assert.equal(result.m, 11);
+        });
+    });
+
+    describe("with positive message index", () => {
+        it("should extract message from specified positive index (index 0)", () => {
+            const result = _extractArgs(["test message", 42, 100], 0, 1);
+
+            assert.equal(result.msg, "test message");
+            assert.equal(result.act, 42);
+            assert.isArray(result.args);
+            assert.equal(result.args.length, 1);
+            assert.equal(result.args[0], 100);
+            assert.equal(result.m, 1);
+        });
+
+        it("should extract message from specified positive index (index 1)", () => {
+            const result = _extractArgs([42, "test message", 100], 1, 1);
+
+            assert.equal(result.act, 42);
+            assert.equal(result.msg, "test message");
+            assert.isArray(result.args);
+            assert.equal(result.args.length, 1);
+            assert.equal(result.args[0], 100);
+            assert.equal(result.m, 10);
+        });
+
+        it("should extract message from specified positive index (index 2)", () => {
+            const result = _extractArgs([42, 100, "test message"], 2, 1);
+
+            assert.equal(result.act, 42);
+            assert.equal(result.msg, "test message");
+            assert.isArray(result.args);
+            assert.equal(result.args.length, 1);
+            assert.equal(result.args[0], 100);
+            assert.equal(result.m, 11);
+        });
+
+        it("should not extract message if index is out of bounds", () => {
+            const result = _extractArgs([42, 100], 5, 1);
+
+            assert.equal(result.act, 42);
+            assert.isUndefined(result.msg);
+            assert.isArray(result.args);
+            assert.equal(result.args.length, 1);
+            assert.equal(result.args[0], 100);
+            assert.equal(result.m, 1); // No message, simple slice mode
+        });
+    });
+
+    describe("with negative message index", () => {
+        it("should extract message from end (index -1)", () => {
+            const result = _extractArgs([42, 100, "test message"], -1, 1);
+
+            assert.equal(result.act, 42);
+            assert.equal(result.msg, "test message");
+            assert.isArray(result.args);
+            assert.equal(result.args.length, 1);
+            assert.equal(result.args[0], 100);
+            assert.equal(result.m, 11);
+        });
+
+        it("should extract message from end (index -2)", () => {
+            const result = _extractArgs([42, "test message", 100], -2, 1);
+
+            assert.equal(result.act, 42);
+            assert.equal(result.msg, "test message");
+            assert.isArray(result.args);
+            assert.equal(result.args.length, 1);
+            assert.equal(result.args[0], 100);
+            assert.equal(result.m, 10);
+        });
+
+        it("should only extract negative index message when numArgs condition is met", () => {
+            // When numArgs >= argLen, negative index should not extract
+            const result = _extractArgs([42, "test message"], -1, 3);
+
+            assert.equal(result.act, 42);
+            assert.isUndefined(result.msg);
+            assert.isArray(result.args);
+            assert.equal(result.args.length, 1);
+            assert.equal(result.args[0], "test message");
+            assert.equal(result.m, 1); // No message extracted, simple slice mode
+        });
+    });
+
+    describe("with numArgs = 0 (no actual value expected)", () => {
+        it("should not extract actual value when numArgs is 0", () => {
+            const result = _extractArgs([100, 200, "test message"], -1, 0);
+
+            assert.isUndefined(result.act);
+            assert.equal(result.msg, "test message");
+            assert.isArray(result.args);
+            assert.equal(result.args.length, 2);
+            assert.equal(result.args[0], 100);
+            assert.equal(result.args[1], 200);
+            assert.equal(result.m, 11); // Message at last position, slice mode
+        });
+
+        it("should extract message from last position when numArgs is 0 and numArgs < theArgs.length", () => {
+            const result = _extractArgs([100, 200, 300], -1, 0);
+
+            assert.isUndefined(result.act);
+            assert.equal(result.msg, 300); // Last arg is extracted as message when numArgs (0) < theArgs.length (3)
+            assert.isArray(result.args);
+            assert.equal(result.args.length, 2);
+            assert.equal(result.args[0], 100);
+            assert.equal(result.args[1], 200);
+            assert.equal(result.m, 11); // Message at last position, slice mode
+        });
+    });
+
+    describe("with numArgs = 2 (actual value + 1 expected arg)", () => {
+        it("should extract actual value and scope arg, with message from last position", () => {
+            const result = _extractArgs([42, 100, 200], -1, 2);
+
+            assert.equal(result.act, 42);
+            assert.equal(result.msg, 200); // Last arg extracted as message when numArgs (2) < theArgs.length (3)
+            assert.isArray(result.args);
+            assert.equal(result.args.length, 1);
+            assert.equal(result.args[0], 100);
+            assert.equal(result.m, 11); // Message at last position, slice mode
+        });
+
+        it("should extract actual value, scope arg, and message", () => {
+            const result = _extractArgs([42, 100, "test message"], -1, 2);
+
+            assert.equal(result.act, 42);
+            assert.equal(result.msg, "test message");
+            assert.isArray(result.args);
+            assert.equal(result.args.length, 1);
+            assert.equal(result.args[0], 100);
+            assert.equal(result.m, 11); // Message at last position, slice mode
+        });
+    });
+
+    describe("edge cases", () => {
+        it("should handle empty args array", () => {
+            const result = _extractArgs([], -1, 1);
+
+            assert.isUndefined(result.act);
+            assert.isUndefined(result.msg);
+            assert.isArray(result.args);
+            assert.equal(result.args.length, 0);
+            assert.equal(result.m, 0); // Empty array, no processing mode
+        });
+
+        it("should extract single arg as message when numArgs = 0 and numArgs < theArgs.length", () => {
+            const result = _extractArgs([42], -1, 0);
+
+            assert.isUndefined(result.act);
+            assert.equal(result.msg, 42); // Single arg extracted as message when numArgs (0) < theArgs.length (1)
+            assert.isArray(result.args);
+            assert.equal(result.args.length, 0);
+            assert.equal(result.m, 2); // Message at index 0, empty scopeArgs
+        });
+
+        it("should handle message at first position with numArgs = 0", () => {
+            const result = _extractArgs(["test message", 100, 200], 0, 0);
+
+            assert.isUndefined(result.act);
+            assert.equal(result.msg, "test message");
+            assert.isArray(result.args);
+            assert.equal(result.args.length, 2);
+            assert.equal(result.args[0], 100);
+            assert.equal(result.args[1], 200);
+            assert.equal(result.m, 1); // Message at index 0, simple slice mode
+        });
+
+        it("should handle undefined message index", () => {
+            const result = _extractArgs([42, 100, 200], undefined, 1);
+
+            assert.equal(result.act, 42);
+            assert.isUndefined(result.msg);
+            assert.isArray(result.args);
+            assert.equal(result.args.length, 2);
+            assert.equal(result.args[0], 100);
+            assert.equal(result.args[1], 200);
+            assert.equal(result.m, 1); // No message, simple slice mode
+        });
+
+        it("should preserve arg types correctly", () => {
+            const obj = { a: 1 };
+            const arr = [1, 2, 3];
+            const fn = () => {};
+
+            const result = _extractArgs([obj, arr, fn, "msg"], -1, 1);
+
+            assert.equal(result.act, obj);
+            assert.equal(result.msg, "msg");
+            assert.equal(result.args[0], arr);
+            assert.equal(result.args[1], fn);
+            assert.equal(result.m, 11); // Message at last position, slice mode
+        });
+
+        it("should handle null and undefined values correctly", () => {
+            const result = _extractArgs([null, undefined, 0, "msg"], -1, 1);
+
+            assert.isNull(result.act);
+            assert.equal(result.msg, "msg");
+            assert.isArray(result.args);
+            assert.equal(result.args.length, 2);
+            assert.isUndefined(result.args[0]);
+            assert.equal(result.args[1], 0);
+            assert.equal(result.m, 11); // Message at last position, slice mode
+        });
+    });
+
+    describe("performance optimization validation", () => {
+        it("should not modify original args array", () => {
+            const originalArgs = [42, 100, "test message"];
+            const argsCopy = [...originalArgs];
+
+            const result = _extractArgs(originalArgs, -1, 1);
+
+            assert.deepEqual(originalArgs, argsCopy);
+            assert.equal(result.m, 11); // Message at last position, slice mode
+        });
+
+        it("should handle many arguments efficiently", () => {
+            const manyArgs: any[] = Array.from({ length: 100 }, (_, i) => i);
+            manyArgs.push("test message");
+
+            const result = _extractArgs(manyArgs, -1, 1);
+
+            assert.equal(result.act, 0);
+            assert.equal(result.msg, "test message");
+            assert.equal(result.args.length, 99);
+            assert.equal(result.args[0], 1);
+            assert.equal(result.args[98], 99);
+            assert.equal(result.m, 11); // Message at last position, slice mode
+        });
+
+        it("should create scopeArgs only when needed", () => {
+            // Single arg, no additional scope args
+            const result1 = _extractArgs([42], -1, 1);
+            assert.isArray(result1.args);
+            assert.equal(result1.args.length, 0);
+            assert.equal(result1.m, 2); // Single arg, empty scopeArgs mode
+
+            // Single arg + message, no additional scope args
+            const result2 = _extractArgs([42, "msg"], -1, 1);
+            assert.isArray(result2.args);
+            assert.equal(result2.args.length, 0);
+            assert.equal(result2.m, 12); // Message at last, empty scopeArgs mode
+        });
+    });
+
+    describe("real-world usage scenarios", () => {
+        it("should handle assert.equal(actual, expected, message) pattern", () => {
+            const result = _extractArgs([42, 42, "should be equal"], -1, 2);
+
+            assert.equal(result.act, 42);
+            assert.equal(result.args[0], 42);
+            assert.equal(result.msg, "should be equal");
+            assert.equal(result.m, 11); // Message at last position, slice mode
+        });
+
+        it("should handle assert.throws(fn, error, message) pattern", () => {
+            const fn = () => {};
+            const errorType = Error;
+
+            const result = _extractArgs([fn, errorType, "should throw"], -1, 3);
+
+            assert.equal(result.act, fn);
+            assert.equal(result.args[0], errorType);
+            // When numArgs (3) >= theArgs.length (3), NO message extracted
+            assert.isUndefined(result.msg);
+            assert.equal(result.args.length, 2);
+            assert.equal(result.args[1], "should throw"); // Message becomes a scope arg
+            assert.equal(result.m, 1); // No message extracted, simple slice mode
+        });
+
+        it("should handle assert.fail(message) pattern", () => {
+            const result = _extractArgs(["failure message"], -1, 0);
+
+            assert.isUndefined(result.act);
+            assert.equal(result.msg, "failure message");
+            assert.equal(result.args.length, 0);
+            assert.equal(result.m, 2); // Single arg extracted as message, empty scopeArgs
+        });
+
+        it("should handle assert.hasProperty(obj, prop, value, message) pattern", () => {
+            const obj = { a: 1 };
+
+            const result = _extractArgs([obj, "a", 1, "should have property"], -1, 3);
+
+            assert.equal(result.act, obj);
+            assert.equal(result.args[0], "a");
+            assert.equal(result.args[1], 1);
+            assert.equal(result.msg, "should have property");
+            assert.equal(result.m, 11); // Message at last position, slice mode
+        });
+
+        it("should handle message at custom position (index 1)", () => {
+            // Simulating message at position 1, not at the end
+            const result = _extractArgs([42, "custom message", 100, 200], 1, 1);
+
+            assert.equal(result.act, 42);
+            assert.equal(result.msg, "custom message");
+            assert.isArray(result.args);
+            assert.equal(result.args.length, 2);
+            assert.equal(result.args[0], 100);
+            assert.equal(result.args[1], 200);
+            assert.equal(result.m, 10); // Message at middle position, iterate and skip mode
+        });
+    });
+});

--- a/core/test/src/assert/members.test.ts
+++ b/core/test/src/assert/members.test.ts
@@ -6,7 +6,8 @@
  * Licensed under the MIT license.
  */
 
-import { assert, expect } from "../../../src/index";
+import { assert } from "../../../src/assert/assertClass";
+import { expect } from "../../../src/assert/expect";
 
 describe("Member Comparison Tests", () => {
     describe("sameMembers", () => {

--- a/core/test/src/config/maxDepth.test.ts
+++ b/core/test/src/config/maxDepth.test.ts
@@ -6,7 +6,9 @@
  * Licensed under the MIT license.
  */
 
-import { assert, assertConfig, expect } from "../../../src/index";
+import { assert } from "../../../src/assert/assertClass";
+import { expect } from "../../../src/assert/expect";
+import { assertConfig } from "../../../src/config/assertConfig";
 
 describe("Config max depth limits", () => {
     afterEach(() => {

--- a/core/test/src/internal/formatManager.test.ts
+++ b/core/test/src/internal/formatManager.test.ts
@@ -1,0 +1,90 @@
+/*
+ * @nevware21/tripwire
+ * https://github.com/nevware21/tripwire
+ *
+ * Copyright (c) 2026 NevWare21 Solutions LLC
+ * Licensed under the MIT license.
+ */
+
+import { assert } from "../../../src/assert/assertClass";
+import { assertConfig } from "../../../src/config/assertConfig";
+
+describe("formatManager", function () {
+    describe("formatMgr.format() convenience method", function () {
+        afterEach(function () {
+            assertConfig.$ops.reset();
+        });
+
+        it("should format simple objects", function () {
+            let formatMgr = assertConfig.$ops.formatMgr;
+
+            let result = formatMgr.format({ a: 1, b: "test" });
+            assert.equal(result, "{a:1,b:\"test\"}");
+        });
+
+        it("should format circular objects", function () {
+            let formatMgr = assertConfig.$ops.formatMgr;
+            let circular = assertConfig.circularMsg?.();
+
+            let obj: any = { value: 42 };
+            obj.self = obj;
+
+            let result = formatMgr.format(obj);
+            // When using formatMgr.format(), circular tracking starts fresh for each call
+            // so the object is formatted one level deep before detecting circularity
+            assert.equal(result, `{value:42,self:{value:42,self:${circular}}}`);
+        });
+
+        it("should apply finalize option", function () {
+            let formatMgr = assertConfig.$ops.formatMgr;
+
+            assertConfig.format = {
+                finalize: true
+            };
+
+            let obj = { text: "\x1b[31mRed\x1b[0m" };
+            let result = formatMgr.format(obj);
+
+            // Should escape ANSI codes
+            assert.includes(result, "\\x1b[31m");
+            assert.includes(result, "\\x1b[0m");
+        });
+
+        it("should work with custom formatters", function () {
+            let formatMgr = assertConfig.$ops.formatMgr;
+
+            formatMgr.addFormatter({
+                name: "testFormatter",
+                value: (ctx, value) => {
+                    if (typeof value === "number" && value > 100) {
+                        return {
+                            res: 0, // eFormatResult.Ok
+                            val: `BIG:${value}`
+                        };
+                    }
+                    return { res: 2 }; // eFormatResult.Skip
+                }
+            });
+
+            let result = formatMgr.format({ small: 10, large: 500 });
+            assert.equal(result, "{small:10,large:BIG:500}");
+        });
+
+        it("should handle multiple format calls independently", function () {
+            let formatMgr = assertConfig.$ops.formatMgr;
+
+            let obj1 = { type: "first" };
+            let obj2 = { type: "second" };
+
+            let result1 = formatMgr.format(obj1);
+            let result2 = formatMgr.format(obj2);
+
+            assert.equal(result1, "{type:\"first\"}");
+            assert.equal(result2, "{type:\"second\"}");
+
+            // Format obj1 again - should not be affected by previous calls
+            let result3 = formatMgr.format(obj1);
+            assert.equal(result3, "{type:\"first\"}");
+        });
+    });
+});

--- a/core/test/src/operations/includeOp.edgeCases.test.ts
+++ b/core/test/src/operations/includeOp.edgeCases.test.ts
@@ -6,8 +6,8 @@
  * Licensed under the MIT license.
  */
 
-import { expect } from "../../../src/index";
 import { createAssertScope } from "../../../src/assert/assertScope";
+import { expect } from "../../../src/assert/expect";
 import { includeOp, deepIncludeOp, ownIncludeOp, deepOwnIncludeOp } from "../../../src/assert/ops/includeOp";
 import { createContext } from "../../../src/assert/scopeContext";
 import { checkError } from "../support/checkError";

--- a/core/test/src/support/checkError.ts
+++ b/core/test/src/support/checkError.ts
@@ -2,7 +2,7 @@
  * @nevware21/tripwire
  * https://github.com/nevware21/tripwire
  *
- * Copyright (c) 2024-2025 NevWare21 Solutions LLC
+ * Copyright (c) 2024-2026 NevWare21 Solutions LLC
  * Licensed under the MIT license.
  */
 
@@ -242,7 +242,7 @@ export function checkError(fn: () => void, match: string | RegExp | Object, chec
             expect(theStack).is.string();
             if (CHECK_INTERNAL_STACK_FRAME_REGEX.test(theStack)) {
                 let scope = preContext || getScopeContext(assert);
-                throw new AssertionError("expected error stack to not contain internal frames - " + _formatValue(scope.opts, theStack), e, null, stackStart);
+                throw new AssertionError("expected error stack to not contain internal frames - " + _formatValue(scope, theStack), e, null, stackStart);
             }
         }
 


### PR DESCRIPTION
- Remove objDefine getters from hot path properties (opts, value, orgArgs)
- Change property accessors from getter functions to direct assignments
- Extract and export _extractArgs() for cleaner argument handling
- Reorder formatters by probability (String, Object, Array first)
- Add configurable prototype chain depth limiting (maxProtoDepth: 4)
- Centralize formatting logic in format manager with convenience method